### PR TITLE
New way of extra advancements for 1.16

### DIFF
--- a/.github/scripts/upload_beta_addon.sh
+++ b/.github/scripts/upload_beta_addon.sh
@@ -23,7 +23,7 @@ fi
 rsync --exclude .git --exclude wesnoth_tools -a . $ADDON
 find $ADDON -type f | xargs sed -i "s@add-ons/Legend_of_the_Invincibles@add-ons/$ADDON@g"
 
-for WESNOTH_VERSION in "1.14.x"; do
+for WESNOTH_VERSION in "1.16.x"; do
 	python wesnoth_tools/wesnoth_addon_manager \
 		-u $ADDON \
 		--port $WESNOTH_VERSION \

--- a/_main.cfg
+++ b/_main.cfg
@@ -79,6 +79,7 @@
         type_lightning= _ "lightning"
     [/language]
 #enddef
+{./extra_advancements.cfg}
 [campaign]
     id="Legend_of_the_Invincibles_I"
     name= _ "Legend of the Invincibles"+ "
@@ -115,6 +116,7 @@ Note: This campaign contains elements alien to other campaigns, and may teach yo
     end_text= _ "To be continued...
 Go to BFW main window > Campaign > Legend of the Invincibles, Part II: Into the Light"
     {LOTI_ABOUT}
+    {LOTI_EXTRA_ADVANCEMENT_LINES}
 [/campaign]
 [campaign]
     id="Legend_of_the_Invincibles_VI"
@@ -151,6 +153,7 @@ There are also two spin-offs on the add-ons server: 'The Beautiful Child' and 'A
     icon="data/add-ons/Legend_of_the_Invincibles/images/chapter7.png"
     image=data/add-ons/Legend_of_the_Invincibles/images/gateway.png
     {LOTI_ABOUT}
+    {LOTI_EXTRA_ADVANCEMENT_LINES}
 [/campaign]
 
 #ifdef CAMPAIGN_LEGEND_OF_THE_INVINCIBLES_PART_I

--- a/extra_advancements.cfg
+++ b/extra_advancements.cfg
@@ -1,0 +1,352 @@
+#define LOTI_EXTRA_ADVANCEMENT_LINES
+    [modify_unit_type]
+        type="Assassin"
+        set_advances_to="Exterminator"
+        set_experience=300
+    [/modify_unit_type]
+    
+    [modify_unit_type]
+        type="Master at Arms"
+        set_advances_to="Champion,Shadowalker"
+        set_experience=320
+    [/modify_unit_type]
+    
+    [modify_unit_type]
+        type="Necromancer"
+        set_advances_to="Arch Necromancer,09 Ancient Lich,Demilich"
+        set_experience=300
+    [/modify_unit_type]
+    
+    [modify_unit_type]
+        type="Lich"
+        set_advances_to="09 Ancient Lich,Demilich,Lich King"
+        set_experience=300
+    [/modify_unit_type]
+    
+    [modify_unit_type]
+        type="Elvish Champion"
+        set_advances_to="Elvish Juggernaut"
+        set_experience=250
+    [/modify_unit_type]
+    
+    [modify_unit_type]
+        type="Orcish Slayer"
+        set_advances_to="Orcish Nightblade loti"
+        set_experience=220
+    [/modify_unit_type]
+    
+    [modify_unit_type]
+        type="Elvish Shyde"
+        set_advances_to="Faerie Incarnation"
+        set_experience=250
+    [/modify_unit_type]
+    
+    [modify_unit_type]
+        type="Soulless"
+        set_advances_to="Monstrosity,Bone Shooter,Revenant"
+        set_experience=90
+    [/modify_unit_type]
+    
+    [modify_unit_type]
+        type="Skeleton"
+        add_advancement="Chocobone"
+    [/modify_unit_type]
+    
+    [modify_unit_type]
+        type="Revenant"
+        add_advancement="Death Knight"
+    [/modify_unit_type]
+    [modify_unit_type]
+        type="Revenant"
+        add_advancement="Zombie Rider"
+    [/modify_unit_type]
+    [modify_unit_type]
+        type="Revenant LotI"
+        add_advancement="Death Knight"
+    [/modify_unit_type]
+    [modify_unit_type]
+        type="Revenant LotI"
+        add_advancement="Zombie Rider"
+    [/modify_unit_type]
+    
+    [modify_unit_type]
+        type="Death Knight"
+        set_advances_to="Deathlord,Infernal Knight,Lich King"
+        set_experience=270
+    [/modify_unit_type]
+    [modify_unit_type]
+        type="Death Knight LotI"
+        set_advances_to="Deathlord,Infernal Knight,Lich King"
+        set_experience=270
+    [/modify_unit_type]
+    
+    [modify_unit_type]
+        type="Draug"
+        set_advances_to="Deathlord"
+        set_experience=250
+    [/modify_unit_type]
+    
+    [modify_unit_type]
+        type="Chocobone LotI"
+        set_advances_to="Grim Knight,Zombie Rider"
+        set_experience=180
+    [/modify_unit_type]
+    [modify_unit_type]
+        type="Chocobone"
+        set_advances_to="Grim Knight,Zombie Rider"
+        set_experience=180
+    [/modify_unit_type]
+    
+    [modify_unit_type]
+        type="Ghast"
+        set_advances_to="Abomination"
+        set_experience=300
+    [/modify_unit_type]
+    
+    [modify_unit_type]
+        type="Direwolf Rider"
+        set_advances_to="Werewolf Rider"
+        set_experience=300
+    [/modify_unit_type]
+    
+    [modify_unit_type]
+        type="Troll Warrior"
+        set_advances_to="Siege Troll"
+        set_experience=280
+    [/modify_unit_type]
+    
+    [modify_unit_type]
+        type="Elvish Sharpshooter"
+        set_advances_to="Elvish Assassin,Elvish Gryphon Rider"
+        set_experience=250
+    [/modify_unit_type]
+    
+    [modify_unit_type]
+        type="Elvish Outrider"
+        set_advances_to="Elvish Gryphon Rider"
+        set_experience=250
+    [/modify_unit_type]
+    
+    [modify_unit_type]
+        type="Spectre"
+        set_advances_to="Reaper"
+        set_experience=300
+    [/modify_unit_type]
+    
+    [modify_unit_type]
+        type="Dwarvish Dragonguard"
+        set_advances_to="Dwarvish Technocrat"
+        set_experience=300
+    [/modify_unit_type]
+    
+    [modify_unit_type]
+        type="Elvish Sylph"
+        set_advances_to="Elvish Seer"
+        set_experience=500
+    [/modify_unit_type]
+    
+    [modify_unit_type]
+        type="Silver Mage"
+        set_advances_to="Duelist Wizard"
+        set_experience=300
+    [/modify_unit_type]
+    
+    [modify_unit_type]
+        type="Troll Rocklobber"
+        set_advances_to="Troll Boulderlobber"
+        set_experience=225
+    [/modify_unit_type]
+    
+    [modify_unit_type]
+        type="Nightgaunt"
+        set_advances_to="Dark Shade"
+        set_experience=250
+    [/modify_unit_type]
+    
+    [modify_unit_type]
+        type="Fencer"
+        add_advancement="Sword Mage"
+    [/modify_unit_type]
+    [modify_unit_type]
+        type="Mage LotI"
+        add_advancement="Sword Mage"
+    [/modify_unit_type]
+    [modify_unit_type]
+        type="Mage"
+        add_advancement="Sword Mage"
+    [/modify_unit_type]
+    
+    [modify_unit_type]
+        type="Lancer"
+        set_advances_to="Lunatic Knight"
+        set_experience=200
+    [/modify_unit_type]
+    
+    [modify_unit_type]
+        type="Royal Guard"
+        set_advances_to="Swordmaster"
+        set_experience=320
+    [/modify_unit_type]
+    
+    [modify_unit_type]
+        type="Great Mage"
+        set_advances_to="Elder Mage LotI"
+        set_experience=500
+    [/modify_unit_type]
+    
+    [modify_unit_type]
+        type="Banebow"
+        set_advances_to="Soul Shooter"
+        set_experience=280
+    [/modify_unit_type]
+    
+    [modify_unit_type]
+        type="Halberdier"
+        set_advances_to="Scythemaster"
+        set_experience=300
+    [/modify_unit_type]
+       
+    [modify_unit_type]
+        type="Elvish High Lord"
+        set_advances_to="Elvish Overlord"
+        set_experience=250
+    [/modify_unit_type]
+    
+    [modify_unit_type]
+        type="Javelineer"
+        set_advances_to="Pilum Master"
+        set_experience=200
+    [/modify_unit_type]
+    
+    [modify_unit_type]
+        type="Dwarvish Berserker"
+        set_advances_to="Dwarvish Battlerager"
+        set_experience=150
+    [/modify_unit_type]
+    
+    [modify_unit_type]
+        type="Dwarvish Sentinel"
+        set_advances_to="Dwarvish Protector"
+        set_experience=250
+    [/modify_unit_type]
+    
+    [modify_unit_type]
+        type="Deathblade"
+        set_advances_to="Phantom,Grim Knight"
+        set_experience=120
+    [/modify_unit_type]
+    
+    [modify_unit_type]
+        type="Elvish Marshal"
+        set_advances_to="Elvish Warlord"
+        set_experience=260
+    [/modify_unit_type]
+    
+    [modify_unit_type]
+        type="Dwarvish Lord"
+        set_advances_to="Dwarvish Hero"
+        set_experience=300
+    [/modify_unit_type]
+    
+    [modify_unit_type]
+        type="Goblin Pillager"
+        set_advances_to="Goblin Ravager"
+        set_experience=180
+    [/modify_unit_type]
+    
+    [modify_unit_type]
+        type="Elvish Avenger"
+        set_advances_to="Elvish Nightprowler"
+        set_experience=230
+    [/modify_unit_type]
+    
+    [modify_unit_type]
+        type="Orcish Slurbow"
+        set_advances_to="Orcish Strafer"
+        set_experience=280
+    [/modify_unit_type]
+    
+    [modify_unit_type]
+        type="Orcish Warlord"
+        set_advances_to="Orcish Warmonger"
+        set_experience=350
+    [/modify_unit_type]
+    
+    [modify_unit_type]
+        type="Goblin Impaler"
+        set_advances_to="Sky Goblin"
+        set_experience=90
+    [/modify_unit_type]
+    
+    [modify_unit_type]
+        type="Grand Knight"
+        set_advances_to="Dragon Rider"
+        set_experience=800
+    [/modify_unit_type]
+    
+    [modify_unit_type]
+        type="Grand Marshal"
+        set_advances_to="Duke,Dragon Rider"
+        set_experience=500
+    [/modify_unit_type]
+    
+    [modify_unit_type]
+        type="Huntsman"
+        set_advances_to="Predator"
+        set_experience=320
+    [/modify_unit_type]
+    
+    [modify_unit_type]
+        type="Ranger"
+        set_advances_to="Forester"
+        set_experience=300
+    [/modify_unit_type]
+    
+    [modify_unit_type]
+        type="Cavalier"
+        set_advances_to="Chaos Rider"
+        set_experience=260
+    [/modify_unit_type]
+    
+    [modify_unit_type]
+        type="Paladin"
+        set_advances_to="Prophet"
+        set_experience=300
+    [/modify_unit_type]
+    
+    [modify_unit_type]
+        type="Mage of Light"
+        set_advances_to="Celestial Messenger,Prophet"
+        set_experience=300
+    [/modify_unit_type]
+    
+    [modify_unit_type]
+        type="Iron Mauler"
+        set_advances_to="Destroyer,Blackguard"
+        set_experience=320
+    [/modify_unit_type]
+    
+    [modify_unit_type]
+        type="Highwayman"
+        set_advances_to="Shadow Prince,Blackguard"
+        set_experience=300
+    [/modify_unit_type]
+    
+    [modify_unit_type]
+        type="Fugitive"
+        set_advances_to="Shadow Prince"
+        set_experience=300
+    [/modify_unit_type]
+    
+    [modify_unit_type]
+        type="Goblin Rouser"
+        set_advances_to="Goblin Warbanner"
+        set_experience=80
+    [/modify_unit_type]
+    
+    [modify_unit_type]
+        type="Master Bowman"
+        set_advances_to="Champion Bowman"
+        set_experience=300
+    [/modify_unit_type]
+#enddef

--- a/units/Abomination.cfg
+++ b/units/Abomination.cfg
@@ -16,12 +16,6 @@
     advances_to=null
     cost=56
     usage=fighter
-#ifndef MULTIPLAYER
-    [advancefrom]
-        unit=Ghast
-        experience=300
-    [/advancefrom]
-#endif
     description= _ "Horror tales about terrifying undead usually lie. They describe ghasts as the most nightmarish beings that ever existed. And that is just plain wrong. There is Abomination, a mutated kind of ghast that scares even the most courageous monster hunters. It has literally a dozen mouths, most of them belonging to ghoul homunculi attached to its body with tentacles. "+{SPECIAL_NOTES}+{SPECIAL_NOTES_POISON}
     die_sound=ghoul-hit.wav
     [abilities]

--- a/units/Ancient_Lich.cfg
+++ b/units/Ancient_Lich.cfg
@@ -14,16 +14,6 @@
     level=4
     alignment=chaotic
     advances_to=null
-#ifndef MULTIPLAYER
-    [advancefrom]
-        unit=Lich
-        experience=300
-    [/advancefrom]
-    [advancefrom]
-        unit=Necromancer
-        experience=300
-    [/advancefrom]
-#endif
     cost=100
     usage=mixed fighter
     description= _ "A being of this order is a revenant of ages long past. Anyone who encounters an Ancient Lich likely has far worse things to worry about than death."+{SPECIAL_NOTES}+{SPECIAL_NOTES_MAGICAL}+{SPECIAL_NOTES_DRAIN}+{SPECIAL_NOTES_ARCANE}+{SPECIAL_NOTES_SUBMERGE}

--- a/units/Arch_Necromancer.cfg
+++ b/units/Arch_Necromancer.cfg
@@ -16,12 +16,6 @@
     advances_to=null
     cost=100
     usage=mixed fighter
-#ifndef MULTIPLAYER
-    [advancefrom]
-        unit=Necromancer
-        experience=300
-    [/advancefrom]
-#endif
     [portrait]
         size=400
         side="left"

--- a/units/Blackguard.cfg
+++ b/units/Blackguard.cfg
@@ -16,16 +16,6 @@
     advances_to=null
     cost=60
     halo=halo/darkens-aura.png
-#ifndef MULTIPLAYER
-    [advancefrom]
-        unit=Highwayman
-        experience=300
-    [/advancefrom]
-    [advancefrom]
-        unit=Iron Mauler
-        experience=320
-    [/advancefrom]
-#endif
     description= _ "Blackguards are either outlaws who were even knighted for causing severe havoc in a land by a rival landlord, or knights whose love for war and gold has gone far beyond reason. They do not behave like knights, rather like a twisted opposite of knights. Clad in black armour, radiating darkness, prefering to fight in the dead of night, attacking by surprise and scaring enemies by their appearance."
     die_sound={SOUND_LIST:HUMAN_DIE}
     usage=fighter

--- a/units/Celestial_Messenger.cfg
+++ b/units/Celestial_Messenger.cfg
@@ -17,12 +17,6 @@
     advances_to=null
     cost=84
     usage=healer
-#ifndef MULTIPLAYER
-    [advancefrom]
-        unit=Mage of Light
-        experience=300
-    [/advancefrom]
-#endif
     [movement_costs]
         shallow_water=1
         deep_water=1

--- a/units/Champion.cfg
+++ b/units/Champion.cfg
@@ -12,12 +12,6 @@
     level=4
     alignment=lawful
     advances_to=null
-#ifndef MULTIPLAYER
-    [advancefrom]
-        unit=Master at Arms
-        experience=320
-    [/advancefrom]
-#endif
     cost=59
     usage=fighter
     description= _ "After hundreds of battles and duels, the survivor learns that victory is not as important as survival. The best warrior is not the one who kills the most enemies, but the one who survives the most battles. Even with fewer kills per battle, the one who lives longer will eventually kill more people than fighters who kill enemies in large numbers. And the secret of survival is proper defence. Even in duels, the winner is the one who does not get hit, not the one who can hit the best.

--- a/units/Champion_Bowman.cfg
+++ b/units/Champion_Bowman.cfg
@@ -15,12 +15,6 @@
     alignment=lawful
     advances_to=null
     cost=60
-#ifndef MULTIPLAYER
-    [advancefrom]
-        unit=Master Bowman
-        experience=300
-    [/advancefrom]
-#endif
     usage=archer
     description= _ "Although any Master Bowman claims he has have reached the zenith of his art, inasmuch as any human is capable, it is far from truth. Their elite archers can become Champion Bowmen, that are really the ones who have reached the zenith of their art, inasmuch as any human is capable."+{SPECIAL_NOTES_MARKSMAN}
     die_sound={SOUND_LIST:HUMAN_DIE}

--- a/units/Chaos_Rider.cfg
+++ b/units/Chaos_Rider.cfg
@@ -16,12 +16,6 @@
     undead_variation=mounted
     cost=65
     usage=scout
-#ifndef MULTIPLAYER
-    [advancefrom]
-        unit=Cavalier
-        experience=260
-    [/advancefrom]
-#endif
     description= _ "The daring deeds of Cavaliers are known, but only some of them choose to play with fire. Wizards bind spirits of fire into their swords and horses, making them one of the most dangerous things on the battlefield."+{SPECIAL_NOTES}+{SPECIAL_NOTES_MAGICAL}
     die_sound=horse-die.ogg
     [portrait]

--- a/units/Dark_Shade.cfg
+++ b/units/Dark_Shade.cfg
@@ -15,12 +15,6 @@
     advances_to=null
     cost=66
     usage=scout
-#ifndef MULTIPLAYER
-    [advancefrom]
-        unit=Nightgaunt
-        experience=250
-    [/advancefrom]
-#endif
     description= _ "Dark shade is a spirit of something so dark that it was not allowed to exist in the real world. Only its shadow appears on walls and attacks the shadows of its victims - and the victims will get hurt too."+{SPECIAL_NOTES}+{SPECIAL_NOTES_BACKSTAB}+{SPECIAL_NOTES_SPIRIT}+{SPECIAL_NOTES_NIGHTSTALK}+{SPECIAL_NOTES_SKIRMISHER}+{SPECIAL_NOTES_DRAIN}
     [portrait]
         size=400

--- a/units/Deathlord.cfg
+++ b/units/Deathlord.cfg
@@ -15,20 +15,6 @@
     advances_to=null
     cost=65
     usage=fighter
-#ifndef MULTIPLAYER
-    [advancefrom]
-        unit=Draug
-        experience=250
-    [/advancefrom]
-    [advancefrom]
-        unit=Death Knight
-        experience=250
-    [/advancefrom]
-    [advancefrom]
-        unit=Death Knight LotI
-        experience=250
-    [/advancefrom]
-#endif
     description= _ "Clad in a dark armour radiating with evil power of their controller, carrying a battle axe made not of steel, but of bones of its victims put together with malevolent magic, these terrible knights of evil bring doom to everyone who crosses their path. Cruelty is not what it seeks, but warfare is the only thing it remembers from its previous life, and so it fights; without any purpose or goal, it is simply the only thing its mindless body can do."+{SPECIAL_NOTES}+{SPECIAL_NOTES_SUBMERGE}
     die_sound=skeleton-big-die.ogg
     [portrait]

--- a/units/Demilich.cfg
+++ b/units/Demilich.cfg
@@ -14,16 +14,6 @@
     level=4
     alignment=chaotic
     advances_to=null
-#ifndef MULTIPLAYER
-    [advancefrom]
-        unit=Lich
-        experience=300
-    [/advancefrom]
-    [advancefrom]
-        unit=Necromancer
-        experience=300
-    [/advancefrom]
-#endif
     cost=100
     usage=mixed fighter
     description= _ "Some liches are less than pleased with their frail skeletal body and experiment with ghosts to keep their ethereal enough to protect themselves from attack. Their ultimate goal is to look like the people they once were. This is a specimen of one that hasn't succeeded yet."+{SPECIAL_NOTES}+{SPECIAL_NOTES_MAGICAL}+{SPECIAL_NOTES_DRAIN}+{SPECIAL_NOTES_ARCANE}+{SPECIAL_NOTES_SUBMERGE}

--- a/units/Destroyer.cfg
+++ b/units/Destroyer.cfg
@@ -17,12 +17,6 @@
     alignment=lawful
     advances_to=null
     cost=62
-#ifndef MULTIPLAYER
-    [advancefrom]
-        unit=Iron Mauler
-        experience=320
-    [/advancefrom]
-#endif
     description= _ "The strongest warriors of mankind, the Destroyers, are because of their strength and resilience sometimes considered to be not humans, but demons in human armour. No matter what they really are, their help in war is so significant that any warlord would pay great amounts of gold for every single destroyer he can have in his army.
 
 Note: Destroyers can learn berserk."

--- a/units/Dragon_Rider.cfg
+++ b/units/Dragon_Rider.cfg
@@ -16,16 +16,6 @@
     undead_variation=mounted
     cost=90
     usage=fighter
-#ifndef MULTIPLAYER
-    [advancefrom]
-        unit=Grand Knight
-        experience=800
-    [/advancefrom]
-    [advancefrom]
-        unit=Grand Marshal
-        experience=500
-    [/advancefrom]
-#endif
     [resistance]
         blade=60
         pierce=80

--- a/units/Duelist_Wizard.cfg
+++ b/units/Duelist_Wizard.cfg
@@ -15,12 +15,6 @@
     alignment=neutral
     advances_to=null
     cost=75
-#ifndef MULTIPLAYER
-    [advancefrom]
-        unit=Silver Mage
-        experience=300
-    [/advancefrom]
-#endif
     usage=mixed fighter
     description= _ "Duelist Wizards are a rare group of mages, who instead of studying magic deeper and deeper decided to start using it to defeat other mages. The main motivation of this was of course the desire to get higher in ranks among other magi, who usually underestimate them because of their weaker knowledge of magical theories. Their philosophy is not based on the seek of knowledge, but on the desire to be stronger than other magi."+{SPECIAL_NOTES}+_"SPECIAL_NOTE^ Duelist Wizards are well-attuned to their magical natures and are highly resistant to non-physical damage."+{SPECIAL_NOTES_MAGICAL}+{SPECIAL_NOTES_TELEPORT}
     die_sound={SOUND_LIST:HUMAN_DIE}

--- a/units/Duke.cfg
+++ b/units/Duke.cfg
@@ -21,12 +21,6 @@
             image="units/humans/duke-leading.png"
         [/frame]
     [/healing_anim]
-#ifndef MULTIPLAYER
-    [advancefrom]
-        unit=Grand Marshal
-        experience=500
-    [/advancefrom]
-#endif
     hitpoints=86
     movement_type=smallfoot
     movement=6

--- a/units/Dwarvish_Battlerager.cfg
+++ b/units/Dwarvish_Battlerager.cfg
@@ -13,12 +13,6 @@
     level=3
     alignment=neutral
     advances_to=null
-#ifndef MULTIPLAYER
-    [advancefrom]
-        unit=Dwarvish Berserker
-        experience=150
-    [/advancefrom]
-#endif
     cost=57
     usage=fighter
     description= _ "Dwarvish Lords are always thinking about ways to make their army more powerful. One of their frequent decisions is that Berserkers, a rare caste of Dwarves, who work themselves into a towering rage before combat, disdain all notion of defence, thinking only of the unrelenting assaults for which they are legendary, should wear armours. Berserkers usually refuse, because armour would prevent them from attacking as strongly as possible. Sometimes a cunning Dwarvish Lord decides to forge an armour to appeal to them. These armours are black, heavy, and there is a lot of spikes on them, that attires the attention of any Berserker. Clad in a spiky armour, a Berserker becomes a Battlerager, an even more scary warrior than Berserkers."+{SPECIAL_NOTES}+{SPECIAL_NOTES_BERSERK}

--- a/units/Dwarvish_Hero.cfg
+++ b/units/Dwarvish_Hero.cfg
@@ -65,12 +65,6 @@
     level=4
     alignment=neutral
     advances_to=null
-#ifndef MULTIPLAYER
-    [advancefrom]
-        unit=Dwarvish Lord
-        experience=300
-    [/advancefrom]
-#endif
     cost=69
     usage=fighter
     description= _ "Dwarvish Heroes are the strongest, toughest and wisest from the dwarves. Hardened by centuries of warfare under the ground and also above it, their strength and wisdom grew beyond measure. Their incredible skill with smithing granted them the mightiest hammers and most solid armours ever, and even dwarvish kings have a strong respect towards them."

--- a/units/Dwarvish_Protector.cfg
+++ b/units/Dwarvish_Protector.cfg
@@ -13,12 +13,6 @@
     level=4
     alignment=neutral
     advances_to=null
-#ifndef MULTIPLAYER
-    [advancefrom]
-        unit=Dwarvish Sentinel
-        experience=250
-    [/advancefrom]
-#endif
     cost=68
     usage=fighter
     description= _ "Dwarvish Protectors are the hardiest from all dwarves. A wall of Dwarvish Protectors can resist enemy blows better than a stone wall - and is much more dangerous."+{SPECIAL_NOTES}+{SPECIAL_NOTES_STEADFAST}

--- a/units/Dwarvish_Technocrat.cfg
+++ b/units/Dwarvish_Technocrat.cfg
@@ -13,12 +13,6 @@
     level=4
     alignment=neutral
     advances_to=null
-#ifndef MULTIPLAYER
-    [advancefrom]
-        unit=Dwarvish Dragonguard
-        experience=300
-    [/advancefrom]
-#endif
     cost=61
     usage=archer
     description= _ "Dwarves always have some secrets they never tell even to their closest friends if they are not dwarves too. One of them is also the secret of their technical invention, the thunderstick. Although it is a very powerful weapon itself, they still seek to improve it and make it even more powerful."

--- a/units/Elder_Mage.cfg
+++ b/units/Elder_Mage.cfg
@@ -100,12 +100,6 @@
     [resistance]
         fire=60
     [/resistance]
-#ifndef MULTIPLAYER
-    [advancefrom]
-        unit=Great Mage
-        experience=500
-    [/advancefrom]
-#endif
     die_sound={SOUND_LIST:HUMAN_OLD_DIE}
     description= _ "Great Magi spread rumours that only several mages per century are given the title of a great mage, but the truth is quite different. They are speaking about Elder Magi, and misuse the similarity and the rarity of them. Among them, there is an even sparser number who, despite their blessed age, are more progressive than the younger professional fraternity. Elder Magi are the real masters of magic, the ones who make new spells and truly understand the arcane. Even if they are not trained for battle, their powerful magic can destroy most enemies before the need for quick reflexes comes."+{SPECIAL_NOTES}+{SPECIAL_NOTES_MAGICAL}
     [portrait]

--- a/units/Elvish_Assassin.cfg
+++ b/units/Elvish_Assassin.cfg
@@ -16,12 +16,6 @@
     advances_to=null
     cost=71
     usage=archer
-#ifndef MULTIPLAYER
-    [advancefrom]
-        unit=Elvish Sharpshooter
-        experience=250
-    [/advancefrom]
-#endif
     description= _ "Unlike human assassins, elvish assassins are honoured warriors who have proven their incredible skill in archery by killing the enemy warband's leader just by shooting him from a distance, or even a whole enemy clump by covering them by a deadly arrow storm before they came to him. Even when cornered and forced to fight in melee range, they can defeat their enemies with trickery, without properly fighting them."+{SPECIAL_NOTES}+{SPECIAL_NOTES_MARKSMAN}+{SPECIAL_NOTES_BACKSTAB}
     die_sound={SOUND_LIST:ELF_HIT}
     # Base image is drawn for the right side.

--- a/units/Elvish_Gryphon_Rider.cfg
+++ b/units/Elvish_Gryphon_Rider.cfg
@@ -17,16 +17,6 @@
     advances_to=null
     cost=66
     usage=scout
-#ifndef MULTIPLAYER
-    [advancefrom]
-        unit=Elvish Sharpshooter
-        experience=250
-    [/advancefrom]
-    [advancefrom]
-        unit=Elvish Outrider
-        experience=250
-    [/advancefrom]
-#endif
     description= _ "With enough skill in archery and horse riding, an elf can decide to ride giant birds instead of horses, gaining incredible mobility and an ability to shoot his foes from above, relatively protected from enemy blows."
     die_sound={SOUND_LIST:GRYPHON_DIE}
     [portrait]

--- a/units/Elvish_Juggernaut.cfg
+++ b/units/Elvish_Juggernaut.cfg
@@ -16,12 +16,6 @@
     advances_to=null
     cost=68
     usage=fighter
-#ifndef MULTIPLAYER
-    [advancefrom]
-        unit=Elvish Champion
-        experience=250
-    [/advancefrom]
-#endif
     description= _ "Elves are known to be excellent archers, but that is only because they prefer bows as primary weapons. They can be equally good with swords, but only a few elves develop this talent. They can whirl their swords in their hands like if they were just small sticks, but with the force of a furious storm, cutting their enemies asunder."
     die_sound={SOUND_LIST:ELF_HIT}
     [portrait]

--- a/units/Elvish_Nightprowler.cfg
+++ b/units/Elvish_Nightprowler.cfg
@@ -14,12 +14,6 @@
     level=4
     alignment=neutral
     advances_to=null
-#ifndef MULTIPLAYER
-    [advancefrom]
-        unit=Elvish Avenger
-        experience=230
-    [/advancefrom]
-#endif
     cost=60
     usage=mixed fighter
     description= _ "Sometimes, elvish avengers will become so good at stealth, that they can even leave the forest at night, remaining concealed."+{SPECIAL_NOTES}+{SPECIAL_NOTES_AMBUSH}+{SPECIAL_NOTES_NIGHTSTALK}

--- a/units/Elvish_Overlord.cfg
+++ b/units/Elvish_Overlord.cfg
@@ -15,12 +15,6 @@
     advances_to=null
     cost=85
     usage=mixed fighter
-#ifndef MULTIPLAYER
-    [advancefrom]
-        unit=Elvish High Lord
-        experience=250
-    [/advancefrom]
-#endif
     description= _ "Some elvish fighters who use faerie powers a lot may eventually become a male half-fairy. It gives them unusual dexterity and their skill with swords will get even better. The main problem with it is that touching iron causes pain to them - that is why they use weapons made from various rare metals."+{SPECIAL_NOTES}+{SPECIAL_NOTES_MAGICAL}+{SPECIAL_NOTES_ARCANE}+{SPECIAL_NOTES_LEADERSHIP}
     die_sound={SOUND_LIST:ELF_HIT}
     [portrait]

--- a/units/Elvish_Warlord.cfg
+++ b/units/Elvish_Warlord.cfg
@@ -22,12 +22,6 @@
     alignment=neutral
     advances_to=null
     cost=72
-#ifndef MULTIPLAYER
-    [advancefrom]
-        unit=Elvish Marshal
-        experience=260
-    [/advancefrom]
-#endif
     usage=fighter
     description= _ "Some elves are not so peace-loving as others, and intentionally seek war. They are not trying to start wars, just joining wars where they know which side is evil. Their skill at leading allies into combat is incredibly good, so that trying to outsmart an Elvish Warlord usually results in an even more humiliating defeat than fighting them using usual strategies."+{SPECIAL_NOTES}+{SPECIAL_NOTES_LEADERSHIP}
     die_sound={SOUND_LIST:ELF_HIT}

--- a/units/Exterminator.cfg
+++ b/units/Exterminator.cfg
@@ -14,12 +14,6 @@
     level=4
     alignment=chaotic
     advances_to=null
-#ifndef MULTIPLAYER
-    [advancefrom]
-        unit=Assassin
-        experience=300
-    [/advancefrom]
-#endif
     cost=60
     usage=fighter
     description= _ "Masters of the Assassins are almost always sent to slay their victims rather than to steal something. Their favourite technique is to stab enemies from behind with a dagger, but because not all murders can be done silently, they also practised standard combat, and carry a scythe they can wield with scary skill, that is particularly useful when surrounded. Deadly at night, exterminators are less able fighting under the sun."+{SPECIAL_NOTES}+{SPECIAL_NOTES_BACKSTAB}+{SPECIAL_NOTES_POISON}+{SPECIAL_NOTES_SKIRMISHER}

--- a/units/Forester.cfg
+++ b/units/Forester.cfg
@@ -14,12 +14,6 @@
     level=4
     alignment=chaotic
     advances_to=null
-#ifndef MULTIPLAYER
-    [advancefrom]
-        unit=Ranger
-        experience=300
-    [/advancefrom]
-#endif
     cost=80
     usage=mixed fighter
     description= _ "Foresters are people who abandoned the life with other people, craving for the solitude in wild places. They can live in places where others would lack food and shelter, and no animal can escape their precise shot.

--- a/units/Goblin_Ravager.cfg
+++ b/units/Goblin_Ravager.cfg
@@ -13,12 +13,6 @@
     level=3
     alignment=chaotic
     advances_to=null
-#ifndef MULTIPLAYER
-    [advancefrom]
-        unit=Goblin Pillager
-        experience=180
-    [/advancefrom]
-#endif
     cost=47
     usage=scout
     description= _ "To perform their destructive work effectively, Goblin Pillagers must be able to move fast. In the event of a shortage of wolves, another mount has to fill in. Though giant spiders are far less intelligent than wolves, the fear spread by their sight makes up for this imperfection. Taming those beasts claims high casualties and their appetite for riders in front of them is detrimental – but one has to overlook such little mishaps leniently: Goblins are numerous, useless for most other jobs, and since birth used to submit to their fates."+{SPECIAL_NOTES}+{SPECIAL_NOTES_SLOW}+{SPECIAL_NOTES_POISON}

--- a/units/Goblin_Warbaner.cfg
+++ b/units/Goblin_Warbaner.cfg
@@ -14,12 +14,6 @@
     level=2
     alignment=chaotic
     advances_to=null
-#ifndef MULTIPLAYER
-    [advancefrom]
-        unit=Goblin Rouser
-        experience=80
-    [/advancefrom]
-#endif
     cost=31
     usage=fighter
     description=_"Some goblins, after surviving an improbably high number of fights, become experienced enough to lead other goblins to battle, or even weaker orcs. These goblins are no longer bullied by orcs, but still used to lead a tiring force."

--- a/units/Grim_Knight.cfg
+++ b/units/Grim_Knight.cfg
@@ -18,20 +18,6 @@
     [/defense]
     cost=49
     usage=fighter
-#ifndef MULTIPLAYER
-    [advancefrom]
-        unit=Deathblade
-        experience=180
-    [/advancefrom]
-    [advancefrom]
-        unit=Chocobone LotI
-        experience=180
-    [/advancefrom]
-    [advancefrom]
-        unit=Chocobone
-        experience=180
-    [/advancefrom]
-#endif
     description= _ "Grim Knights are undead who can ride a living horse thanks to dark magic controlling the horse's mind and altering its body. Undead legions use them for approximately the same purposes as living armies use their horsemen."+{SPECIAL_NOTES}+{SPECIAL_NOTES_CHARGE}
     die_sound=horse-die.ogg
     [abilities]

--- a/units/Incarnation.cfg
+++ b/units/Incarnation.cfg
@@ -17,12 +17,6 @@
     advances_to=null
     cost=65
     usage=mixed fighter
-#ifndef MULTIPLAYER
-    [advancefrom]
-        unit=Elvish Shyde
-        experience=250
-    [/advancefrom]
-#endif
     description= _ "Some elves have gone so far on the faerie path, that they are much more a fairy than an elf. This gives them unearthly beauty and otherworldly powers commanding plants. However, this transformation also includes behavioural changes, and their integration into elvish society is problematic."+{SPECIAL_NOTES}+{SPECIAL_NOTES_SLOW}+{SPECIAL_NOTES_CURES}+{SPECIAL_NOTES_MAGICAL}+{SPECIAL_NOTES_DRAIN}+{SPECIAL_NOTES_POISON}+_" This unit regenerates, which allows it to heal as though always stationed in a village, if it is standing in a forest."
     die_sound={SOUND_LIST:ELF_FEMALE_HIT}
     [portrait]

--- a/units/Infernal_Knight.cfg
+++ b/units/Infernal_Knight.cfg
@@ -15,16 +15,6 @@
     level=4
     alignment=chaotic
     advances_to=null
-#ifndef MULTIPLAYER
-    [advancefrom]
-        unit=Death Knight
-        experience=270
-    [/advancefrom]
-    [advancefrom]
-        unit=Death Knight LotI
-        experience=270
-    [/advancefrom]
-#endif
     [resistance]
         fire=60
     [/resistance]

--- a/units/Lich_King.cfg
+++ b/units/Lich_King.cfg
@@ -14,20 +14,6 @@
     level=4
     alignment=chaotic
     advances_to=null
-#ifndef MULTIPLAYER
-    [advancefrom]
-        unit=Death Knight
-        experience=270
-    [/advancefrom]
-    [advancefrom]
-        unit=Death Knight LotI
-        experience=270
-    [/advancefrom]
-    [advancefrom]
-        unit=Lich
-        experience=300
-    [/advancefrom]
-#endif
     cost=60
     usage=fighter
     description= _ "Lich Kings are powerful undead warriors with free will and magic powers. Unlike other undead, they are not obeying a master, they are raising and controlling their minions, and unlike liches, they are leading their minions into battles."+{SPECIAL_NOTES}+{SPECIAL_NOTES_LEADERSHIP}+{SPECIAL_NOTES_MAGICAL}

--- a/units/Lunatic_Knight.cfg
+++ b/units/Lunatic_Knight.cfg
@@ -13,12 +13,6 @@
     level=3
     alignment=lawful
     advances_to=null
-#ifndef MULTIPLAYER
-    [advancefrom]
-        unit=Lancer
-        experience=200
-    [/advancefrom]
-#endif
     undead_variation=mounted
     cost=60
     usage=fighter

--- a/units/Monstrosity.cfg
+++ b/units/Monstrosity.cfg
@@ -15,12 +15,6 @@
     advances_to=null
     cost=26
     usage=fighter
-#ifndef MULTIPLAYER
-    [advancefrom]
-        unit=Soulless
-        experience=90
-    [/advancefrom]
-#endif
     [abilities]
         {ABILITY_DESPAIR 10}
     [/abilities]

--- a/units/Orcish_Nightblade.cfg
+++ b/units/Orcish_Nightblade.cfg
@@ -16,12 +16,6 @@
     level=3
     alignment=chaotic
     advances_to=null
-#ifndef MULTIPLAYER
-    [advancefrom]
-        unit=Orcish Slayer
-        experience=220
-    [/advancefrom]
-#endif
     cost=43
     usage=mixed fighter
     #textdomain wesnoth-units

--- a/units/Orcish_Strafer.cfg
+++ b/units/Orcish_Strafer.cfg
@@ -13,12 +13,6 @@
     level=4
     alignment=chaotic
     advances_to=null
-#ifndef MULTIPLAYER
-    [advancefrom]
-        unit=Orcish Slurbow
-        experience=280
-    [/advancefrom]
-#endif
     cost=61
     usage=archer
     description= _ "Orcs are generally believed to be simple-minded and unable even to manufacture their crossbows. But it is wrong. The intellect of orcs is not inferior by any means, but they usually prefer not to use it. But competition and battle prowess is usually far the greatest motivation, and if better gear looks like a possibility to get stronger, they start thinking about improvements. One of their inventions is the slurbow, some orcs get them from plunder, some manufacture them themselves. However, even slurbows are not the best, and some creative orcs in times of peace manage to improve it so that it can be operated with a single hand. This way, they can carry two ranged weapons into battle, and devastate most enemies with their deadly and quick shots."

--- a/units/Orcish_Warmonger.cfg
+++ b/units/Orcish_Warmonger.cfg
@@ -168,12 +168,6 @@
 
 [unit_type]
     id=Orcish Warmonger
-#ifndef MULTIPLAYER
-    [advancefrom]
-        unit=Orcish Warlord
-        experience=350
-    [/advancefrom]
-#endif
     [base_unit]
         id=Orcish Warmonger base
     [/base_unit]

--- a/units/Phantom.cfg
+++ b/units/Phantom.cfg
@@ -14,12 +14,6 @@
     alignment=chaotic
     advances_to=null
     cost=43
-#ifndef MULTIPLAYER
-    [advancefrom]
-        unit=Deathblade
-        experience=120
-    [/advancefrom]
-#endif
     [movement_costs]
         deep_water=2
         shallow_water=2

--- a/units/Pilum_Master.cfg
+++ b/units/Pilum_Master.cfg
@@ -13,12 +13,6 @@
     level=3
     alignment=lawful
     advances_to=null
-#ifndef MULTIPLAYER
-    [advancefrom]
-        unit=Javelineer
-        experience=200
-    [/advancefrom]
-#endif
     cost=39
     usage=fighter
     description= _ "Some javelineers came to an incredible skill with javelins, and improved their javelins into pilums. These weapons are hard to use, but they can deal heavy damages to anyone before they even come close enough to hit, even if they are attacked. Although many soldiers consider their weapons obsolete, they wield them proudly, because unlike swords or bows, pilums can be used both in melee and ranged combat."+{SPECIAL_NOTES}+{SPECIAL_NOTES_FIRSTSTRIKE}

--- a/units/Predator.cfg
+++ b/units/Predator.cfg
@@ -14,12 +14,6 @@
     level=4
     alignment=chaotic
     advances_to=null
-#ifndef MULTIPLAYER
-    [advancefrom]
-        unit=Huntsman
-        experience=320
-    [/advancefrom]
-#endif
     cost=71
     usage=archer
     description= _ "Master huntsmen often get to like hunting more than anything else. Their deadly passion guides them, and they care only a little if their prey is human or animal. These predators may attack anything they spot, if it is not too numerous. Provided that one has enough guards around, it is possible to parlay with them, or even to employ them."+{SPECIAL_NOTES}+{SPECIAL_NOTES_MARKSMAN}

--- a/units/Prophet.cfg
+++ b/units/Prophet.cfg
@@ -18,16 +18,6 @@
     undead_variation=mounted
     cost=74
     usage=healer
-#ifndef MULTIPLAYER
-    [advancefrom]
-        unit=Mage of Light
-        experience=300
-    [/advancefrom]
-    [advancefrom]
-        unit=Paladin
-        experience=300
-    [/advancefrom]
-#endif
     description= _ "Formerly either Paladins who decided to expand their knowledge of white magic or Magi of Light who decided that evil has to be defeated also by weapons of war, Prophets are the pious knights who both care about destroying the evil and about helping any righteous person."+{SPECIAL_NOTES}+{SPECIAL_NOTES_CHARGE}+{SPECIAL_NOTES_ARCANE}+{SPECIAL_NOTES_CURES}+{SPECIAL_NOTES_ILLUMINATES}
     die_sound=horse-die.ogg
     [portrait]

--- a/units/Reaper.cfg
+++ b/units/Reaper.cfg
@@ -15,12 +15,6 @@
     advances_to=null
     cost=70
     usage=scout
-#ifndef MULTIPLAYER
-    [advancefrom]
-        unit=Spectre
-        experience=300
-    [/advancefrom]
-#endif
     description= _ "Reapers are abominations, brought from the world of the dead into our world, but maintaining connections to their world to drain excessive amounts of power from it, longing for nothing else but bringing as many souls into the world of the dead. In most cases, they are a creation of a necromancer, forcing a spirit to become a reaper, manipulating it to do what he wants."+{SPECIAL_NOTES}+{SPECIAL_NOTES_DRAIN}+{SPECIAL_NOTES_SPIRIT}+{SPECIAL_NOTES_ARCANE}
     [abilities]
         {ABILITY_KILLHUNGER}

--- a/units/Scythemaster.cfg
+++ b/units/Scythemaster.cfg
@@ -13,12 +13,6 @@
     level=4
     alignment=lawful
     advances_to=null
-#ifndef MULTIPLAYER
-    [advancefrom]
-        unit=Halberdier
-        experience=300
-    [/advancefrom]
-#endif
     cost=60
     usage=fighter
     description= _ "The greatest weapon masters will eventually come to master scythes, whose dual-wielding is the most destructive possibility ever."+{SPECIAL_NOTES}+{SPECIAL_NOTES_FIRSTSTRIKE}

--- a/units/Seer.cfg
+++ b/units/Seer.cfg
@@ -17,12 +17,6 @@
     advances_to=null
     cost=76
     usage=mixed fighter
-#ifndef MULTIPLAYER
-    [advancefrom]
-        unit=Elvish Sylph
-        experience=500
-    [/advancefrom]
-#endif
     description= _ "Sometimes, an elf can get so close to the faerie world, that it grants her a knowledge all the other beings never even dreamed about. This allows her to be both a good healer and a powerful spell-caster."+{SPECIAL_NOTES}+{SPECIAL_NOTES_SLOW}+{SPECIAL_NOTES_HEALS}+{SPECIAL_NOTES_MAGICAL}
     die_sound={SOUND_LIST:ELF_FEMALE_HIT}
     [portrait]

--- a/units/Shadow_Prince.cfg
+++ b/units/Shadow_Prince.cfg
@@ -14,16 +14,6 @@
     level=4
     alignment=chaotic
     advances_to=null
-#ifndef MULTIPLAYER
-    [advancefrom]
-        unit=Fugitive
-        experience=300
-    [/advancefrom]
-    [advancefrom]
-        unit=Highwayman
-        experience=300
-    [/advancefrom]
-#endif
     cost=70
     usage=mixed fighter
     description= _ "After years of life as a criminal, the outlaw gains pride and no longer feels the need to behave like a brute. To teach the others that they are superior too, they learn some magic, and practise fighting with a staff that they used when learning magic. Their authority above other criminals is so great, that they can hide in any settlement."+{SPECIAL_NOTES}+{SPECIAL_NOTES_CONCEALMENT}

--- a/units/Shadowalker.cfg
+++ b/units/Shadowalker.cfg
@@ -14,12 +14,6 @@
     level=4
     alignment=neutral
     advances_to=null
-#ifndef MULTIPLAYER
-    [advancefrom]
-        unit=Master at Arms
-        experience=320
-    [/advancefrom]
-#endif
     cost=59
     usage=fighter
     description= _ "Sometimes, the most dextrous from all masters of combat become Shadowalkers, fighters whose skill with sword is unmatched. No longer requiring illumination to fight, they can fight equally well under the sun and in dark caves. If the situation is not ideal for fencing, they can shoot a poisoned bolt at their enemy or surprise him with an unexpected spell."+{SPECIAL_NOTES}+{SPECIAL_NOTES_BACKSTAB}+{SPECIAL_NOTES_POISON}+{SPECIAL_NOTES_SKIRMISHER}

--- a/units/Siege_Troll.cfg
+++ b/units/Siege_Troll.cfg
@@ -22,12 +22,6 @@
     alignment=chaotic
     advances_to=null
     undead_variation=troll
-#ifndef MULTIPLAYER
-    [advancefrom]
-        unit=Troll Warrior
-        experience=280
-    [/advancefrom]
-#endif
     cost=48
     description= _ "Trolls rarely use more than the most basic of equipment. The Orcish tribes will occasionally outfit the biggest, strongest, toughest Troll they can find with heavy armour and use it as a siege weapon."+{SPECIAL_NOTES}+{SPECIAL_NOTES_REGENERATES}
     die_sound={SOUND_LIST:TROLL_DIE}

--- a/units/Sky_Goblin.cfg
+++ b/units/Sky_Goblin.cfg
@@ -13,12 +13,6 @@
     level=2
     alignment=neutral
     advances_to=null
-#ifndef MULTIPLAYER
-    [advancefrom]
-        unit=Goblin Impaler
-        experience=90
-    [/advancefrom]
-#endif
     cost=26
     usage=scout
     description= _ "The best of goblin fighters get the right to ride giant birds, to scout terrains ahead and occasionally attack vulnerable units that they manage to approach."

--- a/units/Soul_Shooter.cfg
+++ b/units/Soul_Shooter.cfg
@@ -14,12 +14,6 @@
     alignment=chaotic
     advances_to=null
     cost=53
-#ifndef MULTIPLAYER
-    [advancefrom]
-        unit=Banebow
-        experience=280
-    [/advancefrom]
-#endif
     description= _ "Entrapped by the evil of their existence, their victims' souls frequently remain on the battlefield, too scared to leave into the world of the dead. Soul Shooters can exploit them by binding them into their arrows, making them incredibly powerful."+{SPECIAL_NOTES}+{SPECIAL_NOTES_SUBMERGE}
     usage=archer
     die_sound=skeleton-big-die.ogg

--- a/units/Sword_Mage.cfg
+++ b/units/Sword_Mage.cfg
@@ -15,17 +15,6 @@
     alignment=lawful
     advances_to=Knight of Magic
     cost=32
-#ifndef MULTIPLAYER
-    [advancefrom]
-        unit=Mage
-    [/advancefrom]
-    [advancefrom]
-        unit=Mage LotI
-    [/advancefrom]
-    [advancefrom]
-        unit=Fencer
-    [/advancefrom]
-#endif
     usage=fighter
     description= _ "Because both mages and fencers prefer not to use armours, some mages or fencers came to an idea to practise both with a sword and with spells. This is incredibly hard to learn, requiring them to study in libraries and practise sword fights with any fighter who happens to cross their way, such as silk-stocking duelists wandering around, itching after potential affronts. No matter if they are mages or fencers, they are always considered to be too different by their fellow mages or fencers, and are excluded. As a result, they dislike the society and argue with any possible comrade. Due to this, all allies adjacent to a Sword Mage do 20% less damage."+{SPECIAL_NOTES}+{SPECIAL_NOTES_MAGICAL}
     die_sound={SOUND_LIST:HUMAN_DIE}

--- a/units/Swordmaster.cfg
+++ b/units/Swordmaster.cfg
@@ -15,12 +15,6 @@
     alignment=lawful
     advances_to=null
     cost=57
-#ifndef MULTIPLAYER
-    [advancefrom]
-        unit=Royal Guard
-        experience=320
-    [/advancefrom]
-#endif
     description= _ "Some royal guards show a great expertise with swords, not only good defensive abilities, so they act as the main offensive force of defensive forces. Shattering the lines of enemy defence in times of war and protecting castles in times of peace, swordmasters are the greatest elite of human soldiers.
 
 Note: The ability upgrades may require some books to learn them from."

--- a/units/Troll_Boulderlobber.cfg
+++ b/units/Troll_Boulderlobber.cfg
@@ -25,12 +25,6 @@
     [abilities]
         {ABILITY_REGENERATES}
     [/abilities]
-#ifndef MULTIPLAYER
-    [advancefrom]
-        unit=Troll Rocklobber
-        experience=225
-    [/advancefrom]
-#endif
     [attack]
         name=fist
         description=_"fist"

--- a/units/Werewolf_Rider.cfg
+++ b/units/Werewolf_Rider.cfg
@@ -13,12 +13,6 @@
     level=4
     alignment=chaotic
     advances_to=null
-#ifndef MULTIPLAYER
-    [advancefrom]
-        unit=Direwolf Rider
-        experience=300
-    [/advancefrom]
-#endif
     [abilities]
         {ABILITY_MURDERLUST}
     [/abilities]

--- a/units/Zombie_Rider.cfg
+++ b/units/Zombie_Rider.cfg
@@ -15,20 +15,6 @@
     advances_to=null
     cost=49
     usage=scout
-#ifndef MULTIPLAYER
-    [advancefrom]
-        unit=Revenant
-        experience=180
-    [/advancefrom]
-    [advancefrom]
-        unit=Chocobone LotI
-        experience=180
-    [/advancefrom]
-    [advancefrom]
-        unit=Chocobone
-        experience=180
-    [/advancefrom]
-#endif
     description= _ "During undead invasions, not only humans, but also farm animals die and are resurrected into undeath. These undead animals can be ridden by skeletons, producing units that are both zombie and skeleton in nature."+{SPECIAL_NOTES}+{SPECIAL_NOTES_DEFENSE_CAP}
     die_sound={SOUND_LIST:ZOMBIE_HIT}
     {DEFENSE_ANIM "units/undead/zombie-rider-defend.png" "units/undead/zombie-rider.png" {SOUND_LIST:ZOMBIE_HIT} }

--- a/units/undead_advancements.cfg
+++ b/units/undead_advancements.cfg
@@ -6,14 +6,6 @@
     [/base_unit]
     hide_help=true
     do_not_list=yes
-#ifndef MULTIPLAYER
-    [advancefrom]
-        unit=Revenant
-    [/advancefrom]
-    [advancefrom]
-        unit=Revenant LotI
-    [/advancefrom]
-#endif
 [/unit_type]
 [unit_type]
     id=Chocobone LotI
@@ -22,11 +14,6 @@
     [base_unit]
         id=Chocobone
     [/base_unit]
-#ifndef MULTIPLAYER
-    [advancefrom]
-        unit=Skeleton
-    [/advancefrom]
-#endif
 [/unit_type]
 [unit_type]
     id=Revenant LotI
@@ -35,12 +22,6 @@
     [base_unit]
         id=Revenant
     [/base_unit]
-#ifndef MULTIPLAYER
-    [advancefrom]
-        unit=Soulless
-        experience=90
-    [/advancefrom]
-#endif
 [/unit_type]
 [unit_type]
     id=Bone Shooter LotI
@@ -49,10 +30,4 @@
     [base_unit]
         id=Bone Shooter
     [/base_unit]
-#ifndef MULTIPLAYER
-    [advancefrom]
-        unit=Soulless
-        experience=90
-    [/advancefrom]
-#endif
 [/unit_type]


### PR DESCRIPTION
So this is a new way how to do this in 1.16. Sorry for placing advancements without any definite order in a new file.

This patch is incompatible with 1.14. I updated the beta-uploading script chaning 1.14.x to 1.16.x in versions. I dunno if it works on 1.16 but at least it won't upload this incompatible version as beta for 1.14.

Also it seems like undead units like Skeleton LotI, Chocobone LotI now have rather no sense to have (they were a workaround to make advancements, right?). For compatibility I left the code for these unit types to have advancements but I deleted the code that made Skeleton advance into Chocobone LotI, for example, as now it's possible to just make it advance into standard Chocobone