### PR TITLE
Synchronized soul eater/redeem

### DIFF
--- a/lua/redeem.lua
+++ b/lua/redeem.lua
@@ -519,8 +519,11 @@ function wesnoth.wml_actions.show_redeem_menu(cfg)
 		helper.wml_error("[show_redeem_menu]: no units found, may need find_in= parameter.")
 	end
 
-	local result = redeem_menu(ability_tree, units[1])
-	wesnoth.set_variable(to_variable, result)
+	local result = wesnoth.synchronize_choice(_"Soul Eater", function()
+ 		local res = redeem_menu(ability_tree, units[1])
+ 		return {wml.tag.soul_eater_choice {choice = res}}
+ 	end)
+ 	wesnoth.set_variable(to_variable, result[1][2].choice)
 end
 
 -- Tag [count_redeem_upgrades] counts the number of existing redeem upgrades of current unit.


### PR DESCRIPTION
The soul eater/redeem menu has been unsynchronized which led to negative effects both for MP and watching SP replays. In MP it showed the redeem menu for each player and they all had to choose the same option (or they would get a nasty oos some later), in SP replays it's kinda the same, if your character got a new advancement path, the menu pops up and you have to choose the same option as you had in-game, the choice wasn't remembered in the replay. This should fix that, although old unsynched replays won't work after that (they will show oos "input expected but found something else"