### PR TITLE
Fix Beelzebub message in 7_05

### DIFF
--- a/scenarios7/06_Where_the_Flames_Freeze.cfg
+++ b/scenarios7/06_Where_the_Flames_Freeze.cfg
@@ -438,7 +438,7 @@
             message= _ "The river cannot be followed here, the ceiling is too low further."
         [/message]
     [/event]
-    {BEELZEBUB_SPAWN_POINT 6 5 45 3 30-40,1-8}
+    {BEELZEBUB_SPAWN_POINT 6 5 45 3 40-50,1-8}
     {GENERIC_DEATHS}
     {DROPS 5 7 (axe,staff,staff,sword,sword,sword,knife,bow,bow,xbow,spear,spear,bow,dagger,mace) yes 3,4,5}
 [/scenario]


### PR DESCRIPTION
The obelisk is at x=45, but the message triggers between 30 and 40.