### PR TITLE
Don't run initial update_stats on already updated units

### DIFF
--- a/utils/global_events.cfg
+++ b/utils/global_events.cfg
@@ -536,6 +536,13 @@
                         [/variables]
                     [/filter_wml]
                 [/not]
+                [not]
+                    [filter_wml]
+                        [variables]
+                            updated=yes
+                        [/variables]
+                    [/filter_wml]
+                [/not]
             [/filter]
             {UPDATE_STATS}
         [/event]


### PR DESCRIPTION
#390 was still broken for older saves. If the player advanced his AMLA unit without update_started=yes set, it got recalced and the advancement was reverted. Here is a replay with demonstration.

[LotI1-Shadow Empire replay 20220105-062727Bugged.gz](https://github.com/Dugy/Legend_of_the_Invincibles/files/7811704/LotI1-Shadow.Empire.replay.20220105-062727Bugged.gz)

The problem is that unit placed event didn't check "updated=yes", only "update_started=yes". But update_started wasn't set before the first bug-related patch https://github.com/Dugy/Legend_of_the_Invincibles/blame/9929fd0778dfa2c06830c819c16ca6c2272095ee/lua/stats.lua#L45 so in the older saves only "updated=yes" is set but "update_started=yes" is not. But if "updated=yes" is set, it means the unit has been updated at least once so no reason to run initializing update_stats again.