### PR TITLE
Default values for some items and Boulderlobber's xp

### DIFF
--- a/units/Troll_Boulderlobber.cfg
+++ b/units/Troll_Boulderlobber.cfg
@@ -13,6 +13,7 @@
     hitpoints=62
     movement_type=largefoot
     movement=5
+    experience=100
     {QUANTITY experience 70 85 100}
     level=3
     alignment=chaotic

--- a/utils/item_list.cfg
+++ b/utils/item_list.cfg
@@ -2414,6 +2414,7 @@ defeat your foes mace to face."
         drop=1
         expanded_drop=2
         gladiators_drop=2
+        damage=10
         {QUANTITY damage 30 20 10}
         attacks=1
         [latent]
@@ -7746,7 +7747,9 @@ Showshaunshog proved him wrong by collecting condensed water from smoke."
         sort=sword
         expanded_drop=2
         gladiators_drop=2
+        damage=35
         {QUANTITY damage 65 50 35}
+        attacks=5
         {QUANTITY attacks 25 15 5}
         [latent]
             desc= _ "<span color='purple'>2 to base melee damage (requires Transformed Flesh)</span>"
@@ -7882,7 +7885,9 @@ Showshaunshog proved him wrong by collecting condensed water from smoke."
         sort=amulet
         expanded_drop=1
         gladiators_drop=1
+        magic=40
         {QUANTITY magic 50 45 40}
+        damage=-85
         {QUANTITY damage -65 -75 -85}
         flavour=_"Wizards do not need manual skills."
     [/object]
@@ -7979,6 +7984,7 @@ Showshaunshog proved him wrong by collecting condensed water from smoke."
             apply_to=movement
             increase=4
         [/effect]
+        damage=-90
         {QUANTITY damage -70 -80 -90}
         flavour=_"The best runners are too thin to fight."
     [/object]
@@ -9133,6 +9139,7 @@ Showshaunshog proved him wrong by collecting condensed water from smoke."
         sapphires=0
         black_pearls=0
         magic=10
+        damage=0
         {QUANTITY damage 40 20 0}
         [specials]
             {WEAPON_SPECIAL_MIND_RAID}


### PR DESCRIPTION
Some stats of items and units depend on the difficulty with QUANTITY macro. But some of them lacked the default number. When used in addons that don't have difficulty levels (so neither EASY, NORMAL or HARD defined) QUANTITY macro doesn't set any value. So items have no effect at all and Boulderlobber has no defined xp threshold for amla