### PR TITLE
Rename non-unique attack names in update_stats(), e.g. "bow" -> "bow2"

### DIFF
--- a/lua/main.lua
+++ b/lua/main.lua
@@ -830,6 +830,9 @@ function loti_util_list_equippable_sorts(unit_type)
 
 	-- Analyze the list of attacks. Allow weapons that are logical for this unit.
 	for attack in pairs(loti_util_list_attacks(unit_type)) do
+		-- Remove trailing numbers, e.g. bow2 -> bow.
+		attack = attack:gsub('%d+$', '')
+
 		if attack:match("sword$") or attack == "saber"
 			or attack == "war talon" or attack == "war blade"
 			or attack == "mberserk" or attack == "whirlwind"
@@ -984,20 +987,11 @@ end
 -- where attack names are untranslated (always English) and can therefore be used in conditionals.
 --
 function loti_util_list_attacks(unit_type)
-	-- We don't use unit.attacks, because it has a problem with unit.attacks[1].name field
-	-- being already translated (possibly not English), which prevents comparison operations.
-	-- Instead we scan the variable representation of Unit for "attack" fields.
-	local temp_variable = "loti_util_temporary_unit";
-
-	wesnoth.wml_actions.unit { type = unit_type, to_variable = temp_variable}
-	local data = wesnoth.get_variable(temp_variable)
-	wesnoth.set_variable(temp_variable, nil)
-
+	local temp_unit = wesnoth.create_unit { type = unit_type }
 	local has_attack = {}
-	for idx, tag in pairs(data) do
-		if type(tag) == "table" and tag[1] == "attack" then
-			has_attack[tag[2].name] = true
-		end
+
+	for _, attack in ipairs(temp_unit.attacks) do
+		has_attack[attack.name] = true
 	end
 
 	return has_attack

--- a/lua/main.lua
+++ b/lua/main.lua
@@ -830,9 +830,6 @@ function loti_util_list_equippable_sorts(unit_type)
 
 	-- Analyze the list of attacks. Allow weapons that are logical for this unit.
 	for attack in pairs(loti_util_list_attacks(unit_type)) do
-		-- Remove trailing numbers, e.g. bow2 -> bow.
-		attack = attack:gsub('%d+$', '')
-
 		if attack:match("sword$") or attack == "saber"
 			or attack == "war talon" or attack == "war blade"
 			or attack == "mberserk" or attack == "whirlwind"
@@ -981,7 +978,7 @@ function wesnoth.wml_actions.can_equip_item(cfg)
 end
 
 --
--- Utility function for [can_equip_item] (can also be used in get_unit_flavour()).
+-- Utility function for [can_equip_item] and get_unit_flavour().
 -- List the names of all attacks (e.g. "chill tempest") of a certain unit.
 -- Returns the Lua table { attack_name = 1, another_attack_name = 1, ... },
 -- where attack names are untranslated (always English) and can therefore be used in conditionals.
@@ -991,7 +988,9 @@ function loti_util_list_attacks(unit_type)
 	local has_attack = {}
 
 	for _, attack in ipairs(temp_unit.attacks) do
-		has_attack[attack.name] = true
+		-- Remove trailing numbers, e.g. bow2 -> bow.
+		local name = attack.name:gsub('%d+$', '')
+		has_attack[name] = true
 	end
 
 	return has_attack

--- a/lua/stats.lua
+++ b/lua/stats.lua
@@ -29,26 +29,22 @@ end
 -- Rename duplicate attacks within the [unit] WML table,
 -- adding numbers 2, 3, etc. to them to make them unique.
 local function make_attacks_unique(unit)
-	-- This array records the attack names that were already used,
-	-- along with the number of repetitions.
-	-- E.g. { "chill tempest" => 1, "bow" => 2 }.
+	-- This array records the attack names that were already used.
+	-- E.g. { "chill tempest" => 1, "bow" => 1 }.
 	local attack_seen = {}
 
 	-- Find all attacks of this unit.
 	for _, data in ipairs(unit) do
 		if data[1] == "attack" then
 			local name = data[2].name
-			if attack_seen[name] then
-				-- Duplicate found. Rename this attack, e.g. "bow" -> "bow2".
-				local repetition = attack_seen[name] + 1
-				data[2].name = name .. repetition
-
-				-- Next "bow" attacks will be called "bow3", "bow4", etc.
-				attack_seen[name] = repetition
-			else
-				-- Unique attack name (so far).
-				attack_seen[name] = 1
+			while attack_seen[name] do
+				-- Duplicate found. Rename this attack, e.g. "bow",
+				-- to "bowN", where N is a random number between 2 and 999.
+				name = data[2].name .. wesnoth.random(2, 999)
 			end
+
+			data[2].name = name
+			attack_seen[name] = 1
 		end
 	end
 end

--- a/lua/titles.lua
+++ b/lua/titles.lua
@@ -24,17 +24,7 @@ function get_unit_flavour(u)
 	local data = wesnoth.get_variable("lua_unit_to_get_flavour")
 	wesnoth.set_variable("lua_unit_to_get_flavour", nil)
 
-	local function has_attack(attack_name)
-		local has = false
-		for i = 1,#data do
-			if data[i][1] == "attack" then
-				if data[i][2].name == attack_name then
-					has = true
-				end
-			end
-		end
-		return has
-	end
+	local has_attack = loti_util_list_attacks(u.type)
 
 	local function has_special(special_name)
 		local has = false
@@ -128,7 +118,7 @@ function get_unit_flavour(u)
 			end
 		end
 		-- Act accordingly to the reason why it's chaotic, the unliving need more dark
-		if not_living > 1 or has_attack("chill wave") or has_attack("shadow wave") or has_attack("curse") or has_special("plague") then
+		if not_living > 1 or has_attack["chill wave"] or has_attack["shadow wave"] or has_attack["curse"] or has_special("plague") then
 			flavour.dark = flavour.dark + 10
 		else
 			flavour.dark = flavour.dark + 3


### PR DESCRIPTION
Also loti_util_list_attacks() has been simplified, because attack.name is now usable (non-translatable) since the rewrite of stats.cfg.