### PR TITLE
Fallback value for base_seed

### DIFF
--- a/lua/stats.lua
+++ b/lua/stats.lua
@@ -43,7 +43,11 @@ local function get_random_seed_from_unit(unit)
 	if unit.race and string.len(unit.race) > 0 then
 		seed = (seed >> 3) ~ string.byte(unit.race)
 	end
-	seed = wesnoth.get_variable("base_seed") ~ seed
+	local base_seed = wesnoth.get_variable("base_seed")
+	if not base_seed then
+		base_seed = 0
+	end
+	seed = base_seed ~ seed
 	return seed
 end
 


### PR DESCRIPTION
If somehow base_seed isn't set (old code using LotI, for example), Lua will exit with error "can't apply bitwise operations with nil" and the unit disappears