### PR TITLE
AI workaround - let Abaddon attack

### DIFF
--- a/scenarios8/16_Gates_of_Hell.cfg
+++ b/scenarios8/16_Gates_of_Hell.cfg
@@ -93,7 +93,7 @@
         {AI_OVERHAUL_PLACE_2 4}
     [/side]
     [side]
-        type=Abaddon
+        no_leader=yes
         name= _ "Abaddon"
         side=5
         village_gold=0
@@ -103,6 +103,10 @@
         user_team_name=_"Evil"
         {AI_OVERHAUL_PLACE 5}
         {AI_OVERHAUL_PLACE_2 5}
+        [unit]
+            type=Abaddon
+            x,y=14,50
+        [/unit]
         [ai]
             aggression=1.0
             [avoid]


### PR DESCRIPTION
Because of AI bugs, making Abaddon a leader means he almost never attacks anything. So make him a normal guy and let him stomp the player.