### PR TITLE
Enable Soulless to Necrophage through the [modify_unit_type] mechanism

### DIFF
--- a/extra_advancements.cfg
+++ b/extra_advancements.cfg
@@ -43,7 +43,7 @@
     
     [modify_unit_type]
         type="Soulless"
-        set_advances_to="Monstrosity,Bone Shooter,Revenant"
+        set_advances_to="Monstrosity,Bone Shooter,Revenant,Necrophage"
         set_experience=90
     [/modify_unit_type]
     

--- a/utils/global_events.cfg
+++ b/utils/global_events.cfg
@@ -2777,7 +2777,6 @@ $soul_eating"
                 {VARIABLE updated.advances_to "Abomination"}
             [/then]
         [/if]
-#endif
         [if]
             [variable]
                 name=updated.type
@@ -2787,6 +2786,7 @@ $soul_eating"
                 {VARIABLE updated.advances_to "Revenant,Bone Shooter,Monstrosity,Necrophage"}
             [/then]
         [/if]
+#endif
     [/event]
 
 #enddef


### PR DESCRIPTION
post advance now needed only for MP