### PR TITLE
Switch Infernal King leader to Infernal Knight

### DIFF
--- a/scenarios3/06_Darkest_Darkness.cfg
+++ b/scenarios3/06_Darkest_Darkness.cfg
@@ -116,7 +116,7 @@
         [/ai]
     [/side]
     [side]
-        type=Infernal King
+        type=Infernal Knight
         generate_name=yes
         random_traits=yes
         side=5


### PR DESCRIPTION
The leader does not appear with type Infernal King. Based on the original change [here](https://github.com/Dugy/Legend_of_the_Invincibles/commit/dea189d37d1d9eb32d989b50a79d6aa4a087f906#diff-a4b7d243ef9cc503109fe1ee2340bf0441107e722c81536a43f53048e0b14dc0R134), I believe this is the intended unit type.
Found in:
Wesnoth 1.16
LotI 3.2.6.222gb6ec4a5