### PR TITLE
Fixing a pair of typos in advancements

### DIFF
--- a/units/Delly_lich.cfg
+++ b/units/Delly_lich.cfg
@@ -664,7 +664,7 @@
             description= _ "more precise with knives"
             image=attacks/dagger-thrown-human.png
             strict_amla=yes
-            require_amla="knife3"
+            require_amla="knife1,knife2"
             [effect]
                 apply_to=attack
                 name=knife

--- a/units/Vritra.cfg
+++ b/units/Vritra.cfg
@@ -1199,7 +1199,7 @@ A unit afflicted by this ability may lose up to 16 HP per turn, except for poiso
         require_amla="berserk1"
         [effect]
             apply_to=improve_bonus_attack
-            name=mberserk
+            name=mberserk5
             increase_damage=10
         [/effect]
         [effect]


### PR DESCRIPTION
Spotted in the support topic on the forums