### PR TITLE
Fixed error in walkthrough

### DIFF
--- a/utils/help.cfg
+++ b/utils/help.cfg
@@ -1937,7 +1937,7 @@ The enemy boss will be easy to defeat if you have destroyed all the amplificator
                 [command]
                     [message]
                         speaker=narrator
-                        message=_"You are now in the lands that were once the glorious empire of Wesnoth. You will not find any ruins that survived for so long, only some newer ones. Don't recruit too much (but care to have some healers, you will need them) and try to save the gold you find in chests, there will be a trader in a town near the northern border. Prepare to fight some saurians around the swamp, so better don't enter the morass and don't fight them on the sand. You can choose if you want to follow one of the partially sand-covered roads (that is not very safe, but there won't be any bottlenecks), or to follow the lava river and face many demons, later in caves. A lot of items can be found near the lava river."
+                        message=_"You are now in the lands that were once the glorious empire of Wesnoth. You will not find any ruins that survived for so long, only some newer ones. Don't recruit too much (but care to have some healers, you will need them) and try to save the gold you find in chests, there will be a trader in a town near the southern border. Prepare to fight some saurians around the swamp, so better don't enter the morass and don't fight them on the sand. You can choose if you want to follow one of the partially sand-covered roads (that is not very safe, but there won't be any bottlenecks), or to follow the lava river and face many demons, later in caves. A lot of items can be found near the lava river."
                         side_for=$side_number
                         image="wesnoth-icon.png"
                     [/message]


### PR DESCRIPTION
For some reason GitHub does not highlight it, but I replaced text
... there will be a trader in a town near the **northern** border ...
with
... there will be a trader in a town near the **southern** border ...

This is scenario 8.8