### PR TITLE
Reverting one {FOREACH} to [foreach] replacement because traders didn't see descriptions

### DIFF
--- a/utils/items.cfg
+++ b/utils/items.cfg
@@ -59,17 +59,13 @@
             {ITEM_LIST}
         [/literal]
     [/set_variables]
-    [foreach]
-        array=item_list.object
-        index_var=item_number
-        [do]
-            [describe_object]
-                number=$item_list.object[$item_number].number
-                sort=$item_list.object[$item_number].sort
-                output=item_list.object[$item_number].description
-            [/describe_object]
-        [/do]
-    [/foreach]
+    {FOREACH item_list.object item_number}
+        [describe_object]
+            number=$item_list.object[$item_number].number
+            sort=$item_list.object[$item_number].sort
+            output=item_list.object[$item_number].description
+        [/describe_object]
+    {NEXT item_number}
     [clear_item_list_cache]
     [/clear_item_list_cache]
     [set_variables]		#Item types are used in the code, and translating them will cause errors. This should make the usage of language names easy


### PR DESCRIPTION
0e06fb78fa64a07481178747ac5ad54991f00aa1 introduced this, and it seems [foreach] somehow reset the change made by [describe_object], as a result descriptions are empty after leaving the cycle

The consequence of this is that traders don't show info about items to buy
![изображение](https://user-images.githubusercontent.com/68666085/148312738-78cef0a1-411d-49eb-9950-0e303e5f04fc.png)

Pity I didn't notice it two days ago when I was in another scenario with a trader