### PR TITLE
Efraim's name really made translatable

### DIFF
--- a/scenarios1/12_Toxic_Sun.cfg
+++ b/scenarios1/12_Toxic_Sun.cfg
@@ -314,7 +314,7 @@
             gender=male
             id=Efraim
             side=1
-            name=Efraim
+            name= _ "Efraim"
             canrecruit=yes
             unrenamable=yes
             x,y=16,6


### PR DESCRIPTION
Sorry for the second pull just in a few minutes, Efraim in the side tag is probably only a notion for testing, the real Efraim is created here when you play the campaign, so it's here his name must be translatable.