### PR TITLE
Efraim's name made translatable

### DIFF
--- a/scenarios1/12_Toxic_Sun.cfg
+++ b/scenarios1/12_Toxic_Sun.cfg
@@ -38,7 +38,7 @@
         gender=male
         id=Efraim
         side=1
-        name=Efraim
+        name= _ "Efraim"
         canrecruit=yes
         controller=human
         unrenamable=yes


### PR DESCRIPTION
Last time didn't notice Efraim's name in "Toxic Sun" being untranslatable