### PR TITLE
Fixing skipping tutorial #414

### DIFF
--- a/scenarios1/00_Tutorial.cfg
+++ b/scenarios1/00_Tutorial.cfg
@@ -271,6 +271,7 @@
                 [command]
                     # Make sure everything that happens in the tutorial still happens
                     {STRIP_DELENIA}
+                    {GENERATE_ITEM_LIST}
                     [modify_unit]
                         [filter]
                             id=Efraim_de_Ceise
@@ -288,6 +289,7 @@
                             local efraim = wesnoth.units.find_on_map{ id = "Efraim_de_Ceise" }[1]
                             loti.item.on_unit.add(efraim, 605) -- Sword of Krux
                             loti.item.on_unit.add(efraim, 130) -- Potion of Steel Skin
+                            loti.item.storage.add(41) -- Leather Armour
                         >>
                     [/lua]
                     [endlevel]


### PR DESCRIPTION
The latest fix was only for 1.17 item system bug. The tutorial skip wasn't fixed