### PR TITLE
More selective about giving titles to units.

### DIFF
--- a/scenarios3/11_Achilles_Revenge.cfg
+++ b/scenarios3/11_Achilles_Revenge.cfg
@@ -85,6 +85,7 @@
             id=Niflheim
             name="Niflheim"
             random_traits=yes
+            unrenamable=yes
             x=90
             y=16
         [/unit]

--- a/scenarios3/12s_Wings_of_Doom.cfg
+++ b/scenarios3/12s_Wings_of_Doom.cfg
@@ -43,6 +43,7 @@
         gold=500
         team_name=evil
         user_team_name=_"Evil"
+        unrenamable=yes
     [/side]
     [side]
         type=Dark Dragon
@@ -55,6 +56,7 @@
         gold=500
         team_name=evil
         user_team_name=_"Evil"
+        unrenamable=yes
     [/side]
     [side]
         type=Armageddon Drake

--- a/scenarios3/14_Chasing_Dragons.cfg
+++ b/scenarios3/14_Chasing_Dragons.cfg
@@ -165,6 +165,7 @@
         id=Asheviere
         random_traits=no
         recruit=Spearman,Javelineer,Pikeman,Horseman,Lancer,Mage,White Mage,Peasant,Bowman,Longbowman
+        unrenamable=yes
         side=3
         [modifications]
             {TRAIT_INTELLIGENT}
@@ -395,6 +396,7 @@
         random_traits=yes
         recruit=Fire Dragon loti
         side=5
+        unrenamable=yes
         {GOLD 1000 1200 1500}
         {INCOME 30 50 70}
         team_name=evil
@@ -417,6 +419,7 @@
         canrecruit=yes
         id=Niflheim
         name=_"Niflheim"
+        unrenamable=yes
         [modifications]
             [object]
                 [effect]

--- a/scenarios3/15_Nightmare.cfg
+++ b/scenarios3/15_Nightmare.cfg
@@ -141,6 +141,7 @@
         name="Ba'al"
         random_traits=yes
         recruit=Fire Dragon loti,Ice Dragon,Armageddon Drake
+        unrenamable=yes
         side=3
         {GOLD 600 720 840}
         {INCOME 10 20 30}

--- a/scenarios6/15_Apologies.cfg
+++ b/scenarios6/15_Apologies.cfg
@@ -130,6 +130,7 @@
                     id=Lethalia_fake
                     name= _ "Lethalia"
                     random_traits=yes
+                    unrenamable=yes
                     [advancement]
                         id=blablabla
                         [effect]
@@ -256,6 +257,7 @@
                     id=Efraim_fake
                     name= _ "Efraim"
                     random_traits=yes
+                    unrenamable=yes
                     [advancement]
                         id=blablabla
                         [effect]

--- a/scenarios7/10_The_Dragon_and_the_Princess.cfg
+++ b/scenarios7/10_The_Dragon_and_the_Princess.cfg
@@ -65,6 +65,7 @@
         side=3
         team_name=Corruption
         user_team_name=_"Corruption"
+        unrenamable=yes
         {AI_OVERHAUL_PLACE 3}
         {AI_OVERHAUL_PLACE_2 3}
         [modifications]
@@ -200,6 +201,7 @@
             name=Niflheim
             x,y=$dev_null.x,$dev_null.y
             canrecruit=yes
+            unrenamable=yes
             side=3
         [/unit]
         {CLEAR_VARIABLE dev_null}
@@ -231,6 +233,7 @@
             canrecruit=yes
             side=4
             level=15
+            unrenamable=yes
             [modifications]
                 [object]
                     [effect]

--- a/scenarios7/11_An_Old_Friend.cfg
+++ b/scenarios7/11_An_Old_Friend.cfg
@@ -39,6 +39,7 @@
         canrecruit=yes
         random_traits=yes
         name= _ "Argan"
+        unrenamable=yes
         id=Argan
         side=2
         village_gold=2

--- a/scenarios7/12_The_Last_Enemy.cfg
+++ b/scenarios7/12_The_Last_Enemy.cfg
@@ -72,6 +72,7 @@
             type=Lethalia_evil
             id=Lethalia_evil
             name=Lethalia
+            unrenamable=yes
             x,y=17,9
         [/unit]
     [/side]
@@ -503,6 +504,7 @@
                     type=Lethalia_evil
                     side=2
                     name=Lethalia
+                    unrenamable=yes
                     x,y=$Lethstore.x,$Lethstore.y
                     hitpoints=$Lethstore.hitpoints
                     experience=$Lethstore.experience

--- a/scenarios7/14_Arctic_Wastelands.cfg
+++ b/scenarios7/14_Arctic_Wastelands.cfg
@@ -921,6 +921,7 @@ You can build a keep anywhere for 50 gold, or a village for 10 gold. (see option
                     type=Lethalia_evil
                     side=11
                     name=Lethalia
+                    unrenamable=yes
                     x,y=$spawn_x,$spawn_y
                     [modifications]
                         [object]

--- a/scenarios7/15_Annihilation.cfg
+++ b/scenarios7/15_Annihilation.cfg
@@ -233,6 +233,7 @@
             side=2
             id=Lethalia_evil
             name=Lethalia
+            unrenamable=yes
             [modifications]
                 [object]
                     [effect]

--- a/scenarios8/06_Gladiatrix.cfg
+++ b/scenarios8/06_Gladiatrix.cfg
@@ -57,6 +57,7 @@
     [side]
         id=emperor
         name=_"Emperor Abbath I"
+        unrenamable=yes
         type=Demon Infiltrator Prophet
         random_traits=yes
         side=3

--- a/scenarios8/09_Gladiatrix-The_Path_to_Glory.cfg
+++ b/scenarios8/09_Gladiatrix-The_Path_to_Glory.cfg
@@ -80,6 +80,7 @@
     [side]
         id=emperor
         name=Emperor Abbath I
+        unrenamable=yes
         type=Demon Infiltrator Prophet
         random_traits=yes
         side=3

--- a/scenarios8/12_Gladiatrix-The_Reckoning.cfg
+++ b/scenarios8/12_Gladiatrix-The_Reckoning.cfg
@@ -499,6 +499,7 @@
         [unit]
             type=Demon Infiltrator Prophet
             name= _ "Emperor Abbath I"
+            unrenamable=yes
             id=emperor
             x,y=31,6
             side=9

--- a/scenarios8/16_Gates_of_Hell.cfg
+++ b/scenarios8/16_Gates_of_Hell.cfg
@@ -94,7 +94,6 @@
     [/side]
     [side]
         no_leader=yes
-        name= _ "Abaddon"
         side=5
         village_gold=0
         gold=0
@@ -105,6 +104,8 @@
         {AI_OVERHAUL_PLACE_2 5}
         [unit]
             type=Abaddon
+            name= _ "Abaddon"
+            unrenamable=yes
             x,y=14,50
         [/unit]
         [ai]


### PR DESCRIPTION
Fixes https://github.com/Dugy/Legend_of_the_Invincibles/issues/233.

The gist of this is to remove titles from units without advancements. That covers everything in the linked issue, plus merchants, flies, spell eaters, etc, etc. I'm open to changing the logic, but I think that's pretty close to how it should be. The only exception I'd make is to give titles to the officers of spawned parties, e.g. infiltrated celestial messengers in Jungle Hell and corrupted elvish juggernauts in Arctic Wasteland. I think the best way to do that is to give them hero icons.

I made sure that unadvanceable nameless units still get names without the titles.

There seems to be a mix of tab and space indentation in this file. I'm a tab man, so I used tabs for this.