### PR TITLE
Alter a bit the description of Titanic Strength potion

### DIFF
--- a/utils/item_list.cfg
+++ b/utils/item_list.cfg
@@ -2771,7 +2771,7 @@ defeat your foes mace to face."
     [object]
         name= _ "Potion of Titanic Strength"
         image=items/potion-steel.png
-        description= _ "<span color='orange'>Increases all melee damages by 10</span>"
+        description= _ "<span color='orange'>Increases damage of all melee weapons by 10</span>"
         number=144
         sort=potion
         drop=1


### PR DESCRIPTION
As it doesn't increase the damage of attacks that don't have equippable weapons (such as bite of Dragon Riders), folks asked me to make this kind of clarification