### PR TITLE
Allow all three Tome of Bards Volume II amlas

### DIFF
--- a/utils/amla.cfg
+++ b/utils/amla.cfg
@@ -1320,7 +1320,7 @@
     [/advancement]
     [advancement]
         max_times=1
-        id=ToBVII2
+        id=ToBVII3
         strict_amla=yes
         description= _ "improving the damage of nearby party members by 15% (Tome of Bards, Volume II)"
         image="icons/scroll_red.png"


### PR DESCRIPTION
With Tome of Bards Volume II, two of the three AMLAs have the same id, which seems to make them mutually exclusive. I don't think that is intentional.