### PR TITLE
Fixing a typo in Lilith's fireball attack

### DIFF
--- a/units/Lilith.cfg
+++ b/units/Lilith.cfg
@@ -220,7 +220,7 @@
         type=fire
         range=ranged
         {QUANTITY damage 30 35 42}
-        numbers=3
+        number=3
         [specials]
             {WEAPON_SPECIAL_MAGICAL}
         [/specials]


### PR DESCRIPTION
Lilith had 42x0 attack because of the typo (numbers instead of number).