### PR TITLE
Legacy assignment made as unit_placed instead of post_stats_update

### DIFF
--- a/utils/global_events.cfg
+++ b/utils/global_events.cfg
@@ -2095,6 +2095,12 @@ $soul_eating"
                 name=unit.race
                 not_equals=undead
             [/variable]
+            [and]
+                 [variable]
+                     name=unit.variables.got_legacy
+                     not_equals=yes
+                 [/variable]
+            [/and]
             [then]
                 {FOREACH unit.modifications.advancement i}
                     [if]
@@ -2115,6 +2121,7 @@ $soul_eating"
                     [then]
                         {VARIABLE_OP legacy_type rand (fire_dragon_legacy,ice_dragon_legacy,dark_dragon_legacy,undead_legacy,legacy_of_kings,legacy_of_titans,legacy_of_sorrow,legacy_of_light,legacy_of_phoenix,legacy_of_exile,legacy_of_the_freezing_north,legacy_of_the_free)}
                         {VARIABLE unit.modifications.advancement[$unit.modifications.advancement.length].id $legacy_type}
+                        {VARIABLE unit.variables.got_legacy yes}
                         [unstore_unit]
                             variable=unit
                             find_vacant=no

--- a/utils/global_events.cfg
+++ b/utils/global_events.cfg
@@ -2087,19 +2087,19 @@ $soul_eating"
     [/event]
 
     [event]
-        name=post stats update
+        name=unit placed
         first_time_only=no
         {VARIABLE has_legacy 0}
         [if]
             [variable]
-                name=updated.race
+                name=unit.race
                 not_equals=undead
             [/variable]
             [then]
-                {FOREACH updated.modifications.advancement i}
+                {FOREACH unit.modifications.advancement i}
                     [if]
                         [variable]
-                            name=updated.modifications.advancement[$i].id
+                            name=unit.modifications.advancement[$i].id
                             contains="legacy"
                         [/variable]
                         [then]
@@ -2114,7 +2114,11 @@ $soul_eating"
                     [/variable]
                     [then]
                         {VARIABLE_OP legacy_type rand (fire_dragon_legacy,ice_dragon_legacy,dark_dragon_legacy,undead_legacy,legacy_of_kings,legacy_of_titans,legacy_of_sorrow,legacy_of_light,legacy_of_phoenix,legacy_of_exile,legacy_of_the_freezing_north,legacy_of_the_free)}
-                        {VARIABLE updated.modifications.advancement[$updated.modifications.advancement.length].id $legacy_type}
+                        {VARIABLE unit.modifications.advancement[$unit.modifications.advancement.length].id $legacy_type}
+                        [unstore_unit]
+                            variable=unit
+                            find_vacant=no
+                        [/unstore_unit]
                     [/then]
                 [/if]
             [/then]

--- a/utils/global_events.cfg
+++ b/utils/global_events.cfg
@@ -2089,18 +2089,21 @@ $soul_eating"
     [event]
         name=unit placed
         first_time_only=no
+        [filter]
+            [not]
+                [filter_wml]
+                    [variables]
+                        got_legacy=yes
+                    [/variables]
+                [/filter_wml]
+             [/not]
+        [/filter]
         {VARIABLE has_legacy 0}
         [if]
             [variable]
                 name=unit.race
                 not_equals=undead
             [/variable]
-            [and]
-                 [variable]
-                     name=unit.variables.got_legacy
-                     not_equals=yes
-                 [/variable]
-            [/and]
             [then]
                 {FOREACH unit.modifications.advancement i}
                     [if]


### PR DESCRIPTION
The only possible optimization I can think of is to make unit variable "got_legacy" and check that variable first instead of scanning modifications every time. Is it needed so much and will it be significant is debatable