### PR TITLE
Fix backstab overriding

### DIFF
--- a/utils/stats.cfg
+++ b/utils/stats.cfg
@@ -3987,21 +3987,31 @@
                         variable=advanced.attack[$i].specials.damage[$j].id
                         [case]
                             value=charging backstab
-                            {VARIABLE backstab 1}
+                            {VARIABLE new_backstab 1}
                         [/case]
                         [case]
                             value=backstab
-                            {VARIABLE backstab 2}
+                            {VARIABLE new_backstab 2}
                         [/case]
                         [case]
                             value=greater backstab
-                            {VARIABLE backstab 3}
+                            {VARIABLE new_backstab 3}
                         [/case]
                         [case]
                             value=uber backstab
-                            {VARIABLE backstab 4}
+                            {VARIABLE new_backstab 4}
                         [/case]
                     [/switch]
+                    [if]
+                        [variable]
+                            name=backstab
+                            less_than=$new_backstab
+                        [/variable]
+                        [then]
+                            {VARIABLE backstab $new_backstab}
+                        [/then]
+                    [/if]
+                    {CLEAR_VARIABLE new_backstab}
                 [/then]
             [/if]
         {NEXT j}
@@ -4108,7 +4118,7 @@
                                 name=has_charging_backstab
                                 equals=true
                             [/variable]
-                            [then] # Undo this if the unit would be also bastabbing
+                            [then] # Undo this if the unit would be also backstabbing
                                 {VARIABLE x $advanced.attack[$i].specials.damage.length}
                                 {VARIABLE advanced.attack[$i].specials.damage[$x].id "latent_charge_counter_backstab"}
                                 {VARIABLE advanced.attack[$i].specials.damage[$x].multiply 0.666}


### PR DESCRIPTION
This patch fixes backstab overriding. However, is causes the following problem:

The Exterminator has [an advancement](https://wiki.wesnoth.org/LotI_Unit_Advancements#Able_to_Charge_at_Enemies_when_Backstabbing_if_Selected_.E2.80.93_murderous_frenzy) that is a clone of the normal attack with charging backstab added. Since the normal attack has backstab, the new attack is basically a weaker version of the original attack with no new specials, and so is useless. Either:

 - Charging backstab needs a bigger increase in damage
 - Or it should not be overridden, so it stacks with other backstab specials