### PR TITLE
Replacement of {FORCE_CHANCE_TO_HIT} in order not to reset stats

### DIFF
--- a/scenarios1/09_Escape_from_Oblivion.cfg
+++ b/scenarios1/09_Escape_from_Oblivion.cfg
@@ -202,13 +202,90 @@
         [/message]
     [/event]
     #Let the player get a few zombies to have something to sacrifice.
-    {FORCE_CHANCE_TO_HIT side=1 type="Vampire Bat" 100 ()}
+    #It's not possible to use FORCE_CHANCE_TO_HIT because it resets our equip and amlas
+    #(it's implemented as object which is removed after the attack, remove_object resets all)
+    [event]
+        first_time_only=no
+        name=unit placed
+        [filter]
+            side=2
+            type="Vampire Bat"
+        [/filter]
+        [modify_unit]
+            [filter]
+                x,y = $unit.x,$unit.y
+            [/filter]
+            [object]
+                duration=forever
+                [effect]
+                    apply_to="new_ability"
+                    [abilities]
+                        [chance_to_hit]
+                            id=vulnerable_bat
+                            apply_to=opponent
+                            cumulative=no
+                            value=100
+                            [filter_self]
+                                [filter_wml]
+                                    [variables]
+                                        musthit=yes
+                                    [/variables]
+                                [/filter_wml]
+                            [/filter_self]
+                        [/chance_to_hit]
+                    [/abilities]
+                [/effect]
+            [/object]
+        [/modify_unit]
+    [/event]
+    [event]
+        first_time_only=no
+        name="attack"
+        [filter]
+            side=1
+        [/filter]
+        [filter_second]
+            type="Vampire Bat"
+        [/filter_second]
+        {VARIABLE second_unit.variables.musthit yes}
+        [unstore_unit]
+            variable=second_unit
+        [/unstore_unit]
+        [event]
+            name="attack end"
+            {VARIABLE second_unit.variables.musthit no}
+            [unstore_unit]
+                variable=second_unit
+            [/unstore_unit]
+        [/event]
+    [/event]
+    [event]
+        first_time_only=no
+        name="attack"
+        [filter]
+            type="Vampire Bat"
+        [/filter]
+        [filter_second]
+            side=1
+        [/filter_second]
+        {VARIABLE unit.variables.musthit yes}
+        [unstore_unit]
+            variable=unit
+        [/unstore_unit]
+        [event]
+            name="attack end"
+            {VARIABLE unit.variables.musthit no}
+            [unstore_unit]
+                variable=unit
+            [/unstore_unit]
+        [/event]
+    [/event]
 
     [event]
         name=turn 2
         [message]
             speaker=Efraim_de_Ceise
-            message= _ "I am still failing to understand why do you see so much romance in necromancy."		#Wordplay
+            message= _ "I am still failing to understand why do you see so much romance in necromancy."        #Wordplay
         [/message]
         [message]
             speaker=Lethalia


### PR DESCRIPTION
That's a bit clunky, tbh, it turns out I just copypasted the macroexpansion reversing the unit to add object on. Initially I wanted just to place this effect on all bats in "unit placed, side 2, Vampire Bat" event but with it the attack menu shows 100% chances. I don't think we want to show the player so obviously that we tweaked the chances about Vampire Bats, do we?

Things are yet to be fixed with bossed of the Bloodbath, although attacking them is a bit extraordinary event by itself