### PR TITLE
"Can equip" check: prevent "crossbow" attack from being treated as bow

### DIFF
--- a/lua.lua
+++ b/lua.lua
@@ -841,14 +841,14 @@ function loti_util_list_equippable_sorts(unit_type)
 		elseif attack:match("axe$") or attack == "berserker frenzy"
 			then can_equip.axe = 1
 
-		elseif attack:match("bow$")
-			then can_equip.bow = 1
-
 		elseif attack:match("staff$")
 			then can_equip.staff = 1
 
 		elseif attack == "crossbow" or attack == "slurbow"
 			then can_equip.xbow = 1
+
+		elseif attack:match("bow$")
+			then can_equip.bow = 1
 
 		elseif attack == "dagger"
 			then can_equip.dagger = 1


### PR DESCRIPTION
Since "crossbow" matches the "bow$" regex, this regex should be checked
later than comparing to "crossbow" string.