### PR TITLE
Added editorconfig.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*.{wml,pbl}]
+indent_style = space
+indent_size = 4
+
+[*.lua]
+indent_style = tab
+
+[.travis.yml]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
[EditorConfig](https://editorconfig.org) helps automatically set the right indentation settings in editors. Supported by many out of the box, and there are plugins for the rest.