### PR TITLE
Bug: Greater Healing potion should restore attacks

### DIFF
--- a/utils/item_list.cfg
+++ b/utils/item_list.cfg
@@ -1951,7 +1951,7 @@ The bloodline of true warriors"
         [on_equip]
             {VARIABLE armed.hitpoints $armed.max_hitpoints}
             {VARIABLE armed.moves $armed.max_moves}
-            {VARIABLE armed.attacks $armed.max_attacks}
+            {VARIABLE armed.attacks_left $armed.max_attacks}
             {CLEAR_VARIABLE armed.status}
             {IS_A_HEALING_POTION}
         [/on_equip]


### PR DESCRIPTION
The greater healing potion claims to restore attacks, but currently doesn't. Fix it.