### PR TITLE
Make weapon bindings be reinitialized using preload

### DIFF
--- a/lua/stats.lua
+++ b/lua/stats.lua
@@ -93,7 +93,7 @@ function wesnoth.update_stats(original)
 	end
 
 	-- PART III: Recreate the unit
-	local remade = wesnoth.create_unit{ type = original.type, side = original.side, x = original.x, y = original.y, goto_x = original.goto_x, goto_y = original.goto_y, experience = original.experience, canrecruit = original.canrecruit, variation = original.variation, id = original.id, moves = original.moves, hitpoints = original.hitpoints, attacks_left = original.attacks_left, gender = original.gender, name = original.name, facing = original.facing, extra_recruit = original.extra_recruit, underlying_id = original.underlying_id, unrenamable = original.unrenamable, overlays = original.overlays, random_traits = false, { "status", helper.get_child(original, "status")}, { "variables", vars}, { "modifications", visible_modifications}}.__cfg
+	local remade = wesnoth.create_unit{ type = original.type, side = original.side, x = original.x, y = original.y, goto_x = original.goto_x, goto_y = original.goto_y, experience = original.experience, canrecruit = original.canrecruit, variation = original.variation, id = original.id, role = original.role, moves = original.moves, hitpoints = original.hitpoints, attacks_left = original.attacks_left, gender = original.gender, name = original.name, facing = original.facing, extra_recruit = original.extra_recruit, underlying_id = original.underlying_id, unrenamable = original.unrenamable, overlays = original.overlays, random_traits = false, { "status", helper.get_child(original, "status")}, { "variables", vars}, { "modifications", visible_modifications}}.__cfg
 	vars = helper.get_child(remade, "variables")
 	visible_modifications = helper.get_child(remade, "modifications")
 	vars.updated = true

--- a/scenarios1/00_Tutorial.cfg
+++ b/scenarios1/00_Tutorial.cfg
@@ -29,6 +29,8 @@
             story= _ "Efraim de Ceise was a noble fencer who was also proficient with magic. He had studied magic from some books he secretly kept under the false bottom of his chest. Although most competent with the sword, his spells sometimes happened to be useful as well."
         [/part]
     [/story]
+    #cause no global events in this scenario but we need proper item system
+    {PRELOAD_WEAPON_BINDINGS}
     [event]
         name=prestart
         {VARIABLE tutorial.progress 1}

--- a/utils/global_events.cfg
+++ b/utils/global_events.cfg
@@ -2291,20 +2291,8 @@ $soul_eating"
         [if]
             [variable]
                 name=updated.type
-                equals="Grand Knight"
+                equals="Cavalier"
             [/variable]
-            [or]
-                [variable]
-                    name=updated.type
-                    equals="Grand Knight LotI"
-                [/variable]
-            [/or]
-            [or]
-                [variable]
-                    name=updated.type
-                    equals="Cavalier"
-                [/variable]
-            [/or]
             [then]
                 {VARIABLE updated.advances_to "Chaos Rider"}
                 {VARIABLE updated.max_experience 192}
@@ -2365,12 +2353,6 @@ $soul_eating"
                 [variable]
                     name=updated.type
                     equals="Grand Knight LotI"
-                [/variable]
-            [/or]
-            [or]
-                [variable]
-                    name=updated.type
-                    equals="Cavalier"
                 [/variable]
             [/or]
             [then]
@@ -2532,7 +2514,7 @@ $soul_eating"
                 equals="Orcish Warlord"
             [/variable]
             [then]
-                {VARIABLE updated.advances_to "Orcish Sovereign LotI"}
+                {VARIABLE updated.advances_to "Orcish Warmonger"}
                 {VARIABLE updated.max_experience 190}
             [/then]
         [/if]

--- a/utils/global_events.cfg
+++ b/utils/global_events.cfg
@@ -236,6 +236,14 @@
     {DRAW_ITEM}
 #enddef
 
+#define PRELOAD_WEAPON_BINDINGS
+    [event]
+        name=preload
+        first_time_only=no
+        {DEFAULT_WEAPON_BINDINGS}
+    [/event]
+#enddef
+
 #define GLOBAL_EVENTS
 #ifndef DISABLE_AMLA_WORKAROUND
     [event]
@@ -283,6 +291,7 @@
             animate=no
         [/kill]
     [/event]
+    {PRELOAD_WEAPON_BINDINGS}
 #enddef
 
 #define GLOBAL_EVENTS_LIST
@@ -424,7 +433,6 @@
     [event]
         name=start
         {VARIABLE bosses "Umbra4,Akula,Achilles,Baal,Shadowlord,Lethalia_evil,Niflheim,Uria,Lilith,Abaddon,Romero,Beelzebub"} #Some abilities have no effect on bosses, the game needs to know who the bosses are
-        {DEFAULT_WEAPON_BINDINGS}
         {GENERATE_ITEM_LIST}
 
         [set_menu_item]


### PR DESCRIPTION
Fix for #313 . Old midgame saves which lack this preload events will still be broken, but only till the end of the scenario.