### PR TITLE
Fixing item picking by AI sides in multiplayer

### DIFF
--- a/lua/items.lua
+++ b/lua/items.lua
@@ -395,35 +395,64 @@ loti.item.on_the_ground.add = function(item_number, x, y, crafted_sort)
 		halo = loti.item.halo
 	}
 
-	-- Enable "pick item" event when some unit walks onto this hex.
-	-- (see PLACE_ITEM_EVENT for WML version)
-	wesnoth.add_event_handler {
-		id = "ie" .. x .. y,
-		name = "moveto",
-		first_time_only = "no",
-		wml.tag.filter {
-			x = x,
-			y = y,
-			wml.tag["not"] {
-				wml.tag.filter_wml {
-					wml.tag.variables {
-						cant_pick = "yes"
-					}
-				}
-			},
-			wml.tag.filter_side {
-				controller = "human"
-			}
-		},
-		wml.tag.fire_event {
-			name = "item_pick",
-			wml.tag.primary_unit {
+	if wml.variables["allied_sides"] then
+		wesnoth.add_event_handler {
+			id = "ie" .. x .. y,
+			name = "moveto",
+			first_time_only = "no",
+			wml.tag.filter {
 				x = x,
-				y = y
+				y = y,
+				side = wml.variables["allied_sides"],
+				wml.tag["not"] {
+					wml.tag.filter_wml {
+						wml.tag.variables {
+							cant_pick = "yes"
+						}
+					}
+				},
+			},
+			wml.tag.fire_event {
+				name = "item_pick",
+				wml.tag.primary_unit {
+					x = x,
+					y = y
+				}
 			}
 		}
-	}
-	wesnoth.fire_event("item drop", x, y)
+	else
+	-- Enable "pick item" event when some unit walks onto this hex.
+	-- (see PLACE_ITEM_EVENT for WML version)
+	-- this is a LEGACY version, which uses the "controller" side filter
+		wesnoth.add_event_handler {
+			id = "ie" .. x .. y,
+			name = "moveto",
+			first_time_only = "no",
+			wml.tag.filter {
+				x = x,
+				y = y,
+				wml.tag["not"] {
+					wml.tag.filter_wml {
+						wml.tag.variables {
+							cant_pick = "yes"
+						}
+					}
+				},
+				wml.tag.filter_side {
+					controller = "human"
+				}
+			},
+			wml.tag.fire_event {
+				name = "item_pick",
+				wml.tag.primary_unit {
+					x = x,
+					y = y
+				}
+			}
+		}
+		
+	end
+	wesnoth.fire_event("item drop", x, y) -- where is it used?
 end
 
 -- Remove one item from the ground at coordinates (x,y).

--- a/utils/global_events.cfg
+++ b/utils/global_events.cfg
@@ -30,6 +30,14 @@
 #enddef
 
 #define DROPS CHANCE CHANCE_GEM WEAPONS BOSSES ENEMIES
+    #ifndef MULTIPLAYER
+        {DROPS_EXT {CHANCE} {CHANCE_GEM} {WEAPONS} {BOSSES} {ENEMIES} "1"}
+    #else
+        {DROPS_EXT {CHANCE} {CHANCE_GEM} {WEAPONS} {BOSSES} {ENEMIES} "1,2,3,4,5"}
+    #endif
+#enddef
+
+#define DROPS_EXT CHANCE CHANCE_GEM WEAPONS BOSSES ENEMIES ALLIES
     #Adjust this macro to control drops better
     [event]
         name=die
@@ -122,6 +130,7 @@
     [event]
         name=prestart
         {VARIABLE enemy_sides ({ENEMIES})}
+        {VARIABLE allied_sides ({ALLIES})}
     [/event]
 #enddef
 


### PR DESCRIPTION
So this is my proposal how to fix picking items by AI in mp. We have the "allied_sides" variable. The old DROP macros is implemented backward compatibly, also if "allied_sides" not set the lua code will fall back to the previous mechanism.