### PR TITLE
Reimplement DISABLE_UPKEEP: temporary unit.upkeep=loyal on placed units

### DIFF
--- a/utils/utils.cfg
+++ b/utils/utils.cfg
@@ -1046,41 +1046,55 @@ return leader_ai
         {CLEAR_VARIABLE side_{SIDE}_original_user_team_name,side_{SIDE}_original_team_name,NEUTRAL_SIDE_i,NEUTRAL_SIDE_side_store}
     [/event]
 #enddef
+
 #define DISABLE_UPKEEP SIDE
     [event]
-        name=side turn
+        name=unit placed
         first_time_only=no
-        [if]
+        [filter]
+            side={SIDE}
+        [/filter]
+        [filter_condition]
             [variable]
-                name=side_number
-                equals={SIDE}
+                name=unit.upkeep
+                not_equals=loyal
             [/variable]
-            [then]
-                [store_gold]
-                    side={SIDE}
-                    variable=upkeep_mitigation_gold_container_{SIDE}
-                [/store_gold]
-            [/then]
-        [/if]
+        [/filter_condition]
+        [modify_unit]
+            [filter]
+                find_in=unit
+            [/filter]
+            [variables]
+                original_upkeep=$this_unit.upkeep
+            [/variables]
+            upkeep=loyal
+        [/modify_unit]
     [/event]
     [event]
-        name=turn refresh
-        first_time_only=no
-        [if]
-            [variable]
-                name=side_number
-                equals={SIDE}
-            [/variable]
-            [then]
-                [modify_side]
-                    side={SIDE}
-                    gold=$upkeep_mitigation_gold_container_{SIDE}
-                [/modify_side]
-                [clear_variable]
-                    name=upkeep_mitigation_gold_container_{SIDE}
-                [/clear_variable]
-            [/then]
-        [/if]
+        name=victory
+        [modify_unit]
+            [filter]
+                side={SIDE}
+            [/filter]
+            [filter_condition]
+                [variable]
+                    name=$this_unit.variables.original_upkeep
+                    not_equals=
+                [/variable]
+            [/filter_condition]
+            upkeep=$this_unit.variables.original_upkeep
+            [variables]
+                original_upkeep=
+            [/variables]
+        [/modify_unit]
+    [/event]
+    [event]
+        name=prestart
+        [modify_side]
+            side={SIDE}
+            village_gold=0
+            income=-2
+        [/modify_side]
     [/event]
 #enddef
 


### PR DESCRIPTION
Here is the approach:
1) units with loyal trait are unaffected,
2) every non-loyal unit that appears on the battlefield (regardless of
how it appeared there - [unit], recruit, recall, debug, whatever else)
is marked as upkeep=loyal.
Note: this is invisible (not shown on the unit, unlike "loyal" trait).
3) just in case some unit had some tricky upkeep value (e.g. upkeep=7),
we save the original unit.upkeep into unit.variables.original_upkeep.
4) in the "victory" event, (2) is undone, original upkeeps are restored
and unit.variables.original_upkeep is cleared.

This resolves #8 and #11.