### PR TITLE
Fix cumulative leadership (considering Wesnoth bug)

### DIFF
--- a/units/Flower_of_Evil.cfg
+++ b/units/Flower_of_Evil.cfg
@@ -71,8 +71,8 @@
             {WEAPON_SPECIAL_SLOW}
             [chance_to_hit]
                 id=marksman
-                name= _ "marksman"
-                description= _ "When used offensively, this attack always has at least a 60% chance to hit."
+                name= _ "assisted marksman"
+                description= _ "When used offensively, this attack always has at least a 60% chance to hit if any allied Deathshrooms or Hatredshrooms are near this unit."
                 value=60
                 cumulative=yes
                 active_on=offense

--- a/utils/abilities.cfg
+++ b/utils/abilities.cfg
@@ -543,7 +543,7 @@ Enemy units cannot see this unit during dawn or dusk, except if they have units 
 #define ABILITY_EXTRA_DAMAGE_AURA NAME INTENSITY
     [leadership]
         id=extra damage aura {INTENSITY}
-        value={INTENSITY}
+        add={INTENSITY}
         cumulative=yes
         name={NAME}+_" ("+{INTENSITY}+_")"
         female_name={NAME}+_" ("+{INTENSITY}+_")"

--- a/utils/amla.cfg
+++ b/utils/amla.cfg
@@ -2956,7 +2956,7 @@
             [abilities]
                 [leadership]
                     id=Legacy of Kings
-                    value=15
+                    add=15
                     cumulative=yes
                     name= _ "Legacy of Kings"
                     description= _ "This unit can lead your units that are next to it, making them fight better.
@@ -3005,7 +3005,7 @@ Adjacent own units will do 15% more damage and will have 10% better resistances.
             [abilities]
                 [leadership]
                     id=Legacy of Kings
-                    value=20
+                    add=20
                     cumulative=yes
                     name= _ "Legacy of Kings"
                     description= _ "This unit can lead your own units that are next to it, making them fight better.
@@ -3054,7 +3054,7 @@ Adjacent own units will do 20% more damage and will have 15% better resistances.
             [abilities]
                 [leadership]
                     id=Legacy of Kings
-                    value=25
+                    add=25
                     cumulative=yes
                     name= _ "Legacy of Kings"
                     description= _ "This unit can lead your own units that are next to it, making them fight better.


### PR DESCRIPTION
Wesnoth has a bug (https://github.com/wesnoth/wesnoth/issues/6466 ) in 1.16 that cumulative leadership doesn't work with value= attribute, but works with add=. It can't be fixed in 1.16, only in 1.17, so replacing value= with add= is the option to fix rn for addons.