### PR TITLE
Make cataclysmal Demon Lords use their firestorm

### DIFF
--- a/units/demons_race.cfg
+++ b/units/demons_race.cfg
@@ -552,8 +552,8 @@ shrine=Shrine|Temple|Cathedral|Dome|Cradle
                 [/dummy]
             [/specials]
             range=ranged
-            {QUANTITY damage 120 140 160}
-            number=1
+            {QUANTITY damage 70 90 110}
+            number=2
             icon=attacks/firestorm.png
             defense_weight=0
         [/effect]


### PR DESCRIPTION
The AI picks the highest damage, and doesn't know about the storm special. Normal fireball damage is 123, 156, 195, which is higher than firestorm. That means it always picks normal fireball and never picks firestorm. Upgrade firestorm damage so it will get used.