### PR TITLE
Use [update_stats] in Gladiators without storing unit to a variable

### DIFF
--- a/multiplayer/Gladiators.cfg
+++ b/multiplayer/Gladiators.cfg
@@ -762,14 +762,10 @@ The difficulty is adjustable, for 1-5 players, so you can balance it yourself. U
                             name=$leader.name
                             gender=$gender_picked
                             canrecruit=yes
-                            to_variable=advanced2
                         [/unit]
-                        [fire_event]
-                            name=update_stats
-                            [primary_unit]
-                                id=$advanced2.id
-                            [/primary_unit]
-                        [/fire_event]
+                        [update_stats]
+                            x,y=$leader.x,$leader.y
+                        [/update_stats]
                     [/then]
                     [else]
                         [unit]
@@ -779,14 +775,10 @@ The difficulty is adjustable, for 1-5 players, so you can balance it yourself. U
                             x,y=$leader.x,$leader.y
                             name=$leader.name
                             canrecruit=yes
-                            to_variable=advanced2
                         [/unit]
-                        [fire_event]
-                            name=update_stats
-                            [primary_unit]
-                                id=$advanced2.id
-                            [/primary_unit]
-                        [/fire_event]
+                        [update_stats]
+                            x,y=$leader.x,$leader.y
+                        [/update_stats]
                     [/else]
                 [/if]
                 {CLEAR_VARIABLE type_picked}


### PR DESCRIPTION
With to_variable= in [unit], the unit never gets placed onto the map.