### PR TITLE
Little fixes for Ice Wraith

### DIFF
--- a/scenarios7/05_Tundra.cfg
+++ b/scenarios7/05_Tundra.cfg
@@ -516,14 +516,18 @@ You can build a keep anywhere for 50 gold (see options in the right-click menu).
             [/variable]
             [then]
                 {VARIABLE_OP teleport_wait add 1}
-                {VARIABLE_OP random random (0,0,1)}
+                {VARIABLE_OP random rand (0,0,1)}
                 [if]
                     [variable]
                         name=random
                         equals=1
                     [/variable]
                     [then]
-                        {GENERIC_UNIT 7 "Ice Spirit,Ice Wraith" 51 1}
+                        #ifdef HARD
+                        {GENERIC_UNIT 7 "Ice Wraith" 51 1}
+                        #else
+                        {GENERIC_UNIT 7 "Ice Spirit" 51 1}
+                        #endif
                     [/then]
                 [/if]
                 {CLEAR_VARIABLE random}

--- a/units/Ice_Wraith.cfg
+++ b/units/Ice_Wraith.cfg
@@ -32,7 +32,7 @@
             image="units/enemies/icewraith.png:200"
         [/frame]
     [/movement_anim]
-    hitpoints=41
+    hitpoints=51
     movement_type=drakefly
     [defense]
         frozen=40


### PR DESCRIPTION
Turned out Tundra spawn was broken, with random instead of rand. Also I think we can't provide a list in GENERIC_UNIT macro, so I split them by difficulty

Also Ice Wraith had less hp than Ice Spirit, dunno if that was intentional, buffed a little bit.

Also, I would note that the portrait of Fire Wraith is set for Ice Wrait, not recoloured one, I think you may recolour it or just delete the portrait for the unit