### PR TITLE
Use icons of anti-ice/fire/arcane armor for "Resist [...]" upgrades

### DIFF
--- a/lua/redeem.lua
+++ b/lua/redeem.lua
@@ -87,17 +87,17 @@ known_ability_trees.redeem = {
 		requires = { "magic" }
 	},
 	resist_fire = {
-		image = "items/armour-fire.png",
+		image = "attacks/blank-attack.png~BLIT(items/armour-fire.png,-5,-5)",
 		label =_ "Resist fire",
 		requires = { "fireblast" }
 	},
 	resist_cold = {
-		image = "items/armour-ice.png",
+		image = "attacks/blank-attack.png~BLIT(items/armour-ice.png,-5,-5)",
 		label =_ "Resist cold",
 		requires = { "arcticblast" }
 	},
 	resist_arcane = {
-		image = "items/armour-arcane.png",
+		image = "attacks/blank-attack.png~BLIT(items/armour-arcane.png,-5,-5)",
 		label =_ "Resist arcane",
 		requires = { "magic" }
 	},
@@ -232,17 +232,17 @@ known_ability_trees.soul_eater = {
 		requires = { "shadowwave" }
 	},
 	resist_fire = {
-		image = "items/armour-fire.png",
+		image = "attacks/blank-attack.png~BLIT(items/armour-fire.png,-5,-5)",
 		label =_ "Resist fire",
 		requires = { "fireball" }
 	},
 	resist_cold = {
-		image = "items/armour-ice.png",
+		image = "attacks/blank-attack.png~BLIT(items/armour-ice.png,-5,-5)",
 		label =_ "Resist cold",
 		requires = { "chill" }
 	},
 	resist_arcane = {
-		image = "items/armour-arcane.png",
+		image = "attacks/blank-attack.png~BLIT(items/armour-arcane.png,-5,-5)",
 		label =_ "Resist arcane",
 		requires = { "shadowwave", "chill" }
 	},

--- a/lua/redeem.lua
+++ b/lua/redeem.lua
@@ -87,17 +87,17 @@ known_ability_trees.redeem = {
 		requires = { "magic" }
 	},
 	resist_fire = {
-		image = "icons/armor_leather.png",
+		image = "items/armour-fire.png",
 		label =_ "Resist fire",
 		requires = { "fireblast" }
 	},
 	resist_cold = {
-		image = "icons/armor_leather.png",
+		image = "items/armour-ice.png",
 		label =_ "Resist cold",
 		requires = { "arcticblast" }
 	},
 	resist_arcane = {
-		image = "icons/armor_leather.png",
+		image = "items/armour-arcane.png",
 		label =_ "Resist arcane",
 		requires = { "magic" }
 	},
@@ -232,17 +232,17 @@ known_ability_trees.soul_eater = {
 		requires = { "shadowwave" }
 	},
 	resist_fire = {
-		image = "icons/armor_leather.png",
+		image = "items/armour-fire.png",
 		label =_ "Resist fire",
 		requires = { "fireball" }
 	},
 	resist_cold = {
-		image = "icons/armor_leather.png",
+		image = "items/armour-ice.png",
 		label =_ "Resist cold",
 		requires = { "chill" }
 	},
 	resist_arcane = {
-		image = "icons/armor_leather.png",
+		image = "items/armour-arcane.png",
 		label =_ "Resist arcane",
 		requires = { "shadowwave", "chill" }
 	},

--- a/utils/amla.cfg
+++ b/utils/amla.cfg
@@ -6092,7 +6092,7 @@ Adjacent own units will do 25% more damage and will have 20% better resistances.
         id=resist_cold1
         max_times=2
         description= _ "better protected from cold (5% better resistances)"
-        image=items/armour-ice.png
+        image=attacks/blank-attack.png~BLIT(items/armour-ice.png,-5,-5)
         strict_amla=yes
         require_amla="resist_cold"
         [effect]
@@ -6108,7 +6108,7 @@ Adjacent own units will do 25% more damage and will have 20% better resistances.
         id=resist_fire1
         max_times=4
         description= _ "better protected from fire (5% better resistances)"
-        image=items/armour-fire.png
+        image=attacks/blank-attack.png~BLIT(items/armour-fire.png,-5,-5)
         strict_amla=yes
         require_amla="resist_fire"
         [effect]
@@ -6123,7 +6123,7 @@ Adjacent own units will do 25% more damage and will have 20% better resistances.
     [advancement]
         id=resist_arcane1
         max_times=4
-        description= _ "better protected from arcane damage (5% better resistances)"
+        description= _ "attacks/blank-attack.png~BLIT(items/armour-arcane.png,-5,-5)"
         image=items/armour-arcane.png
         strict_amla=yes
         require_amla="resist_arcane"

--- a/utils/amla.cfg
+++ b/utils/amla.cfg
@@ -6092,7 +6092,7 @@ Adjacent own units will do 25% more damage and will have 20% better resistances.
         id=resist_cold1
         max_times=2
         description= _ "better protected from cold (5% better resistances)"
-        image=icons/armor_leather.png
+        image=items/armour-ice.png
         strict_amla=yes
         require_amla="resist_cold"
         [effect]
@@ -6108,7 +6108,7 @@ Adjacent own units will do 25% more damage and will have 20% better resistances.
         id=resist_fire1
         max_times=4
         description= _ "better protected from fire (5% better resistances)"
-        image=icons/armor_leather.png
+        image=items/armour-fire.png
         strict_amla=yes
         require_amla="resist_fire"
         [effect]
@@ -6124,7 +6124,7 @@ Adjacent own units will do 25% more damage and will have 20% better resistances.
         id=resist_arcane1
         max_times=4
         description= _ "better protected from arcane damage (5% better resistances)"
-        image=icons/armor_leather.png
+        image=items/armour-arcane.png
         strict_amla=yes
         require_amla="resist_arcane"
         [effect]


### PR DESCRIPTION
Previously all "Resist [...]" upgrades used the same icon (generic
"leather armor" icon), which didn't look good in redeem menus.

There aren't any distinct anti-pierce/impact/blade armor images,
so their "Resist [...]" upgrades weren't changed (yet).
