### PR TITLE
Fix to allies

### DIFF
--- a/scenarios7/02_Search_for_Elves.cfg
+++ b/scenarios7/02_Search_for_Elves.cfg
@@ -125,7 +125,7 @@
         village_support=1000
         shroud=yes
         random_traits=yes
-        team_name=good
+        team_name=Good
         unrenamable=yes
         user_team_name=_"Good"
     [/side]
@@ -230,6 +230,9 @@
         {GENERIC_UNIT 7 "Elvish Gryphon Rider" 46 1}
         {GENERIC_UNIT 7 "Elvish Ranger" 49 3}
         {GENERIC_UNIT 7 "Elvish Sorceress" 45 8}
+        [ai]
+            ai_algorithm=idle_ai
+        [/ai]
     [/side]
 
     [event]


### PR DESCRIPTION
Allies were not on same team (capitalization appears to matter).
Allies also moved, so now they are set as idle. I'm not sure why they didn't move in the past though.