### PR TITLE
village support 1000 in scenario5

### DIFF
--- a/scenarios5/08_Entrance.cfg
+++ b/scenarios5/08_Entrance.cfg
@@ -61,12 +61,13 @@
         side=1
         controller=human
         recruit=Skeleton,Skeleton Archer,Revenant,Deathblade,Bone Shooter,Ghost,Shadow,Wraith,Chocobone
-        gold=0
-        income=0
         shroud=yes
         team_name=good
         user_team_name=_"Good"
-        village_gold=1
+        gold=0
+        income=0
+        village_gold=0
+        village_support=1000
     [/side]
     [side]
         generate_name=yes

--- a/scenarios5/09_Northwestern_Storeroom.cfg
+++ b/scenarios5/09_Northwestern_Storeroom.cfg
@@ -61,12 +61,13 @@
         side=1
         controller=human
         recruit=Skeleton,Skeleton Archer,Revenant,Deathblade,Bone Shooter,Ghost,Shadow,Wraith,Chocobone
-        gold=0
-        income=0
         shroud=yes
         team_name=good
         user_team_name=_"Good"
-        village_gold=1
+        gold=0
+        income=0
+        village_gold=0
+        village_support=1000        
     [/side]
     [side]
         no_leader=yes

--- a/scenarios5/10_Guards_Quarters.cfg
+++ b/scenarios5/10_Guards_Quarters.cfg
@@ -68,11 +68,12 @@
         controller=human
         recruit=Skeleton,Skeleton Archer,Revenant,Deathblade,Bone Shooter,Ghost,Shadow,Wraith,Chocobone
         gold=0
-        income=0
         shroud=yes
         team_name=good
         user_team_name=_"Good"
-        village_gold=1
+        income=0
+        village_gold=0
+        village_support=1000
     [/side]
     [side]
         no_leader=yes

--- a/scenarios5/11_Northern_Guardian_Room.cfg
+++ b/scenarios5/11_Northern_Guardian_Room.cfg
@@ -57,12 +57,14 @@
         side=1
         controller=human
         recruit=Skeleton,Skeleton Archer,Revenant,Deathblade,Bone Shooter,Ghost,Shadow,Wraith,Chocobone
-        gold=0
         income=0
         shroud=yes
         team_name=good
         user_team_name=_"Good"
-        village_gold=1
+        gold=0
+        income=0
+        village_gold=0
+        village_support=1000        
     [/side]
     [side]
         generate_name=yes

--- a/scenarios5/12_Amplificator1.cfg
+++ b/scenarios5/12_Amplificator1.cfg
@@ -71,12 +71,13 @@
         side=1
         controller=human
         recruit=Skeleton,Skeleton Archer,Revenant,Deathblade,Bone Shooter,Ghost,Shadow,Wraith,Chocobone
-        gold=0
-        income=0
         shroud=yes
         team_name=good
         user_team_name=_"Good"
-        village_gold=1
+        gold=0
+        income=0
+        village_gold=0
+        village_support=1000
     [/side]
     [side]
         no_leader=yes

--- a/scenarios5/13_Eastern_Storeroom.cfg
+++ b/scenarios5/13_Eastern_Storeroom.cfg
@@ -71,13 +71,14 @@
         side=1
         controller=human
         recruit=Skeleton,Skeleton Archer,Revenant,Deathblade,Bone Shooter,Ghost,Shadow,Wraith,Chocobone
-        gold=0
-        income=0
         shroud=yes
         team_name=good
         user_team_name=_"Good"
-        village_gold=1
-    [/side]
+        gold=0
+        income=0
+        village_gold=0
+        village_support=1000
+[/side]
     [side]
         no_leader=yes
         side=2

--- a/scenarios5/14_Armoury.cfg
+++ b/scenarios5/14_Armoury.cfg
@@ -69,12 +69,13 @@
         side=1
         controller=human
         recruit=Skeleton,Skeleton Archer,Revenant,Deathblade,Bone Shooter,Ghost,Shadow,Wraith,Chocobone
-        gold=0
-        income=0
         shroud=yes
         team_name=good
         user_team_name=_"Good"
-        village_gold=1
+        gold=0
+        income=0
+        village_gold=0
+        village_support=1000
     [/side]
     [side]
         generate_name=yes

--- a/scenarios5/15_Amplificator2.cfg
+++ b/scenarios5/15_Amplificator2.cfg
@@ -70,12 +70,13 @@
         side=1
         controller=human
         recruit=Skeleton,Skeleton Archer,Revenant,Deathblade,Bone Shooter,Ghost,Shadow,Wraith,Chocobone
-        gold=0
-        income=0
         shroud=yes
         team_name=good
         user_team_name=_"Good"
-        village_gold=1
+        gold=0
+        income=0
+        village_gold=0
+        village_support=1000
     [/side]
     [side]
         no_leader=yes

--- a/scenarios5/16_Southeastern_Storeroom.cfg
+++ b/scenarios5/16_Southeastern_Storeroom.cfg
@@ -74,13 +74,14 @@
         side=1
         controller=human
         recruit=Skeleton,Skeleton Archer,Revenant,Deathblade,Bone Shooter,Ghost,Shadow,Wraith,Chocobone
-        gold=0
-        income=0
         shroud=yes
         team_name=good
         user_team_name=_"Good"
-        village_gold=1
-    [/side]
+        gold=0
+        income=0
+        village_gold=0
+        village_support=1000
+[/side]
     [side]
         no_leader=yes
         side=2

--- a/scenarios5/17_Amplificator3.cfg
+++ b/scenarios5/17_Amplificator3.cfg
@@ -67,12 +67,13 @@
         side=1
         controller=human
         recruit=Skeleton,Skeleton Archer,Revenant,Deathblade,Bone Shooter,Ghost,Shadow,Wraith,Chocobone
-        gold=0
-        income=0
         shroud=yes
         team_name=good
         user_team_name=_"Good"
-        village_gold=1
+        gold=0
+        income=0
+        village_gold=0
+        village_support=1000        
     [/side]
     [side]
         no_leader=yes

--- a/scenarios5/18_Eastern_Guardian_Room.cfg
+++ b/scenarios5/18_Eastern_Guardian_Room.cfg
@@ -57,12 +57,13 @@
         side=1
         controller=human
         recruit=Skeleton,Skeleton Archer,Revenant,Deathblade,Bone Shooter,Ghost,Shadow,Wraith,Chocobone
-        gold=0
-        income=0
         shroud=yes
         team_name=good
         user_team_name=_"Good"
-        village_gold=1
+        gold=0
+        income=0
+        village_gold=0
+        village_support=1000
     [/side]
     [side]
         generate_name=yes

--- a/scenarios5/19_Soldiers_Training_Room.cfg
+++ b/scenarios5/19_Soldiers_Training_Room.cfg
@@ -66,12 +66,13 @@
         side=1
         controller=human
         recruit=Skeleton,Skeleton Archer,Revenant,Deathblade,Bone Shooter,Ghost,Shadow,Wraith,Chocobone
-        gold=0
-        income=0
         shroud=yes
         team_name=good
         user_team_name=_"Good"
-        village_gold=1
+        gold=0
+        income=0
+        village_gold=0
+        village_support=1000
     [/side]
     [side]
         generate_name=yes

--- a/scenarios5/20_Southern_Guardian_Room.cfg
+++ b/scenarios5/20_Southern_Guardian_Room.cfg
@@ -57,12 +57,13 @@
         side=1
         controller=human
         recruit=Skeleton,Skeleton Archer,Revenant,Deathblade,Bone Shooter,Ghost,Shadow,Wraith,Chocobone
-        gold=0
-        income=0
         shroud=yes
         team_name=good
         user_team_name=_"Good"
-        village_gold=1
+        gold=0
+        income=0
+        village_gold=0
+        village_support=1000
     [/side]
     [side]
         generate_name=yes

--- a/scenarios5/21_Soldiers_Quarters.cfg
+++ b/scenarios5/21_Soldiers_Quarters.cfg
@@ -63,12 +63,13 @@
         side=1
         controller=human
         recruit=Skeleton,Skeleton Archer,Revenant,Deathblade,Bone Shooter,Ghost,Shadow,Wraith,Chocobone
-        gold=0
-        income=0
         shroud=yes
         team_name=good
         user_team_name=_"Good"
-        village_gold=1
+        gold=0
+        income=0
+        village_gold=0
+        village_support=1000
     [/side]
     [side]
         generate_name=yes

--- a/scenarios5/22_Amplificator4.cfg
+++ b/scenarios5/22_Amplificator4.cfg
@@ -68,12 +68,13 @@
         side=1
         controller=human
         recruit=Skeleton,Skeleton Archer,Revenant,Deathblade,Bone Shooter,Ghost,Shadow,Wraith,Chocobone
-        gold=0
-        income=0
         shroud=yes
         team_name=good
         user_team_name=_"Good"
-        village_gold=1
+        gold=0
+        income=0
+        village_gold=0
+        village_support=1000
     [/side]
     [side]
         no_leader=yes

--- a/scenarios5/23_Akulas_Place.cfg
+++ b/scenarios5/23_Akulas_Place.cfg
@@ -72,7 +72,10 @@
         income=0
         team_name=good
         user_team_name=_"Good"
-        village_gold=1
+#        gold=0 commented as 200 gold (above) intentional
+        income=0
+        village_gold=0
+        village_support=1000
     [/side]
     [side]
         name=Akula

--- a/scenarios5/24_Escape_Tunnel.cfg
+++ b/scenarios5/24_Escape_Tunnel.cfg
@@ -54,11 +54,12 @@
         controller=human
         recruit=Skeleton,Skeleton Archer,Revenant,Deathblade,Bone Shooter,Ghost,Shadow,Wraith,Chocobone
         gold=0
-        income=0
-        shroud=yes
         team_name=good
         user_team_name=_"Good"
-        village_gold=1
+        shroud=yes
+        income=0
+        village_gold=0
+        village_support=1000
     [/side]
     [side]
         no_leader=yes

--- a/scenarios5/25_Prison.cfg
+++ b/scenarios5/25_Prison.cfg
@@ -81,12 +81,13 @@
         side=1
         controller=human
         recruit=Skeleton,Skeleton Archer,Revenant,Deathblade,Bone Shooter,Ghost,Shadow,Wraith,Chocobone
-        gold=0
-        income=0
         shroud=yes
         team_name=good
         user_team_name=_"Good"
-        village_gold=1
+        gold=0
+        income=0
+        village_gold=0
+        village_support=1000
     [/side]
     [side]
         no_leader=yes

--- a/scenarios5/26_Library.cfg
+++ b/scenarios5/26_Library.cfg
@@ -50,12 +50,13 @@
         side=1
         controller=human
         recruit=Skeleton,Skeleton Archer,Revenant,Deathblade,Bone Shooter,Ghost,Shadow,Wraith,Chocobone
-        gold=0
-        income=0
         shroud=yes
         team_name=good
         user_team_name=_"Good"
-        village_gold=1
+        gold=0
+        income=0
+        village_gold=0
+        village_support=1000
     [/side]
     [side]
         no_leader=yes

--- a/scenarios5/27_Power_Station.cfg
+++ b/scenarios5/27_Power_Station.cfg
@@ -66,12 +66,13 @@
         side=1
         controller=human
         recruit=Skeleton,Skeleton Archer,Revenant,Deathblade,Bone Shooter,Ghost,Shadow,Wraith,Chocobone
-        gold=0
-        income=0
         shroud=yes
         team_name=good
         user_team_name=_"Good"
-        village_gold=1
+        gold=0
+        income=0
+        village_gold=0
+        village_support=1000
     [/side]
     [side]
         no_leader=yes

--- a/scenarios5/28_War_Zone.cfg
+++ b/scenarios5/28_War_Zone.cfg
@@ -58,11 +58,12 @@
         side=1
         controller=human
         recruit=Skeleton,Skeleton Archer,Revenant,Deathblade,Bone Shooter,Ghost,Shadow,Wraith,Chocobone
-        gold=0
-        income=0
         team_name=good
         user_team_name=_"Good"
-        village_gold=2
+        gold=0
+        income=0
+        village_gold=0
+        village_support=1000        
     [/side]
     [side]
         generate_name=yes


### PR DESCRIPTION
In scenario 5 cfgs, where `{DISABLE_UPKEEP 1}` appears, changed side 1 (Efraim) to have the following values
```
        gold=0
        income=0
        village_gold=0
        village_support=1000
```
except in Akula's place where `gold=200`

Note that if any scenarios don't have a village owned by Efraim at the start, the old `DISABLE_UPKEEP` code may still be needed. A "workaround" (instead of `DISABLE_UPKEEP`) on such maps would be to create a village "off map". Then that village is assigned to Efraim, shrouded, and never revealed. This would be needed to prevent teleportation to the site as a "safe heal" location.