### PR TITLE
Fix eastern exit from Verminous Sewers

### DIFF
--- a/scenarios9/43_Verminous_Sewers.cfg
+++ b/scenarios9/43_Verminous_Sewers.cfg
@@ -125,25 +125,25 @@
                     [/variable]
                     [then]
                         [terrain]
-                            x=10
-                            y=38
+                            x=52
+                            y=24
                             terrain=Ur
                         [/terrain]
                         [terrain]
-                            x=11
-                            y=38
+                            x=53
+                            y=24
                             terrain=Ur
                         [/terrain]
                     [/then]
                     [else]
                         [terrain]
-                            x=6
-                            y=31
+                            x=53
+                            y=36
                             terrain=Ur
                         [/terrain]
                         [terrain]
-                            x=7
-                            y=31
+                            x=54
+                            y=36
                             terrain=Ur
                         [/terrain]
                     [/else]


### PR DESCRIPTION
I think I noticed this being odd a long time ago, but suddenly today I dug into it. The random choice to set up an exit on the east side opens terrain in the southwest instead of in the east.