### PR TITLE
Lethalia's nightstalk is now removed at the end of ch 5 scen 5.

### DIFF
--- a/scenarios5/05_We_Walk_in_the_Shadows.cfg
+++ b/scenarios5/05_We_Walk_in_the_Shadows.cfg
@@ -757,7 +757,7 @@ Enemy units cannot see this unit at night, except if they have units next to it.
         [if]
             [variable]
                 name=gifted.modifications.object[$i].id
-                equals=Sneak-Lethalia
+                equals=Sneak_Lethalia
             [/variable]
             [then]
                 {CLEAR_VARIABLE gifted.modifications.object[$i]}


### PR DESCRIPTION
There was a mismatch between the `[object]` id and the removal id.