### PR TITLE
Fixing unforgiving ability

### DIFF
--- a/utils/abilities.cfg
+++ b/utils/abilities.cfg
@@ -797,6 +797,7 @@ A unit cared for by this healer may heal up to "+{VALUE}+_" HP per turn, or be c
         [/affect_adjacent]
     [/heals]
     [heals]
+        # this is needed for healing of incinerating, unholy hunger etc
         id=healing
     [/heals]
 #enddef

--- a/utils/abilities_events.cfg
+++ b/utils/abilities_events.cfg
@@ -5542,26 +5542,41 @@
             [/filter_wml]
         [/filter]
         {VARIABLE has_it false}
-        {FOREACH second_unit.variables.unforgiven i}
-            [if]
-                [variable]
-                    name=unit.variables.unforgiven[$i].type
-                    equals=$second_unit.type
-                [/variable]
-                [then]
-                    {VARIABLE has_it true}
-                [/then]
-            [/if]
-        {NEXT i}
-        [harm_unit]
-            [filter]
-                find_in=second_unit
-            [/filter]
-            amount="$($weapon.damage/2)"
-            damage_type=fire
-            fire_event=yes
-            animate=no
-        [/harm_unit]
+        [foreach]
+            array=unit.variables.unforgiven
+            variable=unforgiven_entry
+            [do]
+                [if]
+                    [variable]
+                        name=unforgiven_entry.type
+                        equals=$second_unit.type
+                    [/variable]
+                    [then]
+                        {VARIABLE has_it true}
+                    [/then]
+                [/if]
+            [/do]
+        [/foreach]
+        [if]
+            [variable]
+                name=has_it
+                boolean_equals=true
+            [/variable]
+            [then]
+                [harm_unit_loti]
+                    [filter]
+                        find_in=second_unit
+                    [/filter]
+                    [filter_second]
+                        find_in=unit
+                    [/filter_second]
+                    amount="$($weapon.damage/2)"
+                    damage_type=fire
+                    fire_event=yes
+                    animate=no
+                [/harm_unit_loti]
+            [/then]
+        [/if]
         {CLEAR_VARIABLE has_it}
     [/event]
 
@@ -5593,7 +5608,7 @@
                         {VARIABLE has_something true}
                     [/then]
                     [else]
-                        {CLEAR_VARIABLE unforgiving[$i].variables.unforgiven[$j}
+                        {CLEAR_VARIABLE unforgiving[$i].variables.unforgiven[$j]}
                     [/else]
                 [/if]
             {NEXT j}


### PR DESCRIPTION
Unforgiving was broken in several ways. First, it didn't reset the variable after 5 turns. Second, in reality it applied to any attack, not only on those unforgiven unit types. And third, on offense it used [harm_loti] without a harmer, so the unit didn't get XP, soul counts, etc (it was considered that the target just died, not killed by the unforgiving attacker)

Also added a comment for recent healing fix, in order not to forget in the future why it's there