### PR TITLE
clear unit_list variable

### DIFF
--- a/utils/chapter9_utils.cfg
+++ b/utils/chapter9_utils.cfg
@@ -2286,6 +2286,7 @@
                                             [/value]
                                         [/set_variables]
                                     {NEXT i}
+                                    {CLEAR_VARIABLE unit_list}
                                     [insert_tag]
                                         name=message
                                         variable=add_message


### PR DESCRIPTION
This variable is huge and isn't needed, so clear it.