### PR TITLE
Fix of Elvish Lord in multiplayer

### DIFF
--- a/utils/global_events.cfg
+++ b/utils/global_events.cfg
@@ -2722,7 +2722,7 @@ $soul_eating"
         [if]
             [variable]
                 name=updated.type
-                equals="Elvish Lord"
+                equals="Elvish High Lord"
             [/variable]
             [then]
                 {VARIABLE updated.advances_to "Elvish Overlord"}


### PR DESCRIPTION
In the current code it's 2 lvl Elvish Lord who advances straight to the 4 lvl Elvish Overlord. I guess it should be Elvish High Lord receiving such a promotion option