### PR TITLE
_main.cfg: replace deprecated syntax (in the list of difficulties)

### DIFF
--- a/_main.cfg
+++ b/_main.cfg
@@ -89,8 +89,22 @@
 
     abbrev= _ "LotI1"
     rank=812
-    difficulties=EASY,NORMAL,HARD
-    difficulty_descriptions= _ "&data/core/images/units/human-loyalists/fencer.png~RC(magenta>red)=Easy;*&data/core/images/units/human-loyalists/duelist.png~RC(magenta>red)=Medium;&data/core/images/units/human-loyalists/master-at-arms.png~RC(magenta>red)=Hard"
+    [difficulty]
+        define=EASY
+        image=units/human-loyalists/fencer.png~RC(magenta>red)
+        label=_"Easy"
+    [/difficulty]
+    [difficulty]
+        define=NORMAL
+        image=units/human-loyalists/duelist.png~RC(magenta>red)
+        label=_"Medium"
+        default=yes
+    [/difficulty]
+    [difficulty]
+        define=HARD
+        image=units/human-loyalists/master-at-arms.png~RC(magenta>red)
+        label=_"Hard"
+    [/difficulty]
     description= _ "Sometimes, people don't embrace the tempting powers of darkness because of desires to rule, but merely for survival. Can the dark powers be used to fight against dark schemes with no limits or will they eventually corrupt its users?
 
 (Intermediate level, 90 scenarios separated to five chapters)
@@ -111,8 +125,22 @@ Go to BFW main window > Campaign > Legend of the Invincibles, Part II: Into the 
     first_scenario="01_The_Awakening"
     abbrev= _ "LotI2"
     rank=816
-    difficulties=EASY,NORMAL,HARD
-    difficulty_descriptions= _ "&data/core/images/items/bones.png=Easy;*&data/core/images/items/burial.png=Medium;&data/core/images/items/bonestack.png=Hard"
+    [difficulty]
+        define=EASY
+        image=items/bones.png
+        label=_"Easy"
+    [/difficulty]
+    [difficulty]
+        define=NORMAL
+        image=items/burial.png
+        label=_"Medium"
+        default=yes
+    [/difficulty]
+    [difficulty]
+        define=HARD
+        image=items/bonestack.png
+        label=_"Hard"
+    [/difficulty]
     description= _ "Continuation of the previous part millennia later, when the consequences of past deeds transform the world into a much worse place. Will the old darkness-filled heroes attempt to clean it or just accept it and exploit it?
 
 (Intermediate level, 110 scenarios separated to five chapters)


### PR DESCRIPTION
This fixes the following warnings on Wesnoth startup:

error deprecation: [campaign]difficulties has been deprecated and will be removed in version 1.15.0. Use [difficulty] instead.
error deprecation: [campaign]difficulty_descriptions has been deprecated and will be removed in version 1.15.0. Use [difficulty] instead.