### PR TITLE
Fix great spells resetting stats if not used in chapter 5

### DIFF
--- a/utils/chapter5_utils.cfg
+++ b/utils/chapter5_utils.cfg
@@ -1501,6 +1501,16 @@ Spells remaining: " + ${VARIABLE_NAME}
         {CLEAR_VARIABLE gifted}
         {CLEAR_VARIABLE gifted2}
     [/event]
+    
+    # Efraim and Lethalia can get scenario-long attacks (meteor, lava) but don't use them. As they are installed as objects with scenario TTL,
+    # in the end of the scenario they are cleared and units rebuilt from scratch, so we need to rerun update_stats to have all LotI effects back   
+    [event]
+        name=start
+        [update_stats]
+            side=1
+            canrecruit=yes
+        [/update_stats]
+    [/event]
 
     {DROPS 10 13 (sword,sword,sword,bow,bow,bow,staff,staff,staff,axe,axe,axe,xbow,dagger,knife,mace,mace,spear) yes 2,3,4,5}
     [event]


### PR DESCRIPTION
Instead of writing some extra logic to gracefully remove them, I think we may just update_stats of Efraim and Lethalia at the start of all scenarios? It won't be too much burden, will it?