### PR TITLE
Weapon bindings system

### DIFF
--- a/lua/items.lua
+++ b/lua/items.lua
@@ -52,6 +52,7 @@ loti.item.type = {}
 loti.item.on_unit = {}
 loti.item.on_the_ground = {}
 loti.item.util = {}
+loti.item.weapon_bindings = {}
 
 -- Blinking animation on the ground hex if there is an item.
 loti.item.halo = "halo/misc/leadership-flare-1.png:20,halo/misc/leadership-flare-2.png:20," ..
@@ -808,4 +809,11 @@ function wesnoth.wml_actions.random_item(cfg)
 	else
 		loti.item.on_the_ground.add(generated, cfg.x, cfg.y)
 	end
+end
+
+-- Add a binding "weapon name -> weapon type
+function wesnoth.wml_actions.add_weapon_binding(cfg)
+	local name = cfg.name or helper.wml_error("[dadd_weapon_binding] lacks a required name= key")
+	local type = cfg.type or "exotic"
+	loti.item.weapon_bindings[name] = type
 end

--- a/lua/main.lua
+++ b/lua/main.lua
@@ -841,47 +841,8 @@ function loti.util.list_equippable_sorts(unit)
 	-- Analyze the list of attacks. Allow weapons that are logical for this unit.
 	for attack in pairs(loti.util.list_attacks(unit)) do
 		local weapon_type = loti.item.weapon_bindings[attack]
-		if weapon_type == "sword"
-				then can_equip.sword = 1
-		elseif weapon_type == "axe"
-			then can_equip.axe = 1
-
-		elseif weapon_type == "staff"
-			then can_equip.staff = 1
-
-		elseif weapon_type == "xbow"
-			then can_equip.xbow = 1
-
-		elseif weapon_type == "bow"
-			then can_equip.bow = 1
-
-		elseif weapon_type == "dagger"
-			then can_equip.dagger = 1
-
-		elseif weapon_type == "knife"
-			then can_equip.knife = 1
-
-		elseif weapon_type == "mace"
-				then can_equip.mace = 1
-
-		elseif weapon_type == "polearm"
-				then can_equip.polearm = 1
-
-		elseif weapon_type == "claws"
-			then can_equip.claws = 1
-
-		elseif weapon_type == "sling"
-			then can_equip.sling = 1
-
-		elseif weapon_type == "essence"
-				then can_equip.essence = 1
-
-		elseif weapon_type == "thunderstick"
-			then can_equip.thunderstick = 1
-
-
-		elseif weapon_type == "spear"
-				then can_equip.spear = 1
+		if weapon_type then
+			can_equip[weapon_type] = 1
 		end
 	end
 

--- a/lua/main.lua
+++ b/lua/main.lua
@@ -840,60 +840,47 @@ function loti.util.list_equippable_sorts(unit)
 
 	-- Analyze the list of attacks. Allow weapons that are logical for this unit.
 	for attack in pairs(loti.util.list_attacks(unit)) do
-		if attack:match("sword$") or attack == "saber"
-			or attack == "war talon" or attack == "war blade"
-			or attack == "mberserk" or attack == "whirlwind"
-			or attack == "spectral blades"
+		local weapon_type = loti.item.weapon_bindings[attack]
+		if weapon_type == "sword"
 				then can_equip.sword = 1
-
-		elseif attack:match("axe$") or attack == "berserker frenzy"
+		elseif weapon_type == "axe"
 			then can_equip.axe = 1
 
-		elseif attack:match("staff$")
+		elseif weapon_type == "staff"
 			then can_equip.staff = 1
 
-		elseif attack == "crossbow" or attack == "slurbow"
+		elseif weapon_type == "xbow"
 			then can_equip.xbow = 1
 
-		elseif attack:match("bow$")
+		elseif weapon_type == "bow"
 			then can_equip.bow = 1
 
-		elseif attack == "dagger"
+		elseif weapon_type == "dagger"
 			then can_equip.dagger = 1
 
-		elseif attack == "knife" or attack == "throwing knives"
+		elseif weapon_type == "knife"
 			then can_equip.knife = 1
 
-		elseif attack == "mace" or attack == "mace-spiked"
-			or attack == "morning star" or attack == "club"
-			or attack == "flail" or attack == "scourge"
-			or attack == "mace_berserk" or attack == "hammer"
-			or attack == "hammer_runic"
+		elseif weapon_type == "mace"
 				then can_equip.mace = 1
 
-		elseif attack == "halberd" or attack == "scythe"
-			or attack == "scythe-whirlwind"
+		elseif weapon_type == "polearm"
 				then can_equip.polearm = 1
 
-		elseif attack:match("claws$")
+		elseif weapon_type == "claws"
 			then can_equip.claws = 1
 
-		elseif attack == "sling" or attack == "bolas" or attack == "net"
+		elseif weapon_type == "sling"
 			then can_equip.sling = 1
 
-		elseif attack == "touch" or attack == "baneblade"
-			or attack == "faerie touch" or attack == "vine"
-			or attack == "torch"
+		elseif weapon_type == "essence"
 				then can_equip.essence = 1
 
-		elseif attack == "thunderstick" or attack == "dragonstaff"
+		elseif weapon_type == "thunderstick"
 			then can_equip.thunderstick = 1
 
 
-		elseif attack == "spear" or attack == "javelin"
-			or attack == "lance" or attack == "spike"
-			or attack == "pike" or attack == "trident"
-			or attack == "trident-blade" or attack == "pitchfork"
+		elseif weapon_type == "spear"
 				then can_equip.spear = 1
 		end
 	end

--- a/lua/stats.lua
+++ b/lua/stats.lua
@@ -235,38 +235,7 @@ function wesnoth.update_stats(original)
 			table.insert(weap, specials)
 		end
 
-		-- TODO: This could be a WML resource file producing a table indexed by weapon name and receiving weapon type
-		if wn == "sword" or wn == "short sword" or wn == "greatsword" or wn == "battlesword" or wn == "saber" or wn == "mberserk" or wn == "whirlwind" or wn == "spectral blades" or wn == "lichsword" then
-			weapon_type = "sword"
-		elseif wn == "axe" or wn == "battle axe" or wn == "axe_whirlwind" or wn == "berserker frenzy" or wn == "cleaver" or wn == "hatchet" then
-			weapon_type = "axe"
-		elseif wn == "bow" or wn == "longbow" then
-			weapon_type = "bow"
-		elseif wn == "staff" or wn == "plague staff" then
-			weapon_type = "staff"
-		elseif wn == "crossbow" or wn == "slurbow" then
-			weapon_type = "xbow"
-		elseif wn == "dagger" then
-			weapon_type = "dagger"
-		elseif wn == "knife" or wn == "throwing knife" or wn == "throwing knives" then
-			weapon_type = "knife"
-		elseif wn == "mace" or wn == "mace-spiked" or wn == "morning star" or wn == "club" or wn == "flail" or wn == "scourge" or wn == "mace_berserk" or wn == "hammer" or wn == "hammer-runic" then
-			weapon_type = "mace"
-		elseif wn == "spear" or wn == "javelin" or wn == "lance" or wn == "spike" or wn == "pike" or wn == "trident" or wn == "trident" or wn == "trident-blade" or wn == "pitchfork" then
-			weapon_type = "spear"
-		elseif wn == "war talon" or wn == "war blade" then
-			weapon_type = "exotic"
-		elseif wn == "halberd" or wn == "scythe" or wn == "whirlwind-scythe" then
-			weapon_type = "polearm"
-		elseif wn == "claws" or wn == "battle claws" then
-			weapon_type = "claws"
-		elseif wn == "touch" or wn == "baneblade" or wn == "faerie touch" or wn == "vine" or wn == "torch" then
-			weapon_type = "essence"
-		elseif wn == "sling" or wn == "bolas" or wn == "net" then
-			weapon_type = "sling"
-		elseif wn == "thunderstick" or wn == "dragonstaff" then
-			weapon_type = "thunderstick"
-		end
+		weapon_type = loti.item.weapon_bindings[wn]
 
 		if not weapon_type then
 			if wn == "thorns" or wn == "gossamer" or wn == "entangle" or wn == "ensnare" or wn == "water spray" or wn == "ink" or wn == "magic blast" then

--- a/utils/global_events.cfg
+++ b/utils/global_events.cfg
@@ -424,6 +424,7 @@
     [event]
         name=start
         {VARIABLE bosses "Umbra4,Akula,Achilles,Baal,Shadowlord,Lethalia_evil,Niflheim,Uria,Lilith,Abaddon,Romero,Beelzebub"} #Some abilities have no effect on bosses, the game needs to know who the bosses are
+        {DEFAULT_WEAPON_BINDINGS}
         {GENERATE_ITEM_LIST}
 
         [set_menu_item]

--- a/utils/weapons.cfg
+++ b/utils/weapons.cfg
@@ -1,0 +1,302 @@
+#the table of bindings "weapon name -> weapon type"
+#define DEFAULT_WEAPON_BINDINGS
+    [add_weapon_binding]
+        name="sword"
+        type="sword"
+    [/add_weapon_binding]
+
+    [add_weapon_binding]
+        name="short sword"
+        type="sword"
+    [/add_weapon_binding]
+    
+    [add_weapon_binding]
+        name="greatsword"
+        type="sword"
+    [/add_weapon_binding]
+    
+    [add_weapon_binding]
+        name="long sword"
+        type="sword"
+    [/add_weapon_binding]
+    
+    [add_weapon_binding]
+        name="battlesword"
+        type="sword"
+    [/add_weapon_binding]
+    
+    [add_weapon_binding]
+        name="saber"
+        type="sword"
+    [/add_weapon_binding]
+    
+    [add_weapon_binding]
+        name="mberserk"
+        type="sword"
+    [/add_weapon_binding]
+    
+    [add_weapon_binding]
+        name="whirlwind"
+        type="sword"
+    [/add_weapon_binding]
+    
+    [add_weapon_binding]
+        name="spectral blades"
+        type="sword"
+    [/add_weapon_binding]
+    
+    [add_weapon_binding]
+        name="lichsword"
+        type="sword"
+    [/add_weapon_binding]
+    
+    [add_weapon_binding]
+        name="axe"
+        type="axe"
+    [/add_weapon_binding]
+    
+    [add_weapon_binding]
+        name="battle axe"
+        type="axe"
+    [/add_weapon_binding]
+    
+    [add_weapon_binding]
+        name="axe_whirlwind"
+        type="axe"
+    [/add_weapon_binding]
+    
+    [add_weapon_binding]
+        name="berserker frenzy"
+        type="axe"
+    [/add_weapon_binding]
+    
+    [add_weapon_binding]
+        name="cleaver"
+        type="axe"
+    [/add_weapon_binding]
+    
+    [add_weapon_binding]
+        name="hatchet"
+        type="axe"
+    [/add_weapon_binding]
+    
+    [add_weapon_binding]
+        name="bow"
+        type="bow"
+    [/add_weapon_binding]
+    
+    [add_weapon_binding]
+        name="longbow"
+        type="bow"
+    [/add_weapon_binding]
+    
+    [add_weapon_binding]
+        name="staff"
+        type="staff"
+    [/add_weapon_binding]
+    
+    [add_weapon_binding]
+        name="plague staff"
+        type="staff"
+    [/add_weapon_binding]
+    
+    [add_weapon_binding]
+        name="crossbow"
+        type="xbow"
+    [/add_weapon_binding]
+    
+    [add_weapon_binding]
+        name="slurbow"
+        type="xbow"
+    [/add_weapon_binding]
+    
+    [add_weapon_binding]
+        name="dagger"
+        type="dagger"
+    [/add_weapon_binding]
+    
+    [add_weapon_binding]
+        name="knife"
+        type="knife"
+    [/add_weapon_binding]
+    
+    [add_weapon_binding]
+        name="throwing knife"
+        type="knife"
+    [/add_weapon_binding]
+    
+    [add_weapon_binding]
+        name="throwing knives"
+        type="knife"
+    [/add_weapon_binding]
+    
+    [add_weapon_binding]
+        name="mace"
+        type="mace"
+    [/add_weapon_binding]
+    
+    [add_weapon_binding]
+        name="mace-spiked"
+        type="mace"
+    [/add_weapon_binding]
+    
+    [add_weapon_binding]
+        name="morning star"
+        type="mace"
+    [/add_weapon_binding]
+    
+    [add_weapon_binding]
+        name="club"
+        type="mace"
+    [/add_weapon_binding]
+    
+    [add_weapon_binding]
+        name="flail"
+        type="mace"
+    [/add_weapon_binding]
+    
+    [add_weapon_binding]
+        name="scourge"
+        type="mace"
+    [/add_weapon_binding]
+    
+    [add_weapon_binding]
+        name="mace_berserk"
+        type="mace"
+    [/add_weapon_binding]
+    
+    [add_weapon_binding]
+        name="hammer"
+        type="mace"
+    [/add_weapon_binding]
+    
+    [add_weapon_binding]
+        name="hammer-runic"
+        type="mace"
+    [/add_weapon_binding]
+    
+    [add_weapon_binding]
+        name="spear"
+        type="spear"
+    [/add_weapon_binding]
+    
+    [add_weapon_binding]
+        name="javelin"
+        type="spear"
+    [/add_weapon_binding]
+    
+    [add_weapon_binding]
+        name="lance"
+        type="spear"
+    [/add_weapon_binding]
+    
+    [add_weapon_binding]
+        name="spike"
+        type="spear"
+    [/add_weapon_binding]
+    
+    [add_weapon_binding]
+        name="pike"
+        type="spear"
+    [/add_weapon_binding]
+    
+    [add_weapon_binding]
+        name="trident"
+        type="spear"
+    [/add_weapon_binding]
+    
+    [add_weapon_binding]
+        name="trident-blade"
+        type="spear"
+    [/add_weapon_binding]
+    
+    [add_weapon_binding]
+        name="pitchfork"
+        type="spear"
+    [/add_weapon_binding]
+    
+    [add_weapon_binding]
+        name="halberd"
+        type="polearm"
+    [/add_weapon_binding]
+    
+    [add_weapon_binding]
+        name="scythe"
+        type="polearm"
+    [/add_weapon_binding]
+    
+    [add_weapon_binding]
+        name="whirlwind-scythe"
+        type="polearm"
+    [/add_weapon_binding]
+    
+    [add_weapon_binding]
+        name="war talon"
+        type="claws"
+    [/add_weapon_binding]
+    
+    [add_weapon_binding]
+        name="claws"
+        type="claws"
+    [/add_weapon_binding]
+    
+    [add_weapon_binding]
+        name="battle claws"
+        type="claws"
+    [/add_weapon_binding]
+    
+    [add_weapon_binding]
+        name="war blade"
+        type="claws"
+    [/add_weapon_binding]
+    
+    [add_weapon_binding]
+        name="touch"
+        type="essence"
+    [/add_weapon_binding]
+    
+    [add_weapon_binding]
+        name="baneblade"
+        type="essence"
+    [/add_weapon_binding]
+    
+    [add_weapon_binding]
+        name="faerie touch"
+        type="essence"
+    [/add_weapon_binding]
+    
+    [add_weapon_binding]
+        name="vine"
+        type="essence"
+    [/add_weapon_binding]
+    
+    [add_weapon_binding]
+        name="torch"
+        type="essence"
+    [/add_weapon_binding]
+    
+    [add_weapon_binding]
+        name="sling"
+        type="sling"
+    [/add_weapon_binding]
+    
+    [add_weapon_binding]
+        name="bolas"
+        type="sling"
+    [/add_weapon_binding]
+    
+    [add_weapon_binding]
+        name="net"
+        type="sling"
+    [/add_weapon_binding]
+    
+    [add_weapon_binding]
+        name="thunderstick"
+        type="thunderstick"
+    [/add_weapon_binding]
+    
+    [add_weapon_binding]
+        name="dragonstaff"
+        type="thunderstick"
+    [/add_weapon_binding]
+#enddef


### PR DESCRIPTION
As mentioned in #302 we need a unified table of all weapon bindings, so I suggest my solution.

Not exactly a WML resource table, like items' list. I made a special tag `add_weapon_binding` which adds a "name->type" binding to a table `loti.item.weapon_bindings`, then both stats.lua and main.lua use that lua table to determine items' effects and allowed items to gear. Additional bindings are easy to add for other addons using LotI. Also, as mentioned in the issue, I made Drakes' war talon and war blade to be metal claws instead of sword/exotic. Also added cleaver as an axe (in the previous system cleaver has a reversed bug: axe would work for it if equipped but the system doesn't allow to equip it.

My only concern about this solution might be the compatibility with other add-ons using LotI, if they don't use LotI's GLOBAL_EVENTS macro (which now loads DEFAULT_WEAPON_BINDINGS). I checked other Dugi's campaigns, and they all use it, and my addons I will easily patch when the new major LotI release comes