### PR TITLE
Extra damage from high-level hybrids of steel is user-visible.

### DIFF
--- a/units/Akula_steel.cfg
+++ b/units/Akula_steel.cfg
@@ -84,6 +84,7 @@
     #      [/portrait]
     {TRAIT_MECHANICAL}
     [abilities]
+        {ABILITY_TENTACLES}
         {ABILITY_REGENERATES}
     [/abilities]
     [attack]
@@ -353,44 +354,4 @@
         [/effect]
         {AMLA_DEFAULT_BONUSES}
     [/advancement]
-    [event]
-        name=attacker hits,attacker misses
-        first_time_only=no
-        [filter_attack]
-            range=melee
-        [/filter_attack]
-        [filter_second]
-            type=Akula_steel
-        [/filter_second]
-        [harm_unit]
-            [filter]
-                x,y=$x1,$y1
-            [/filter]
-            amount=10
-            type=pierce
-            fire_event=yes
-            experience=no
-            animate=no
-        [/harm_unit]
-    [/event]
-    [event]
-        name=defender hits,defender misses
-        first_time_only=no
-        [filter]
-            type=Akula_steel
-        [/filter]
-        [filter_attack]
-            range=melee
-        [/filter_attack]
-        [harm_unit]
-            [filter]
-                x,y=$x2,$y2
-            [/filter]
-            amount=10
-            type=pierce
-            fire_event=yes
-            experience=no
-            animate=no
-        [/harm_unit]
-    [/event]
 [/unit_type]

--- a/units/hybrids_of_steel.cfg
+++ b/units/hybrids_of_steel.cfg
@@ -209,6 +209,7 @@
     {DEFENSE_ANIM_RANGE "units/human-loyalists/royalguard-defend-2.png" "units/human-loyalists/royalguard-defend-1.png" {SOUND_LIST:HUMAN_HIT} ranged}
     {DEFENSE_ANIM_RANGE "units/enemies/royalguard+tentacles-defend-2.png" "units/enemies/royalguard+tentacles-defend-1.png" {SOUND_LIST:HUMAN_HIT} melee}
     [abilities]
+        {ABILITY_TENTACLES}
         {ABILITY_REGENERATES}
     [/abilities]
     [portrait]
@@ -524,6 +525,7 @@
     {DEFENSE_ANIM_RANGE "units/enemies/marshal+tentacles-defend-2.png" "units/enemies/marshal+tentacles-defend-1.png" {SOUND_LIST:HUMAN_HIT} melee }
     {DEFENSE_ANIM_RANGE "units/human-loyalists/marshal-crossbow-defend.png" "units/human-loyalists/marshal-crossbow.png" {SOUND_LIST:HUMAN_HIT} ranged }
     [abilities]
+        {ABILITY_TENTACLES}
         {ABILITY_REGENERATES}
         {ABILITY_LEADERSHIP_LEVEL 6}
     [/abilities]

--- a/utils/abilities.cfg
+++ b/utils/abilities.cfg
@@ -1245,6 +1245,13 @@ Enemy units cannot see this unit at night, except if they have units next to it.
         description= _ "Any unit that attacks this unit in melee suffers two points of piercing damage. Unlike reflect, it can kill."
     [/dummy]
 #enddef
+#define ABILITY_TENTACLES
+    [dummy]
+        id=tentacles
+        name= _ "tentacles"
+        description= _ "Any unit that attacks this unit in melee suffers ten points of impact damage per swing, even if it misses. This applies to retaliation attacks. This can kill."
+    [/dummy]
+#enddef
 #define ABILITY_LESSER_REDEEM
     [dummy]
         id=lesser redeem

--- a/utils/abilities_events.cfg
+++ b/utils/abilities_events.cfg
@@ -6394,6 +6394,47 @@
         [/harm_unit]
     [/event]
 
+    [event]
+        name=attacker hits,attacker misses
+        first_time_only=no
+        [filter_attack]
+            range=melee
+        [/filter_attack]
+        [filter_second]
+            ability=tentacles
+        [/filter_second]
+        [harm_unit]
+            [filter]
+                x,y=$x1,$y1
+            [/filter]
+            amount=10
+            type=impact
+            fire_event=yes
+            experience=no
+            animate=no
+        [/harm_unit]
+    [/event]
+    [event]
+        name=defender hits,defender misses
+        first_time_only=no
+        [filter]
+            ability=tentacles
+        [/filter]
+        [filter_attack]
+            range=melee
+        [/filter_attack]
+        [harm_unit]
+            [filter]
+                x,y=$x2,$y2
+            [/filter]
+            amount=10
+            type=impact
+            fire_event=yes
+            experience=no
+            animate=no
+        [/harm_unit]
+    [/event]
+
     [event]	#This was taken from wesnoth forums, author was dixie, slightly modified by Dugi to fit the interface
         name=attacker hits
         first_time_only=no

--- a/utils/chapter5_utils.cfg
+++ b/utils/chapter5_utils.cfg
@@ -1122,58 +1122,6 @@ Spells remaining: " + ${VARIABLE_NAME}
         [/set_menu_item]
     [/event]
     [event]
-        name=attacker hits,attacker misses
-        first_time_only=no
-        [filter_attack]
-            range=melee
-        [/filter_attack]
-        [filter_second]
-            type=Royal Guard_steel
-            [or]
-                type=Grand Marshal_steel
-            [/or]
-        [/filter_second]
-        [harm_unit]
-            [filter]
-                x,y=$x1,$y1
-            [/filter]
-            [filter_second]
-                x,y=$x2,$y2
-            [/filter_second]
-            amount=10
-            type=impact
-            fire_event=yes
-            experience=no
-            animate=no
-        [/harm_unit]
-    [/event]
-    [event]
-        name=defender hits,defender misses
-        first_time_only=no
-        [filter]
-            type=Royal Guard_steel
-            [or]
-                type=Grand Marshal_steel
-            [/or]
-        [/filter]
-        [filter_attack]
-            range=melee
-        [/filter_attack]
-        [harm_unit]
-            [filter]
-                x,y=$x2,$y2
-            [/filter]
-            [filter_second]
-                x,y=$x1,$y1
-            [/filter_second]
-            amount=10
-            type=impact
-            fire_event=yes
-            experience=no
-            animate=no
-        [/harm_unit]
-    [/event]
-    [event]
         name=attack end
         first_time_only=no
 


### PR DESCRIPTION
The first time I played chapter 5, when Akula revealed her true form, I attacked her with Efraim's lesser berserk. Imagine my surprise when he started taking significant damage for no discernible reason, and eventually died from it. I made this into an ability, so now the player doesn't get any nasty surprises.

Akula's extra damage was pierce before this change.