### PR TITLE
Fix replace to append on marksman ability

### DIFF
--- a/units/Elvish_Juggernaut.cfg
+++ b/units/Elvish_Juggernaut.cfg
@@ -278,7 +278,7 @@
                 name=bow
                 increase_damage=-1
                 [set_specials]
-                    mode=replace
+                    mode=append
                     {WEAPON_SPECIAL_MARKSMAN}
                 [/set_specials]
             [/effect]


### PR DESCRIPTION
The amla that adds the marksman ability is set to replace specials, when it should append to specials. Fixed.