### PR TITLE
Update 04_Last_Survivors.cfg

### DIFF
--- a/scenarios7/04_Last_Survivors.cfg
+++ b/scenarios7/04_Last_Survivors.cfg
@@ -536,7 +536,8 @@
         [/message]
         [message]
             speaker=Lethalia
-            message= _ "Yes, and I am pregnant by him!" /*or "Yes, and I am pregnant from his seed!"*/
+            message= _ "Yes, and I am pregnant by him!"
+#           or "Yes, and I am pregnant from his seed!"
         [/message]
         [message]
             speaker=Efraim


### PR DESCRIPTION
(MP had previously used comment type from Wireless Markup Language rather than Wesnoth Markup Language.  Whoops)