### PR TITLE
(travis) Run wmllint tool from Wesnoth core after every commit via Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+dist: trusty
+language: python
+
+git:
+  depth: 1
+
+notifications:
+  email: false
+
+python:
+  - 3.6
+
+before_script:
+  # Copy the addon elsewhere, so that wmllint can check it without all the other Wesnoth sources
+  # (they will also be in the root directory).
+  - rsync --exclude .git -a . Legend_of_the_Invincibles
+
+  # Download Wesnoth core (contains WML linter utility and its dependencies).
+  - git clone --depth 1 https://github.com/wesnoth/wesnoth
+
+  # Apply pull request #3785 - required bugfix for wmllint.
+  # Remove this line after https://github.com/wesnoth/wesnoth/pull/3785 gets merged.
+  - ( cd wesnoth && git fetch origin pull/3785/head:bugfix && git merge bugfix )
+
+script:
+  - python wesnoth/data/tools/wmllint -vv -d -K Legend_of_the_Invincibles


### PR DESCRIPTION
This automatically generates reports like https://travis-ci.org/edwardspec/Legend_of_the_Invincibles/builds/468652178 after each commit or pull request.
All LotI sources (maps, WML, lua) are analyzed by wmllint utility, which is a part of Wesnoth.

wmllint spots typos, deprecated syntax, etc. For example, here is the typo of #152:
`"Legend_of_the_Invincibles/scenarios5/23_Akulas_Place.cfg", line 1072: unknown 'akulas_siter' referred to by id`

Note: to tell Travis that it should react to new commits, you need to turn the "On-Off" switch for this repository on https://travis-ci.org/account/repositories
