### PR TITLE
Make possible unequipping items

### DIFF
--- a/lua/inventory/storage.lua
+++ b/lua/inventory/storage.lua
@@ -431,7 +431,7 @@ local function onshow(unit, item_sort)
 		-- Show/hide fields related to current item
 		wesnoth.set_dialog_visible(true, "current_item")
 		
-		if not item_sort == "limited" and not item_sort == "potion" then
+		if not (item_sort == "limited") and not (item_sort == "potion") then
 			wesnoth.set_dialog_visible(true, "unequip")
 
 			-- Note: Drop/Destroy dropdown menu near Unequip button is not yet supported in Tutorial,


### PR DESCRIPTION
The latest fix to disallow unequipping limited items broke unequipping of any item because of missing parentheses