### PR TITLE
Fixing untranslatable names in the first chapter

### DIFF
--- a/scenarios1/05_Shatter_the_Defilers.cfg
+++ b/scenarios1/05_Shatter_the_Defilers.cfg
@@ -51,7 +51,7 @@
         [unit]
             type=Elvish Enchantress
             id=Lethalia
-            name="Lethalia"
+            name= _ "Lethalia"
             x=40
             y=4
             unrenamable=yes

--- a/scenarios1/07_The_Return.cfg
+++ b/scenarios1/07_The_Return.cfg
@@ -422,7 +422,7 @@
         [unit]
             type=Fugitive
             id=Evil_Bastard
-            name="Greor"
+            name= _ "Greor"
             x=36
             y=4
             side=2

--- a/scenarios1/08_Where_the_Sun_Does_not_Shine.cfg
+++ b/scenarios1/08_Where_the_Sun_Does_not_Shine.cfg
@@ -67,7 +67,7 @@
         [unit]
             type=Death Knight
             id=Argan
-            name="Argan"
+            name= _ "Argan"
             x=4
             y=9
             {IS_HERO}
@@ -417,7 +417,7 @@
             #The Fire Dragon unit looks beautiful on 1.9.X, but is lacking animations. I tried to create some, it is not good, but better than a moveless monster
             #crashing into its enemies for 26-2 damage and performing mental blasts for 14-4 fire damage.
             id=dragon
-            name="Hephaestus"
+            name= _ "Hephaestus"
             x=44
             y=26
             ai_special=guardian

--- a/scenarios1/09_Escape_from_Oblivion.cfg
+++ b/scenarios1/09_Escape_from_Oblivion.cfg
@@ -408,7 +408,7 @@
             type=Duelist
             random_traits=yes
             id=Connor
-            name="Connor"
+            name= _ "Connor"
             x=17
             y=17
             side=1

--- a/scenarios1/12_Toxic_Sun.cfg
+++ b/scenarios1/12_Toxic_Sun.cfg
@@ -59,7 +59,7 @@
             type=Elvish Shyde
             advances_to=Faerie Incarnation
             id=Ethiel
-            name="Ethiel"
+            name= _ "Ethiel"
             x=14
             y=5
             random_traits=yes

--- a/scenarios1/13_Twilight.cfg
+++ b/scenarios1/13_Twilight.cfg
@@ -47,7 +47,7 @@
     [side]
         type=Efraim_lich
         id=Efraim
-        name="Efraim"
+        name= _ "Efraim"
         unrenamable=yes
         side=1
         canrecruit=yes


### PR DESCRIPTION
I've found some names in chapter 1 weren't marked as translatable. It was probably missed because they didn't require the special treatment for translating into a language with the Latin script.