### PR TITLE
[Requires review] Simplify binary search and try to plug all the holes

### DIFF
--- a/scenarios10/14_End_of_the_World.cfg
+++ b/scenarios10/14_End_of_the_World.cfg
@@ -559,13 +559,7 @@ After several days' travel through a wintry landscape, they found an oasis that 
                         less_than="$foreach"
                     [/variable]
                     [do]
-                        {VARIABLE_OP variable_to_set_length to_variable item_storage.$count|.length}
-                        [set_variables]
-                            name=item_storage.$count|[$variable_to_set_length]
-                            mode=replace
-                            to_variable=main_item_storage.$count|[$i]
-                        [/set_variables]
-                        {CLEAR_VARIABLE variable_to_set_length}
+                        {INSERT_INTO_ITEMS item_storage $count $main_item_storage.$count|[$i].type|}
                         {VARIABLE_OP i add 1}
                     [/do]
                 [/while]

--- a/scenarios8/14_Finally_Together.cfg
+++ b/scenarios8/14_Finally_Together.cfg
@@ -191,6 +191,7 @@
                 {TEXT_COUNT count armour helm}
                 {TEXT_COUNT count nothing_yet armour}
                 {VARIABLE variable_in_foreach "vritra_item_storage.$count|.length"}
+                {VARIABLE i 0}
                 [set_variable]
                     name="foreach"
                     to_variable="$variable_in_foreach"
@@ -201,13 +202,7 @@
                         less_than="$foreach"
                     [/variable]
                     [do]
-                        {VARIABLE_OP variable_to_set_length to_variable item_storage.$count|.length}
-                        [set_variables]
-                            name=item_storage.$count|[$variable_to_set_length]
-                            mode=replace
-                            to_variable=vritra_item_storage.$count|[$i]
-                        [/set_variables]
-                        {CLEAR_VARIABLE variable_to_set_length}
+                        {INSERT_INTO_ITEMS item_storage $count $vritra_item_storage.$count|[$i].type|}
                         {VARIABLE_OP i add 1}
                     [/do]
                 [/while]

--- a/scenarios8/15_Jungle_Hell.cfg
+++ b/scenarios8/15_Jungle_Hell.cfg
@@ -454,18 +454,8 @@ Items left behind WILL BE put into the inventory."
                     [/set_variable]
                 [/do]
             [/while]
-            [set_variable]
-                name=length
-                to_variable=item_storage.$item_list.object[$item_number].sort|.length
-            [/set_variable]
-            [set_variables]
-                name=item_storage.$item_list.object[$item_number].sort|[$length]
-                mode=replace
-                [value]
-                    type=$item_list.object[$item_number].number
-                [/value]
-            [/set_variables]
-            {CLEAR_VARIABLE item_number,o,length}
+            {INSERT_INTO_ITEMS item_storage $item_list.object[$item_number].sort| $item_list.object[$item_number].number|}
+            {CLEAR_VARIABLE o}
         {NEXT i}
         [endlevel]
             result=victory

--- a/utils/global_events.cfg
+++ b/utils/global_events.cfg
@@ -518,15 +518,7 @@
                                 equals=$items[$k].type
                             [/variable]
                             [then]
-                                {VARIABLE_OP length to_variable "item_storage.$item_list.object[$i].sort|.length"}
-                                [set_variables]
-                                    name=item_storage.$item_list.object[$i].sort|[$length]
-                                    mode=replace
-                                    [value]
-                                        type=$items[$k].type
-                                    [/value]
-                                [/set_variables]
-                                {CLEAR_VARIABLE length}
+                                {INSERT_INTO_ITEMS item_storage $item_list.object[$i].sort| $items[$k].type}
                             [/then]
                         [/if]
                     {NEXT i}
@@ -2198,17 +2190,7 @@ Do you want to create this item?"
                                                         [/do]
                                                     [/while]
                                                     {CLEAR_VARIABLE k}
-                                                    [set_variable]
-                                                        name=length
-                                                        to_variable=item_storage.$item_removal_sort|.length
-                                                    [/set_variable]
-                                                    [set_variables]
-                                                        name=item_storage.$item_removal_sort|[$length]
-                                                        mode=replace
-                                                        [value]
-                                                            type=$item_list.object[$item_number].number
-                                                        [/value]
-                                                    [/set_variables]
+                                                    {INSERT_INTO_ITEMS item_storage $item_removal_sort $item_list.object[$item_number].number}
                                                 [/command]
                                             [/option]
                                             [option]
@@ -3485,20 +3467,9 @@ $soul_eating"
                     [/variable]
                 [/or]
                 [then]
-                    [set_variable]
-                        name=length
-                        to_variable=item_storage.$stripped.modifications.object[$i].sort|.length
-                    [/set_variable]
-                    [set_variables]
-                        name=item_storage.$stripped.modifications.object[$i].sort|[$length]
-                        mode=replace
-                        [value]
-                            type=$stripped.modifications.object[$i].number
-                        [/value]
-                    [/set_variables]
+                    {INSERT_INTO_ITEMS item_storage $stripped.modifications.object[$i].sort| $stripped.modifications.object[$i].number|}
                     {CLEAR_VARIABLE stripped.modifications.object[$i]}
                     {VARIABLE_OP i sub 1}
-                    {CLEAR_VARIABLE length}
                 [/then]
             [/if]
         {NEXT i}
@@ -4559,7 +4530,7 @@ $soul_eating"
                                 action=add
                            [/micro_ai_fast]
 #endif
- 
+
                         [/then]
                     [/if]
                 {NEXT i}

--- a/utils/items.cfg
+++ b/utils/items.cfg
@@ -4,96 +4,65 @@
     # Use these to shorten code below
     {VARIABLE sort {SORT}}
     {VARIABLE item {ITEM_NUMBER}}
+
+    # Insert into the item storage using a binary search to find the position
     [set_variable]
         name=high
         to_variable={ARRAY}.$sort|.length
     [/set_variable]
-    {VARIABLE_OP high sub 1}
-    # Insert into the item storage using a binary search to find the position
+    {VARIABLE low 0}
+
+    [while]
+        {VARIABLE_CONDITIONAL low not_equals $high}
+        [do]
+            # mid = (low + high) // 2
+            {VARIABLE mid $high}
+            {VARIABLE_OP mid add $low}
+            {VARIABLE_OP mid divide 2}
+            {VARIABLE_OP mid round floor}
+            [if]
+                [variable]
+                    name={ARRAY}.$sort|[$mid].type
+                    greater_than_equal_to=$item
+                [/variable]
+                [then]
+                    {VARIABLE high $mid}
+                [/then]
+                [else]
+                    {VARIABLE_OP mid add 1}
+                    {VARIABLE low $mid}
+                [/else]
+            [/if]
+            {CLEAR_VARIABLE mid}
+        [/do]
+    [/while]
     [if]
-        # First check if the array is empty or item is greater than the last element
         [variable]
             name=high
-            equals=-1
+            equals=${ARRAY}.$sort|.length
         [/variable]
-        [or]
-            [variable]
-                name={ARRAY}.$sort|[$high].type
-                less_than=$item
-            [/variable]
-        [/or]
         [then]
-            # Append item to the end of the array
-            {VARIABLE_OP high add 1}
             [set_variables]
-                name={ARRAY}.$sort|[$high]
-                mode=replace
+                name={ARRAY}.$sort
+                mode=append
                 [value]
-                    type={ITEM_NUMBER}
+                    type=$item
                 [/value]
             [/set_variables]
         [/then]
-        [else][if]
-            # Then check if item is less than the first element (we know the array is not empty)
-            [variable]
-                name={ARRAY}.$sort|[0].type
-                greater_than_equal_to=$item
-            [/variable]
-            [then]
-                # Insert at position 0
-                [set_variables]
-                    name={ARRAY}.$sort|[0]
-                    mode=insert
-                    [value]
-                        type={ITEM_NUMBER}
-                    [/value]
-                [/set_variables]
-            [/then]
-            [else]
-                # Binary search bit. High is the upper bound, low is the lower bound
-                # Iterate until the difference is 1, at which point item should go between positions low and high
-                {VARIABLE low 0}
-                {VARIABLE diff $high}
-                {VARIABLE_OP diff sub $low}
-                [while]
-                    {VARIABLE_CONDITIONAL diff not_equals 1}
-                    [do]
-                        # mid = (low + high) // 2
-                        {VARIABLE mid $high}
-                        {VARIABLE_OP mid add $low}
-                        {VARIABLE_OP mid divide 2}
-                        {VARIABLE_OP mid round floor}
-                        [if]
-                            [variable]
-                                name={ARRAY}.$sort|[$mid].type
-                                greater_than_equal_to=$item
-                            [/variable]
-                            [then]
-                                {VARIABLE high $mid}
-                            [/then]
-                            [else]
-                                {VARIABLE low $mid}
-                            [/else]
-                        [/if]
-                        {VARIABLE diff $high}
-                        {VARIABLE_OP diff sub $low}
-                        {CLEAR_VARIABLE mid}
-                    [/do]
-                [/while]
-                {CLEAR_VARIABLE low}
-                {CLEAR_VARIABLE diff}
-                # insert at high to put item between low and high
-                [set_variables]
-                    name={ARRAY}.$sort|[$high]
-                    mode=insert
-                    [value]
-                        type=$item
-                    [/value]
-                [/set_variables]
-            [/else]
-        [/if][/else]
+        [else]
+            [set_variables]
+                name={ARRAY}.$sort|[$high]
+                mode=insert
+                [value]
+                    type=$item
+                [/value]
+            [/set_variables]
+        [/else]
     [/if]
+
     {CLEAR_VARIABLE high}
+    {CLEAR_VARIABLE low}
     {CLEAR_VARIABLE sort}
     {CLEAR_VARIABLE item}
 #enddef


### PR DESCRIPTION
Improves on the sorting of items that was added before. I've gone though and tried to update everywhere that `item_storage` is added to, as currently the item list slowly goes out of order due to unpatched modifications. I have tested all the changed cases except `scenarios10/14_End_of_the_World.cfg` as I don't have a replay of that ATM. It's similar enough to `scenarios8/14_Finally_Together.cfg` that the code should be correct, though.