### PR TITLE
Grammar fix

### DIFF
--- a/utils/items.cfg
+++ b/utils/items.cfg
@@ -766,7 +766,7 @@
                                     equals=-1
                                 [/variable]
                                 [then]
-                                    {VARIABLE object_description[$object_description.length].effect _"<span color='#60A0FF'>1 fewer movement point </span>"}
+                                    {VARIABLE object_description[$object_description.length].effect _"<span color='#60A0FF'>1 less movement point </span>"}
                                 [/then]
                                 [else]
                                     {VARIABLE negated "$(-1*$item_list.object[$item_number].effect[$p].increase)"}


### PR DESCRIPTION
Fewer should be used with multiple nouns, but less should be used when singular (in this case the movement point)