### PR TITLE
Fix non-working lookup of weapon specials for titles

### DIFF
--- a/lua/titles.lua
+++ b/lua/titles.lua
@@ -32,8 +32,10 @@ function loti.util.get_unit_flavour(u)
 		for i = 1,#data do
 			if data[i][1] == "attack" then
 				for j = 1,#data[i][2] do
-					if data[i][2][j][2].id == special_name then
-						has = true
+					for k = 1,#data[i][2][j][2] do
+						if data[i][2][j][2][k][2].id == special_name then
+							has = true
+						end
 					end
 				end
 			end
@@ -54,8 +56,10 @@ function loti.util.get_unit_flavour(u)
 			else
 				local is_spell = false
 				for j = 1,#data[i][2] do
-					if data[i][2][j][2].id == "magical" then
-						is_spell = true
+					for k = 1,#data[i][2][j][2] do
+						if data[i][2][j][2][k][2].id == "magical" then
+							is_spell = true
+						end
 					end
 				end
 				if is_spell then
@@ -204,7 +208,6 @@ function loti.util.get_unit_flavour(u)
 			end
 		end
 	end
-
 	return flavour
 end
 


### PR DESCRIPTION
The previous code didn't actually looked up the specials, it reached the tag `[specials]` and queried its `id` (which is absent ofc), for actual looking up you need to iterate over `[specials]` children