### PR TITLE
Fix a typo in Beelzebub

### DIFF
--- a/units/Beelzebub.cfg
+++ b/units/Beelzebub.cfg
@@ -2,7 +2,7 @@
 [unit_type]
     id=Beelzebub
     name= _ "Lord of the Flies"
-    race=demon_loti
+    race=demon-loti
     gender=male
     image="units/enemies/beelzebub-magic1.png"
     hitpoints=200


### PR DESCRIPTION
He was of a "(none)" race all the way because of this typo