### PR TITLE
UI improvement for Investigations in ch8

### DIFF
--- a/scenarios8/05_Investigations.cfg
+++ b/scenarios8/05_Investigations.cfg
@@ -1,4 +1,16 @@
 #textdomain wesnoth-loti
+
+#define NEXT_GOAL NEXT_X NEXT_Y LABEL CUR_X CUR_Y
+    {REMOVE_IMAGE {CUR_X} {CUR_Y}}
+    [label]
+        x,y={NEXT_X},{NEXT_Y}
+        text={LABEL}
+        visible_in_shroud=yes
+    [/label]
+    {HIGHLIGHT_IMAGE {NEXT_X} {NEXT_Y} items/gohere.png ()}
+    {SCROLL_TO {CUR_X} {CUR_Y}}
+#enddef
+
 [scenario]
     id="05_Investigations"
     name= _ "Investigations"
@@ -188,11 +200,7 @@
             caption= _ "Sleepy man"
             message= _ "Thortoron. Got himself the best abode in town, that sleeveen, directly on the marketplace. Now let me doss down again."
         [/message]
-        [label]
-            x,y=22,19
-            text= _ "Thortoron's house"
-            visible_in_shroud=yes
-        [/label]
+        {NEXT_GOAL 22 19 (Thortoron's house) 49 7}
     [/event]
 
     [event]
@@ -292,11 +300,7 @@
                 id=Efraim
             [/primary_unit]
         [/fire_event]
-        [label]
-            x,y=12,35
-            text= _ "Ferthar's manor"
-            visible_in_shroud=yes
-        [/label]
+        {NEXT_GOAL 12 35 (Ferthar's manor) 22 19}
         [show_objectives]
             side=1
         [/show_objectives]
@@ -397,11 +401,7 @@
                     id=Efraim
                 [/primary_unit]
             [/fire_event]
-            [label]
-                x,y=43,18
-                text= _ "Urdrea's residence"
-                visible_in_shroud=yes
-            [/label]
+            {NEXT_GOAL 43 18 (Urdrea's residence) 12 35}
             [show_objectives]
                 side=1
             [/show_objectives]
@@ -436,11 +436,7 @@
                     speaker=Efraim
                     message= _ "Thank you, have fun."
                 [/message]
-                [label]
-                    x,y=22,22
-                    text= _ "Hergor's residence"
-                    visible_in_shroud=yes
-                [/label]
+                {NEXT_GOAL 22 22 (Hergor's residence) 43 18}
             [/event]
             [event]
                 name=moveto
@@ -560,11 +556,7 @@
                         id=Efraim
                     [/primary_unit]
                 [/fire_event]
-                [label]
-                    x,y=14,10
-                    text= _ "Trading Company"
-                    visible_in_shroud=yes
-                [/label]
+                {NEXT_GOAL 14 10 (Trading Company) 22 22}
                 [show_objectives]
                     side=1
                 [/show_objectives]


### PR DESCRIPTION
I've never liked the way labels appeared in this scenario. They often appear offscreen, so the first time player doesn't even realize that a label's been placed. Even if they do, tracking it down is tedious. With this change, the screen is temporarily scrolled to the goal location and a marker is placed, so the player knows where to go.

I could fold the objectives updates into this too, but I figured I'd see what you thought before I did any more work.