### PR TITLE
Replace obsolete parameter "ai_formula=idle_ai" with modern syntax

### DIFF
--- a/multiplayer/Gladiators.cfg
+++ b/multiplayer/Gladiators.cfg
@@ -204,9 +204,11 @@ The difficulty is adjustable, for 1-5 players, so you can balance it yourself. U
         team_name=heroes,Opponents
         user_team_name=_"Observers"
         village_gold=0
-        ai_formula=idle_ai
         gold=0
         income=-2
+        [ai]
+            ai_algorithm=idle_ai
+        [/ai]
         [modifications]
             [object]
                 [effect]

--- a/scenarios8/06_Gladiatrix.cfg
+++ b/scenarios8/06_Gladiatrix.cfg
@@ -89,7 +89,9 @@
         recruit=
         team_name=Observers
         user_team_name=_"Observers"
-        ai_formula=idle_ai
+        [ai]
+            ai_algorithm=idle_ai
+        [/ai]
         [unit]
             id=moderator
             type=Duelist

--- a/scenarios8/09_Gladiatrix-The_Path_to_Glory.cfg
+++ b/scenarios8/09_Gladiatrix-The_Path_to_Glory.cfg
@@ -110,7 +110,9 @@
         team_name=Observers
         user_team_name=_"Observers"
         village_gold=0
-        ai_formula=idle_ai
+        [ai]
+            ai_algorithm=idle_ai
+        [/ai]
         [modifications]
             [object]
                 [effect]

--- a/scenarios8/13_River_of_Flame.cfg
+++ b/scenarios8/13_River_of_Flame.cfg
@@ -85,7 +85,9 @@
     [side]
         no_leader=yes
         side=6
-        ai_formula=idle_ai
+        [ai]
+            ai_algorithm=idle_ai
+        [/ai]
         team_name=trolls
         user_team_name=_"Trolls"
         {GUARDIAN_UNIT 6 "Troll" 45 38}


### PR DESCRIPTION
Because ai_formula= no longer works, AI tried to calculate moves for
the "Observers" side in the Gladiators arena.

Replaced with [ai]ai_algorithm=idle_ai[/ai]