### PR TITLE
Make legacy choice depend on the last byte of unit's id

### DIFF
--- a/lua/stats.lua
+++ b/lua/stats.lua
@@ -18,6 +18,9 @@ local function get_random_seed_from_unit(unit)
 	if unit.race and string.len(unit.race) > 0 then
 		seed = (seed << 3) ~ string.byte(unit.race)
 	end
+	if unit.id and string.len(unit.id) > 0 then
+		seed = (seed << 3) ~ string.byte(unit.id,string.len(unit.id))
+	end
 	local base_seed = wml.variables["base_seed"]
 	if not base_seed then
 		base_seed = 0


### PR DESCRIPTION
What was a bit troubling for me in the current legacy-assignment scheme is that if you recruit the same unit type on the same castle hex over and over again, they will always have the same legacy. This way it would depend on the id of an individual unit as well. The last byte chosen because unit's ids are normally something like Unittype-67, so the last byte will differ when recruits go sequentially. Of course, the inner perfectionist tells me that it allows only 10 different legacies out of 12 for a unit type on a given hex, but putting a full-scale hash function seems like an overkill, the last byte of id is reasonably simple.

This shouldn't cause OOS in replays unless someone discovers a unit's legacy in the same scenario as he got the unit, but this is not a standard situation