### PR TITLE
Gladiators: remove Spell Eater boss as unbalanced

### DIFF
--- a/multiplayer/Gladiators.cfg
+++ b/multiplayer/Gladiators.cfg
@@ -1658,7 +1658,7 @@ Everyone will choose difficulty, and the selected difficulties will be averaged.
                                 name=turn end
                                 {VARIABLE hitpoints $difficulty}
                                 {VARIABLE damage $difficulty}
-                                {VARIABLE_OP boss_type rand (Fire Dragon loti,Ice Dragon,Dark Dragon,Skeletal Dragon,Dracolich,Reaper,Dark Shade,Lich King,Corrupted Elvish Juggernaut,Ancient Lich,Spell Eater)}
+                                {VARIABLE_OP boss_type rand (Fire Dragon loti,Ice Dragon,Dark Dragon,Skeletal Dragon,Dracolich,Reaper,Dark Shade,Lich King,Corrupted Elvish Juggernaut,Ancient Lich)}
                                 [set_variables]
                                     name=boss_object
                                     mode=replace


### PR DESCRIPTION
Spell Eater easily defeats any hero, regardless of resistances, items,
skills, etc. It's game over whenever this boss appears in Gladiators.

We can scale down its HP and damage, but the essence of the problem is
its ranged/melee attacks both being magical, so better just remove it.