### PR TITLE
Modularizing GLOBAL_EVENTS and removing hardcoded allied sides

### DIFF
--- a/utils/global_events.cfg
+++ b/utils/global_events.cfg
@@ -116,11 +116,7 @@
         first_time_only=no
         [filter]
             [not]
-#ifndef MULTIPLAYER
-                side=1
-#else
-                side=1,2,3,4,5
-#endif
+                side={ALLIES}
             [/not]
         [/filter]
         [check_unit_title]
@@ -143,11 +139,7 @@
             first_time_only=no	#This would cause a neglectful delay and break the 'press t to keep moving' thing when stepping on places where items dropped, but the delay
             [filter]		#is really neglectful and the player is not very likely to discover some units when walking where items already dropped. It might be more
                 x,y={X},{Y}	#significant in HotOW, but it would just fool the player to assure that he won't notice enemy spawns due to the delays when they are created.
-#ifndef MULTIPLAYER
-                side=1
-#else
-                side=1,2,3,4,5
-#endif
+                side=$allied_sides
                 [not]
                     [filter_wml]
                         [variables]
@@ -474,11 +466,7 @@
         # Remove recently picked gems on units on the recall list
         [store_unit]
             [filter]
-#ifndef MULTIPLAYER
-                side=1
-#else
-                side=1,2,3,4,5
-#endif
+                side=$allied_sides
             [/filter]
             variable=starters
             kill=yes
@@ -521,11 +509,7 @@
                     [/variables]
                 [/filter_wml]
             [/not]
-#ifndef MULTIPLAYER
-            side=1
-#else
-            side=1,2,3,4,5
-#endif
+            side=$allied_sides
         [/update_stats]
     [/event]
     [event]
@@ -563,11 +547,7 @@
     [event]
         name=unit placed
         [filter]
-#ifndef MULTIPLAYER
-            side=1
-#else
-            side=1,2,3,4,5
-#endif
+            side=$allied_sides
             [not]
                 [filter_wml]
                     [variables]
@@ -1794,35 +1774,9 @@ $soul_eating"
         first_time_only=no
         [if]
             [variable]
-                name=side_number
-                equals=1
+                name=allied_sides
+                contains=$side_number
             [/variable]
-#ifdef MULTIPLAYER
-            [or]
-                [variable]
-                    name=side_number
-                    equals=2
-                [/variable]
-            [/or]
-            [or]
-                [variable]
-                    name=side_number
-                    equals=3
-                [/variable]
-            [/or]
-            [or]
-                [variable]
-                    name=side_number
-                    equals=4
-                [/variable]
-            [/or]
-            [or]
-                [variable]
-                    name=side_number
-                    equals=5
-                [/variable]
-            [/or]
-#endif
             [then]
                 [store_unit]
                     [filter]

--- a/utils/global_events.cfg
+++ b/utils/global_events.cfg
@@ -307,45 +307,7 @@
     {ABILITIES_EVENTS}
     {SOUL_EATER}
     {REDEEMING}
-    [event]
-        name=victory
-        {FOREACH items k}
-            [remove_item]
-                x,y=$items[$k].x,$items[k$].y
-            [/remove_item]
-            [if]
-                [variable]
-                    name=items[$k].turn
-                    equals=$turn_number
-                [/variable]
-                [or]
-                    [have_location]
-                        x,y=$items[$k].x,$items[$k].y
-                        terrain=X*^*,*^X*
-                    [/have_location]
-                [/or]
-                [then]
-                    {FOREACH item_list.object i}
-                        [if]
-                            [variable]
-                                name=item_list.object[$i].number
-                                equals=$items[$k].type
-                            [/variable]
-                            [then]
-                                {INSERT_INTO_ITEMS $item_list.object[$i].sort $items[$k].type}
-                                [message]
-                                    speaker=narrator
-                                    message=_"Automatically picked $item_list.object[$i].name you could not pick before the end of the scenario."
-                                    image="wesnoth-icon.png"
-                                [/message]
-                            [/then]
-                        [/if]
-                    {NEXT i}
-                [/then]
-            [/if]
-        {NEXT k}
-        {CLEAR_VARIABLE item_x,item_y,items}
-    [/event]
+    {LOTI_COLLECT_WHEN_VICTORY}
     [event]
         name=victory
         id=kill_walking_corpses
@@ -439,6 +401,228 @@
 #else
 
 #endif
+    {LOTI_UPDATES}
+    
+    {LOTI_ESSENTIALS}
+
+    {LOTI_RECALL_LIST_ITEMS}
+
+    {HELP_EVENTS}
+    
+    {LOTI_RECRUIT_MODS}
+
+    {LOTI_DEMON_HACK}
+
+    {LOTI_FORCE_RESPEC}
+
+    {LOTI_MAKE_BLACK_SOUL}
+
+    {LOTI_MAKE_DOPPELGANGER}
+
+    {LOTI_DELAYED_EXP}
+
+    {LOTI_CLEAR_HEALED_STATUS}
+    
+    {LOTI_LEGACY_ASSIGNMENT}
+
+#ifndef NO_LOTI
+    {LOTI_BEELZEBUB_PROGRESS}
+#endif
+
+#ifdef ACCELERATE_AI
+    [event]
+        name=start
+        [if]
+            [variable]
+                name=no_fast_ai
+                equals=yes
+            [/variable]
+            [else]
+                [store_side]
+                    [filter]
+                    [/filter]
+                    variable=ai_sides
+                [/store_side]
+                {FOREACH ai_sides i}
+                    [if]
+                        [variable]
+                            name=ai_sides[$i].controller
+                            equals=ai
+                        [/variable]
+                        [then]
+                            [micro_ai]
+                                side=$ai_sides[$i].side
+                                ai_type=fast_ai
+                                action=add
+                            [/micro_ai]
+                        [/then]
+                    [/if]
+                {NEXT i}
+                {CLEAR_VARIABLE ai_sides}
+            [/else]
+        [/if]
+    [/event]
+#endif
+
+    {LOTI_EXTRA_ADVANCEMENT_PATHS}
+
+#enddef
+
+#define LOTI_UPDATES
+    [event]
+        name=prestart
+        # Remove recently picked gems on units on the recall list
+        [store_unit]
+            [filter]
+#ifndef MULTIPLAYER
+                side=1
+#else
+                side=1,2,3,4,5
+#endif
+            [/filter]
+            variable=starters
+            kill=yes
+        [/store_unit]
+        {FOREACH starters i}
+            {FOREACH starters[$i].modifications.object j}
+                [if]
+                    [variable]
+                        name=starters[$i].modifications.object[$j].number
+                        greater_than_equal_to=521
+                    [/variable]
+                    [and]
+                        [variable]
+                            name=starters[$i].modifications.object[$j].number
+                            less_than_equal_to=530
+                        [/variable]
+                    [/and]
+                    [then]
+                        {CLEAR_VARIABLE starters[$i].modifications.object[$j]}
+                        {VARIABLE_OP j sub 1}
+                    [/then]
+                [/if]
+            {NEXT j}
+            [unstore_unit]
+                variable=starters[$i]
+            [/unstore_unit]
+        {NEXT i}
+        {CLEAR_VARIABLE starters}
+    [/event]
+
+    [event]
+        name=turn refresh
+        first_time_only=no
+        #Workaround to make units newly created with plague behave properly.
+        [update_stats]
+            [not]
+                [filter_wml]
+                    [variables]
+                        updated=yes
+                    [/variables]
+                [/filter_wml]
+            [/not]
+#ifndef MULTIPLAYER
+            side=1
+#else
+            side=1,2,3,4,5
+#endif
+        [/update_stats]
+    [/event]
+    [event]
+        name=recall
+        first_time_only=no
+        [filter]
+            side=1
+        [/filter]
+        [store_unit]
+            [filter]
+                x,y=$x1,$y1
+            [/filter]
+            variable=advanced
+            kill=no
+        [/store_unit]
+        [if]
+            [variable]
+                name=advanced.variables.updated
+                equals=yes
+            [/variable]
+            [else]
+                {UPDATE_STATS}
+            [/else]
+        [/if]
+        {CLEAR_VARIABLE advanced.variables.starving}
+        [unstore_unit]
+            variable=advanced
+            find_vacant=no
+        [/unstore_unit]
+        {CLEAR_VARIABLE advanced}
+        [allow_undo]
+        [/allow_undo]
+    [/event]
+
+    [event]
+        name=unit placed
+        [filter]
+#ifndef MULTIPLAYER
+            side=1
+#else
+            side=1,2,3,4,5
+#endif
+            [not]
+                [filter_wml]
+                    [variables]
+                        update_started=yes
+                    [/variables]
+                [/filter_wml]
+            [/not]
+        [/filter]
+        {UPDATE_STATS}
+    [/event]
+#enddef
+
+#define LOTI_COLLECT_WHEN_VICTORY
+    [event]
+        name=victory
+        {FOREACH items k}
+            [remove_item]
+                x,y=$items[$k].x,$items[k$].y
+            [/remove_item]
+            [if]
+                [variable]
+                    name=items[$k].turn
+                    equals=$turn_number
+                [/variable]
+                [or]
+                    [have_location]
+                        x,y=$items[$k].x,$items[$k].y
+                        terrain=X*^*,*^X*
+                    [/have_location]
+                [/or]
+                [then]
+                    {FOREACH item_list.object i}
+                        [if]
+                            [variable]
+                                name=item_list.object[$i].number
+                                equals=$items[$k].type
+                            [/variable]
+                            [then]
+                                {INSERT_INTO_ITEMS $item_list.object[$i].sort $items[$k].type}
+                                [message]
+                                    speaker=narrator
+                                    message=_"Automatically picked $item_list.object[$i].name you could not pick before the end of the scenario."
+                                    image="wesnoth-icon.png"
+                                [/message]
+                            [/then]
+                        [/if]
+                    {NEXT i}
+                [/then]
+            [/if]
+        {NEXT k}
+        {CLEAR_VARIABLE item_x,item_y,items}
+    [/event]
+#enddef
+
+#define LOTI_ESSENTIALS
     [event]
         name=start
         {VARIABLE bosses "Umbra4,Akula,Achilles,Baal,Shadowlord,Lethalia_evil,Niflheim,Uria,Lilith,Abaddon,Romero,Beelzebub"} #Some abilities have no effect on bosses, the game needs to know who the bosses are
@@ -839,7 +1023,9 @@ $soul_eating"
 
         {CLEAR_VARIABLE desc_prefix,attacks_list,abilities_list,resistances_list,defences_list,limited_items_list,advancements_taken,soul_eating,potions_list}
     [/event]
+#enddef
 
+#define LOTI_RECALL_LIST_ITEMS
     [event]
         name=recall list items
         first_time_only=no
@@ -1158,67 +1344,9 @@ $soul_eating"
             variable=advanced2
         [/unstore_unit]
     [/event]
+#enddef
 
-    [event]
-        name=prestart
-        # Remove recently picked gems on units on the recall list
-        [store_unit]
-            [filter]
-#ifndef MULTIPLAYER
-                side=1
-#else
-                side=1,2,3,4,5
-#endif
-            [/filter]
-            variable=starters
-            kill=yes
-        [/store_unit]
-        {FOREACH starters i}
-            {FOREACH starters[$i].modifications.object j}
-                [if]
-                    [variable]
-                        name=starters[$i].modifications.object[$j].number
-                        greater_than_equal_to=521
-                    [/variable]
-                    [and]
-                        [variable]
-                            name=starters[$i].modifications.object[$j].number
-                            less_than_equal_to=530
-                        [/variable]
-                    [/and]
-                    [then]
-                        {CLEAR_VARIABLE starters[$i].modifications.object[$j]}
-                        {VARIABLE_OP j sub 1}
-                    [/then]
-                [/if]
-            {NEXT j}
-            [unstore_unit]
-                variable=starters[$i]
-            [/unstore_unit]
-        {NEXT i}
-        {CLEAR_VARIABLE starters}
-    [/event]
-
-    [event]
-        name=turn refresh
-        first_time_only=no
-        #Workaround to make units newly created with plague behave properly.
-        [update_stats]
-            [not]
-                [filter_wml]
-                    [variables]
-                        updated=yes
-                    [/variables]
-                [/filter_wml]
-            [/not]
-#ifndef MULTIPLAYER
-            side=1
-#else
-            side=1,2,3,4,5
-#endif
-        [/update_stats]
-    [/event]
-    {HELP_EVENTS}
+#define LOTI_RECRUIT_MODS
     [event]
         name=recruit
         first_time_only=no
@@ -1604,57 +1732,9 @@ $soul_eating"
         {CLEAR_VARIABLE bonus,type}
     [/event]
 #endif
-    [event]
-        name=recall
-        first_time_only=no
-        [filter]
-            side=1
-        [/filter]
-        [store_unit]
-            [filter]
-                x,y=$x1,$y1
-            [/filter]
-            variable=advanced
-            kill=no
-        [/store_unit]
-        [if]
-            [variable]
-                name=advanced.variables.updated
-                equals=yes
-            [/variable]
-            [else]
-                {UPDATE_STATS}
-            [/else]
-        [/if]
-        {CLEAR_VARIABLE advanced.variables.starving}
-        [unstore_unit]
-            variable=advanced
-            find_vacant=no
-        [/unstore_unit]
-        {CLEAR_VARIABLE advanced}
-        [allow_undo]
-        [/allow_undo]
-    [/event]
+#enddef
 
-    [event]
-        name=unit placed
-        [filter]
-#ifndef MULTIPLAYER
-            side=1
-#else
-            side=1,2,3,4,5
-#endif
-            [not]
-                [filter_wml]
-                    [variables]
-                        update_started=yes
-                    [/variables]
-                [/filter_wml]
-            [/not]
-        [/filter]
-        {UPDATE_STATS}
-    [/event]
-
+#define LOTI_DEMON_HACK
     [event]
         name=start
         [store_unit]
@@ -1706,6 +1786,9 @@ $soul_eating"
         {NEXT i}
         {CLEAR_VARIABLE leader}
     [/event]
+#enddef
+
+#define LOTI_FORCE_RESPEC
     [event]
         name=turn refresh
         first_time_only=no
@@ -1890,7 +1973,62 @@ $soul_eating"
         [/if]
         {CLEAR_VARIABLE experience_to_give,times_advanced,advancing_store}
     [/event]
+#enddef
 
+#define LOTI_BEELZEBUB_PROGRESS
+    [event]
+        name=victory
+        [store_turns]
+            variable=turns
+        [/store_turns]
+        [if]
+            [variable]
+                name=turns
+                not_equals=-1
+            [/variable]
+            [then]
+                [if]
+                    # Initialise variable if necessary
+                    [variable]
+                        name=saved_turns
+                        greater_than=0
+                    [/variable]
+                    [else]
+                        {VARIABLE saved_turns 0}
+                    [/else]
+                [/if]
+                {VARIABLE turns_multiplied "$($turns-$turn_number)"}
+                {VARIABLE_OP turns_multiplied multiply 100}
+                {VARIABLE_OP turns_multiplied divide $turns}
+                {VARIABLE old_saved_turns $saved_turns}
+                {VARIABLE_OP saved_turns add $turns_multiplied}
+                [if]
+                    [variable]
+                        name=saved_turns
+                        greater_than_equal_to=500
+                    [/variable]
+                    [and]
+                        [variable]
+                            name=old_saved_turns
+                            less_than=500
+                        [/variable]
+                    [/and]
+                    [then]
+                        [message]
+                            speaker=narrator
+                            message=_"Your rapid progress has caused your enemies to panic. Horribly desperate to stop your progress, they looked into ancient archives of forbidden lore and found a solution. They cast a spell that exploited a small weakness in the barrier separating Inferno, reached in and summoned one of its most horrid entities, Beelzebub. They made a pact so that the hellspawn would chase you. Fortunately, Beelzebub is not very good at pursuing."
+                            side_for=$side_number
+                            image="wesnoth-icon.png"
+                        [/message]
+                    [/then]
+                [/if]
+            [/then]
+        [/if]
+        {CLEAR_VARIABLE turns_multiplied,turns,old_saved_turns}
+    [/event]
+#enddef
+
+#define LOTI_MAKE_BLACK_SOUL
     [event]
         name=make black soul
         first_time_only=no
@@ -1965,7 +2103,9 @@ $soul_eating"
             [/effect]
         [/object]
     [/event]
+#enddef
 
+#define LOTI_MAKE_DOPPELGANGER
     [event]
         name=make doppelganger
         first_time_only=no
@@ -2035,7 +2175,35 @@ $soul_eating"
         [/if]
         {CLEAR_VARIABLE doppel_stats}
     [/event]
+#enddef
 
+#define LOTI_CLEAR_HEALED_STATUS
+    [event]
+        name=new turn,victory
+        first_time_only=no
+        [store_unit]
+            [filter]
+                [filter_wml]
+                    [variables]
+                        healed_this_turn=yes
+                    [/variables]
+                [/filter_wml]
+            [/filter]
+            variable=no_longer
+        [/store_unit]
+        {FOREACH no_longer i}
+            {CLEAR_VARIABLE no_longer[$i].variables.healed_this_turn}
+            [unstore_unit]
+                variable=no_longer[$i]
+                find_vacant=no
+                advance=no
+            [/unstore_unit]
+        {NEXT i}
+        {CLEAR_VARIABLE no_longer}
+    [/event]
+#enddef
+
+#define LOTI_DELAYED_EXP
     [event]
         name=attack_end
         first_time_only=no
@@ -2070,31 +2238,9 @@ $soul_eating"
             [/then]
         [/if]
     [/event]
+#enddef
 
-    [event]
-        name=new turn,victory
-        first_time_only=no
-        [store_unit]
-            [filter]
-                [filter_wml]
-                    [variables]
-                        healed_this_turn=yes
-                    [/variables]
-                [/filter_wml]
-            [/filter]
-            variable=no_longer
-        [/store_unit]
-        {FOREACH no_longer i}
-            {CLEAR_VARIABLE no_longer[$i].variables.healed_this_turn}
-            [unstore_unit]
-                variable=no_longer[$i]
-                find_vacant=no
-                advance=no
-            [/unstore_unit]
-        {NEXT i}
-        {CLEAR_VARIABLE no_longer}
-    [/event]
-
+#define LOTI_LEGACY_ASSIGNMENT
     [event]
         name=unit placed
         first_time_only=no
@@ -2144,95 +2290,9 @@ $soul_eating"
         [/if]
         {CLEAR_VARIABLE has_legacy,legacy_type}
     [/event]
+#enddef
 
-#ifndef NO_LOTI
-    [event]
-        name=victory
-        [store_turns]
-            variable=turns
-        [/store_turns]
-        [if]
-            [variable]
-                name=turns
-                not_equals=-1
-            [/variable]
-            [then]
-                [if]
-                    # Initialise variable if necessary
-                    [variable]
-                        name=saved_turns
-                        greater_than=0
-                    [/variable]
-                    [else]
-                        {VARIABLE saved_turns 0}
-                    [/else]
-                [/if]
-                {VARIABLE turns_multiplied "$($turns-$turn_number)"}
-                {VARIABLE_OP turns_multiplied multiply 100}
-                {VARIABLE_OP turns_multiplied divide $turns}
-                {VARIABLE old_saved_turns $saved_turns}
-                {VARIABLE_OP saved_turns add $turns_multiplied}
-                [if]
-                    [variable]
-                        name=saved_turns
-                        greater_than_equal_to=500
-                    [/variable]
-                    [and]
-                        [variable]
-                            name=old_saved_turns
-                            less_than=500
-                        [/variable]
-                    [/and]
-                    [then]
-                        [message]
-                            speaker=narrator
-                            message=_"Your rapid progress has caused your enemies to panic. Horribly desperate to stop your progress, they looked into ancient archives of forbidden lore and found a solution. They cast a spell that exploited a small weakness in the barrier separating Inferno, reached in and summoned one of its most horrid entities, Beelzebub. They made a pact so that the hellspawn would chase you. Fortunately, Beelzebub is not very good at pursuing."
-                            side_for=$side_number
-                            image="wesnoth-icon.png"
-                        [/message]
-                    [/then]
-                [/if]
-            [/then]
-        [/if]
-        {CLEAR_VARIABLE turns_multiplied,turns,old_saved_turns}
-    [/event]
-#endif
-
-#ifdef ACCELERATE_AI
-    [event]
-        name=start
-        [if]
-            [variable]
-                name=no_fast_ai
-                equals=yes
-            [/variable]
-            [else]
-                [store_side]
-                    [filter]
-                    [/filter]
-                    variable=ai_sides
-                [/store_side]
-                {FOREACH ai_sides i}
-                    [if]
-                        [variable]
-                            name=ai_sides[$i].controller
-                            equals=ai
-                        [/variable]
-                        [then]
-                            [micro_ai]
-                                side=$ai_sides[$i].side
-                                ai_type=fast_ai
-                                action=add
-                            [/micro_ai]
-                        [/then]
-                    [/if]
-                {NEXT i}
-                {CLEAR_VARIABLE ai_sides}
-            [/else]
-        [/if]
-    [/event]
-#endif
-
+#define LOTI_EXTRA_ADVANCEMENT_PATHS
     [event]
         name=post stats update
         first_time_only=no

--- a/utils/global_events.cfg
+++ b/utils/global_events.cfg
@@ -245,7 +245,7 @@
     [/event]
 #enddef
 
-#define GLOBAL_EVENTS
+#define LOTI_AMLA_STUFF
 #ifndef DISABLE_AMLA_WORKAROUND
     [event]
         name=pre advance
@@ -280,6 +280,10 @@
         {CLEAR_VARIABLE pre_advance_store}
     [/event]
 #endif
+#enddef
+
+#define GLOBAL_EVENTS
+{LOTI_AMLA_STUFF}
     [event]
         name=prestart
         [unit]

--- a/utils/utils.cfg
+++ b/utils/utils.cfg
@@ -123,11 +123,7 @@
         name=moveto
         id=utils_chest_event_{X}_{Y}
         [filter]
-#ifdef MULTIPLAYER
-            side=1,2,3,4,5
-#else
-            side=1
-#endif
+            side=$allied_sides
             x,y={X},{Y}
         [/filter]
         [sound]


### PR DESCRIPTION
For advanced add-on making tweaking global events might prove beneficial, so I think it might be a good idea to split {GLOBAL_EVENTS} a bit into independent blocks, so when an addon maker assembles his global events, he won't have to copypaste all the essential code. A bit changed the order, hope it's not significant.

Also can't find where "recall list items" used, probably it's legacy

And also fixed placed in globals events and utils (gold chests) where players' sides were hardcoded, replaced with $allied_sides as it should be now