### PR TITLE
Fixed zombie rider weapon special AMLAs.

### DIFF
--- a/units/Zombie_Rider.cfg
+++ b/units/Zombie_Rider.cfg
@@ -182,7 +182,7 @@
             [effect]
                 apply_to=attack
                 name=touch
-                remove_specials=plague
+                remove_specials="plague(Soulless)"
                 increase_damage=-1
                 [set_specials]
                     mode=append
@@ -194,14 +194,14 @@
         [advancement]
             max_times=1
             id=monstrosity
-            description= _ "causing enemies to become Soulless even if killed indirectly"
+            description= _ "transforming enemies into Monstrosities with the plague"
             image="attacks/touch-zombie.png"
             strict_amla=yes
             require_amla="soulless_infect"
             [effect]
                 apply_to=attack
                 name=touch
-                remove_specials=plague
+                remove_specials="greater infect"
                 increase_damage=-1
                 [set_specials]
                     mode=append


### PR DESCRIPTION
My Zombie Rider has plague (Soulless), greater infect and plague (Monstrosity) all at the same time. The monstrosity plague doesn't work. This seems to fix it.

Note that greater infect is removed when plague (Monstrosity) is added. Not sure if that's desired behavior, but they seem to be incompatible, so that's what I went with.