### PR TITLE
Improve parry bonus attacks

### DIFF
--- a/units/Delly_lich.cfg
+++ b/units/Delly_lich.cfg
@@ -828,7 +828,7 @@
                 clone_anim=yes
                 defense_weight=0
                 damage=-20
-                number=-55
+                number=-30
                 [specials]
                     {WEAPON_SPECIAL_PARRY}
                 [/specials]

--- a/units/Delly_lich.cfg
+++ b/units/Delly_lich.cfg
@@ -828,7 +828,7 @@
                 clone_anim=yes
                 defense_weight=0
                 damage=-20
-                number=-70
+                number=-55
                 [specials]
                     {WEAPON_SPECIAL_PARRY}
                 [/specials]

--- a/units/Delly_start.cfg
+++ b/units/Delly_start.cfg
@@ -406,7 +406,7 @@
                 clone_anim=yes
                 defense_weight=0
                 damage=-20
-                number=-55
+                number=-30
                 [specials]
                     {WEAPON_SPECIAL_PARRY}
                 [/specials]

--- a/units/Delly_start.cfg
+++ b/units/Delly_start.cfg
@@ -406,7 +406,7 @@
                 clone_anim=yes
                 defense_weight=0
                 damage=-20
-                number=-70
+                number=-55
                 [specials]
                     {WEAPON_SPECIAL_PARRY}
                 [/specials]

--- a/units/Forester.cfg
+++ b/units/Forester.cfg
@@ -308,7 +308,7 @@ Due to their solitude, they lack any relation to other humans, and so they do no
                 clone_anim=yes
                 defense_weight=0
                 damage=-20
-                number=-70
+                number=-55
                 [specials]
                     {WEAPON_SPECIAL_PARRY}
                 [/specials]

--- a/units/Forester.cfg
+++ b/units/Forester.cfg
@@ -308,7 +308,7 @@ Due to their solitude, they lack any relation to other humans, and so they do no
                 clone_anim=yes
                 defense_weight=0
                 damage=-20
-                number=-55
+                number=-30
                 [specials]
                     {WEAPON_SPECIAL_PARRY}
                 [/specials]

--- a/units/Shadowalker.cfg
+++ b/units/Shadowalker.cfg
@@ -820,7 +820,7 @@
                 clone_anim=yes
                 defense_weight=0
                 damage=-20
-                number=-70
+                number=-55
                 [specials]
                     {WEAPON_SPECIAL_PARRY}
                 [/specials]

--- a/units/Shadowalker.cfg
+++ b/units/Shadowalker.cfg
@@ -820,7 +820,7 @@
                 clone_anim=yes
                 defense_weight=0
                 damage=-20
-                number=-55
+                number=-30
                 [specials]
                     {WEAPON_SPECIAL_PARRY}
                 [/specials]

--- a/units/Swordmaster.cfg
+++ b/units/Swordmaster.cfg
@@ -218,7 +218,7 @@ Note: The ability upgrades may require some books to learn them from."
                 clone_anim=yes
                 defense_weight=0
                 damage=-20
-                number=-70
+                number=-55
                 [specials]
                     {WEAPON_SPECIAL_PARRY}
                 [/specials]

--- a/units/Swordmaster.cfg
+++ b/units/Swordmaster.cfg
@@ -218,7 +218,7 @@ Note: The ability upgrades may require some books to learn them from."
                 clone_anim=yes
                 defense_weight=0
                 damage=-20
-                number=-55
+                number=-30
                 [specials]
                     {WEAPON_SPECIAL_PARRY}
                 [/specials]


### PR DESCRIPTION
I first thought about making it even -50%, but decided to restrain myself a bit and make it 55%. For units with 4 base strikes it makes 1 parry strike, but they got 2 attack after one "parrying better" advancements. For units with 5 base strikes it gives 2 parry strikes. So overall parry becomes beneficial against enemies with 3 or more strikes when you're on a good terrain. Although having 1 parry strikes for units with 4 strikes might seem not very convincing for new players (like doesn't look very powerful), after all I decided that having 2 parry strikes for 4 strikes base attack right from the only advancement is too much (and the only unit with 4 base strikes to have a "parry" advancement is two variations of Delly)