### PR TITLE
Fixed damage calculation in bonus attacks.

### DIFF
--- a/lua/stats.lua
+++ b/lua/stats.lua
@@ -456,7 +456,7 @@ function wesnoth.update_stats(original)
 						end
 					end
 					if (not eff.range or eff.range == atk.range) and not atk.is_bonus_attack then
-						local damage = atk.damage * atk.number
+						local damage = math.floor(atk.damage) * math.floor(atk.number)
 						if eff.force_original_type and eff.force_original_type == atk.type then
 							damage = damage * 1000000
 						end


### PR DESCRIPTION
Wesnoth uses integer values for damage and attacks, while lua uses floats. So Guide to Lycanthropy was choosing a 18-5 (damage = 90) attack over a 16-6 (damage = 96) attack, because it was actually seeing 16.85-6 (damage = 101.1) and 18.5-5.75 (damage = 106.375).