### PR TITLE
Improved (exact/consistent) description of some AMLA upgrades, part 1

### DIFF
--- a/units/Ancient_Lich.cfg
+++ b/units/Ancient_Lich.cfg
@@ -179,7 +179,7 @@
     {GENERIC_AMLA units/undead-necromancers/ancient-lich.png units/undead-necromancers/ancient-lich-magic-1.png units/undead-necromancers/ancient-lich-magic-2.png units/undead-necromancers/ancient-lich.png units/undead-necromancers/ancient-lich-magic-1.png units/undead-necromancers/ancient-lich-magic-2.png (    [advancement]
     max_times=1
     id=melee
-    description= _ "better at melee combat"
+    description= _ "faster at melee combat"
     image="attacks/touch-undead.png"
     strict_amla=yes
     require_amla=""
@@ -238,7 +238,7 @@
 [advancement]
     max_times=1
     id=magic-chill
-    description= _ "a better caster of chill tempests"
+    description= _ "a faster caster of chill tempests"
     image="attacks/iceball.png"
     strict_amla=yes
     require_amla=""
@@ -269,7 +269,7 @@
 [advancement]
     max_times=1
     id=magic-shadow
-    description= _ "a better caster of shadow waves"
+    description= _ "a faster caster of shadow waves"
     image="attacks/dark-missile.png"
     strict_amla=yes
     require_amla=""
@@ -328,7 +328,7 @@
 [advancement]
     max_times=1
     id=magic-shadow-leech
-    description= _ "leeching enemies with shadow wave"
+    description= _ "leeching health from enemies with shadow wave"
     image="attacks/dark-missile.png"
     strict_amla=yes
     require_amla="magic-shadow2"

--- a/units/Celestial_Messenger.cfg
+++ b/units/Celestial_Messenger.cfg
@@ -522,7 +522,7 @@ Thanks to the feathered wings on their backs, they can travel much faster throug
         [advancement]
             max_times=1
             id=lightbeam2
-            description= _ "better with magic"
+            description= _ "faster with magic"
             image=attacks/lightbeam.png
             strict_amla=yes
             require_amla="lightbeam"
@@ -551,7 +551,7 @@ Thanks to the feathered wings on their backs, they can travel much faster throug
         [advancement]
             max_times=1
             id=mace
-            description= _ "better with mace"
+            description= _ "faster with mace"
             image=attacks/mace-spiked.png
             strict_amla=yes
             require_amla=""

--- a/units/Champion_Bowman.cfg
+++ b/units/Champion_Bowman.cfg
@@ -179,7 +179,7 @@
             max_times=1
             always_display=yes
             id=bow2
-            description= _ "striking better with bow"
+            description= _ "striking faster with bow"
             image=attacks/bow.png
             strict_amla=yes
             require_amla="bow"
@@ -210,7 +210,7 @@
             max_times=1
             always_display=yes
             id=bow-precision
-            description= _ "striking more precisely with bow"
+            description= _ "shooting insanely precisely"
             image=attacks/bow.png
             strict_amla=yes
             require_amla="bow"
@@ -229,7 +229,7 @@
             max_times=1
             always_display=yes
             id=arrowstorm
-            description= _ "able to shoot a storm on arrows without giving the enemy a chance to counterattack"
+            description= _ "able to shoot a storm on arrows without giving the enemy a chance to counterattack (new attack)"
             image=attacks/bow-elven-magic.png
             strict_amla=yes
             require_amla=""
@@ -284,7 +284,7 @@
             max_times=1
             always_display=yes
             id=sword2
-            description= _ "striking better with sword"
+            description= _ "striking faster with sword"
             image=attacks/sword-human.png
             strict_amla=yes
             require_amla="sword"

--- a/units/Chaos_Rider.cfg
+++ b/units/Chaos_Rider.cfg
@@ -270,7 +270,7 @@
         [advancement]
             max_times=1
             id=fireball2
-            description= _ "better with fireball"
+            description= _ "faster with fireball"
             image=attacks/fireball.png
             strict_amla=yes
             require_amla="fireball"

--- a/units/Demilich.cfg
+++ b/units/Demilich.cfg
@@ -364,7 +364,7 @@
 [advancement]
     max_times=1
     id=magic-shadow-leech
-    description= _ "leeching enemies with shadow wave"
+    description= _ "leeching health from enemies with shadow wave"
     image="attacks/dark-missile.png"
     strict_amla=yes
     require_amla="magic-shadow2"

--- a/units/Destroyer.cfg
+++ b/units/Destroyer.cfg
@@ -169,7 +169,7 @@ Note: Destroyers can learn berserk."
             max_times=1
             always_display=yes
             id=scourge2
-            description= _ "striking more furiously with scourge"
+            description= _ "striking faster with scourge"
             image=attacks/morning-star.png
             strict_amla=yes
             require_amla="scourge"
@@ -200,7 +200,7 @@ Note: Destroyers can learn berserk."
             max_times=1
             always_display=yes
             id=berserk
-            description= _ "able to enter a battle frenzy like dwarves, but only when attacking"
+            description= _ "able to enter a battle frenzy like dwarves, but only when attacking (new attack)"
             image=attacks/frenzy.png
             strict_amla=yes
             require_amla="scourge"
@@ -224,7 +224,7 @@ Note: Destroyers can learn berserk."
             max_times=5
             always_display=yes
             id=berserk2
-            description= _ "striking better when in battle frenzy"
+            description= _ "striking faster when in battle frenzy"
             image=attacks/frenzy.png
             strict_amla=yes
             require_amla="berserk"

--- a/units/Duelist_Wizard.cfg
+++ b/units/Duelist_Wizard.cfg
@@ -484,7 +484,7 @@
         [advancement]
             max_times=1
             id=missile2
-            description= _ "better with magic missile"
+            description= _ "faster with magic missile"
             image=attacks/magic-missile.png
             strict_amla=yes
             require_amla="magic,missile"

--- a/units/Dwarvish_Battlerager.cfg
+++ b/units/Dwarvish_Battlerager.cfg
@@ -119,7 +119,7 @@
         [advancement]
             id=axe2
             max_times=1
-            description= _ "frenzying better"
+            description= _ "frenzying faster"
             image=attacks/frenzy.png
             strict_amla=yes
             require_amla="axe"
@@ -162,7 +162,7 @@
         [advancement]
             id=armour
             max_times=5
-            description= _ "tougher"
+            description= _ "tougher (2-3% better resistances)"
             image=icons/steel_armor.png
             strict_amla=yes
             require_amla=""

--- a/units/Dwarvish_Hero.cfg
+++ b/units/Dwarvish_Hero.cfg
@@ -405,7 +405,7 @@
         [advancement]
             max_times=5
             id=block
-            description= _ "blocking better"
+            description= _ "better at blocking (lowering the chance to be hit by 2-4%)"
             image="icons/shield_tower.png"
             strict_amla=yes
             require_amla=""
@@ -434,7 +434,7 @@
             max_times=1
             always_display=yes
             id=lightning
-            description= _ "capable to use lightning"
+            description= _ "capable to use lightning (new attack)"
             image=attacks/lightning.png
             strict_amla=yes
             require_amla=""

--- a/units/Dwarvish_Protector.cfg
+++ b/units/Dwarvish_Protector.cfg
@@ -275,7 +275,7 @@
         [advancement]
             max_times=5
             id=block
-            description= _ "blocking better"
+            description= _ "better at blocking (lowering the chance to be hit by 2-4%)"
             image="icons/shield_tower.png"
             strict_amla=yes
             require_amla=""

--- a/units/Dwarvish_Technocrat.cfg
+++ b/units/Dwarvish_Technocrat.cfg
@@ -308,7 +308,7 @@
             max_times=1
             id=storm
             strict_amla=yes
-            description= _ "more technically skilled, using a gun that can fire very quickly"
+            description= _ "more technically skilled, using a gun that can fire very quickly (new attack)"
             image=attacks/thunderstick.png
             require_amla=""
             [effect]
@@ -328,7 +328,7 @@
             max_times=3
             always_display=yes
             id=storm2
-            description= _ "shooting bullet storms better"
+            description= _ "shooting bullet storms faster"
             image=attacks/thunderstick.png
             strict_amla=yes
             require_amla="storm"
@@ -344,7 +344,7 @@
             max_times=1
             id=blunderbuss
             strict_amla=yes
-            description= _ "more technically skilled, using a very precise gun"
+            description= _ "more technically skilled, using a very precise gun (new attack)"
             image=attacks/thunderstick.png
             require_amla=""
             [effect]
@@ -381,7 +381,7 @@
             max_times=1
             always_display=yes
             id=bullets
-            description= _ "shooting bullets that penetrate armour better"
+            description= _ "shooting bullets that penetrate armour better (+10% pierce resistance penetration)"
             image=attacks/thunderstick-modern.png
             strict_amla=yes
             require_amla=""
@@ -392,7 +392,7 @@
             max_times=4
             always_display=yes
             id=bullets2
-            description= _ "shooting bullets that penetrate armour better"
+            description= _ "shooting bullets that penetrate armour better (+5% pierce resistance penetration)"
             image=attacks/thunderstick-modern.png
             strict_amla=yes
             require_amla="bullets"

--- a/units/Elvish_Juggernaut.cfg
+++ b/units/Elvish_Juggernaut.cfg
@@ -241,7 +241,7 @@
         [advancement]
             max_times=1
             id=bow
-            description= _ "better with the bow"
+            description= _ "faster with the bow"
             image="attacks/bow-elven.png"
             strict_amla=yes
             require_amla=""
@@ -255,7 +255,7 @@
         [advancement]
             max_times=1
             id=bow2
-            description= _ "better with bow"
+            description= _ "better with the bow"
             image="attacks/bow-elven.png"
             strict_amla=yes
             require_amla="bow"
@@ -269,7 +269,7 @@
         [advancement]
             max_times=1
             id=bow-precise
-            description= _ "shooting insanely precisely"
+            description= _ "more precise with bow"
             image="attacks/bow-elven.png"
             strict_amla=yes
             require_amla="bow,bow2"
@@ -353,7 +353,7 @@
             max_times=1
             always_display=yes
             id=mayhem
-            description= _ "able to maim enemies, lowering their damage until they advance"
+            description= _ "able to maim enemies, lowering their damage until they advance (new attack)"
             image=attacks/greatsword-elven.png
             strict_amla=yes
             require_amla="sword"

--- a/units/Elvish_Overlord.cfg
+++ b/units/Elvish_Overlord.cfg
@@ -323,7 +323,7 @@
             max_times=1
             always_display=yes
             id=gossamer
-            description= _ "able to cover his sword in sticky spiderwebs to slow enemies"
+            description= _ "able to cover his sword in sticky spiderwebs to slow enemies (new attack)"
             image=attacks/web.png
             strict_amla=yes
             require_amla="faerie2"

--- a/units/Exterminator.cfg
+++ b/units/Exterminator.cfg
@@ -356,7 +356,7 @@
             max_times=1
             always_display=yes
             id=scythe2
-            description= _ "better with scythe"
+            description= _ "faster with scythe"
             image=attacks/scythe.png
             strict_amla=yes
             require_amla="scythe"
@@ -400,7 +400,7 @@
         [advancement]
             max_times=1
             id=knife2
-            description= _ "very precise with knives"
+            description= _ "insanely precise with knives"
             image=attacks/dagger-thrown-poison-human.png
             strict_amla=yes
             require_amla="knife"
@@ -472,7 +472,7 @@
             max_times=1
             always_display=yes
             id=whirlwind
-            description= _ "able to perform a whirlwind attack"
+            description= _ "able to perform a whirlwind attack (new attack)"
             image=attacks/scythe.png
             strict_amla=yes
             require_amla=""

--- a/units/Pilum_Master.cfg
+++ b/units/Pilum_Master.cfg
@@ -244,7 +244,7 @@
             max_times=1
             always_display=yes
             id=trickery
-            description= _ "able to attack in a tricky way that lowers enemy defence"
+            description= _ "able to attack in a tricky way that lowers enemy defence (new attack)"
             image=attacks/spear.png
             strict_amla=yes
             require_amla=""
@@ -283,7 +283,7 @@
         [advancement]
             max_times=5
             id=block
-            description= _ "blocking better"
+            description= _ "better at blocking (lowering the chance to be hit by 2-3%)"
             image="icons/shield_tower.png"
             strict_amla=yes
             require_amla=""

--- a/units/Soul_Shooter.cfg
+++ b/units/Soul_Shooter.cfg
@@ -182,7 +182,7 @@
         [advancement]
             max_times=1
             id=bow2
-            description= _ "better with bow"
+            description= _ "faster with bow"
             image="attacks/bow-orcish.png"
             strict_amla=yes
             require_amla="bow"
@@ -228,7 +228,7 @@
         [advancement]
             max_times=1
             id=bow-leech
-            description= _ "leeching enemies with bow"
+            description= _ "leeching health from enemies with bow"
             image="attacks/bow-orcish.png"
             strict_amla=yes
             require_amla="bow2"
@@ -264,7 +264,7 @@
             max_times=1
             always_display=yes
             id=arcane
-            description= _ "able to shoot cursed arcane arrows"
+            description= _ "able to shoot cursed arcane arrows (new attack)"
             image=attacks/bow-elven-magic.png
             strict_amla=yes
             require_amla=""
@@ -312,7 +312,7 @@
         [advancement]
             max_times=1
             id=dagger2
-            description= _ "better with dagger"
+            description= _ "faster with dagger"
             image="attacks/dagger-undead.png"
             strict_amla=yes
             require_amla="dagger"


### PR DESCRIPTION
1) Replaced "better with N" with "faster with N" in upgrades if they
provide +1 to number of attacks.

2) Upgrades that add focused/marksman now have a common wording:
"insanely precisely" for focused, "more precise" for just marksman.

3) Upgrades that add a completely new attack type (e.g. arrow storm)
are now marked as "(new attack)"

4) Upgrades like "blocking better", "tougher", etc. now explain what
exactly are they doing. (rather than leaving the player to guess)

TODO: only some units were modified, should also fix all other units.