### PR TITLE
Close the [unit_type] tag

### DIFF
--- a/units/Abomination.cfg
+++ b/units/Abomination.cfg
@@ -327,3 +327,4 @@
             {AMLA_DEFAULT_BONUSES}
         [/advancement]
     ) "Abomination"}
+[/unit_type]

--- a/units/Akula.cfg
+++ b/units/Akula.cfg
@@ -334,3 +334,4 @@
     [/effect]
     {AMLA_DEFAULT_BONUSES}
 [/advancement]) "Akula"}
+[/unit_type]

--- a/units/Ancient_Lich.cfg
+++ b/units/Ancient_Lich.cfg
@@ -365,3 +365,4 @@
         increase=1
     [/effect]
 [/advancement]) "09 Ancient Lich"}
+[/unit_type]

--- a/units/Arch_Necromancer.cfg
+++ b/units/Arch_Necromancer.cfg
@@ -457,3 +457,4 @@
             [/effect]
         [/advancement]
     ) "Arch Necromancer"}
+[/unit_type]

--- a/units/Argan_lich.cfg
+++ b/units/Argan_lich.cfg
@@ -1083,5 +1083,5 @@ Advancements with crossbow add great precision."
             {GREATER_AMLA_DEFAULT_BONUSES}
         [/advancement]
     ) "Argan_lich"}
-
+[/unit_type]
 #undef LIGHTNING

--- a/units/Blackguard.cfg
+++ b/units/Blackguard.cfg
@@ -201,3 +201,4 @@
     {AMLA_DEFAULT_BONUSES}
 [/advancement]
 ) "Blackguard"}
+[/unit_type]

--- a/units/Celestial_Messenger.cfg
+++ b/units/Celestial_Messenger.cfg
@@ -771,3 +771,4 @@ Thanks to the feathered wings on their backs, they can travel much faster throug
             {AMLA_DEFAULT_BONUSES}
         [/advancement]
     ) "Celestial Messenger"}
+[/unit_type]

--- a/units/Champion.cfg
+++ b/units/Champion.cfg
@@ -487,3 +487,4 @@ Advancements are defense-oriented, this unit's potential in avoiding hits is the
             [/effect]
         [/advancement]
     ) "Champion"}
+[/unit_type]

--- a/units/Champion_Bowman.cfg
+++ b/units/Champion_Bowman.cfg
@@ -337,3 +337,4 @@
             {AMLA_DEFAULT_BONUSES}
         [/advancement]
     ) "Champion Bowman"}
+[/unit_type]

--- a/units/Chaos_Rider.cfg
+++ b/units/Chaos_Rider.cfg
@@ -321,3 +321,4 @@
             {AMLA_DEFAULT_BONUSES}
         [/advancement]
     ) "Chaos Rider"}
+[/unit_type]

--- a/units/Dark_Shade.cfg
+++ b/units/Dark_Shade.cfg
@@ -358,3 +358,4 @@
             [/effect]
         [/advancement]
     ) "Dark Shade"}
+[/unit_type]

--- a/units/Deathlord.cfg
+++ b/units/Deathlord.cfg
@@ -348,3 +348,4 @@
             {AMLA_DEFAULT_BONUSES}
         [/advancement]
     ) "Deathlord"}
+[/unit_type]

--- a/units/Delly_lich.cfg
+++ b/units/Delly_lich.cfg
@@ -865,5 +865,5 @@
             [/effect]
         [/advancement]
     ) "Delly_lich"}
-
+[/unit_type]
 #undef LIGHTNING

--- a/units/Delly_start.cfg
+++ b/units/Delly_start.cfg
@@ -443,3 +443,4 @@
             [/effect]
         [/advancement]
     ) "Delly_start"}
+[/unit_type]

--- a/units/Demilich.cfg
+++ b/units/Demilich.cfg
@@ -418,3 +418,4 @@
                 increase=1
             [/effect]
         [/advancement]) "Demilich"}
+[/unit_type]

--- a/units/Destroyer.cfg
+++ b/units/Destroyer.cfg
@@ -261,3 +261,4 @@ Note: Destroyers can learn berserk."
             {AMLA_DEFAULT_BONUSES}
         [/advancement]
     ) "Destroyer"}
+[/unit_type]

--- a/units/Dragon_Rider.cfg
+++ b/units/Dragon_Rider.cfg
@@ -540,3 +540,4 @@
             {AMLA_DEFAULT_BONUSES}
         [/advancement]
     ) "Dragon Rider"}
+[/unit_type]

--- a/units/Duelist_Wizard.cfg
+++ b/units/Duelist_Wizard.cfg
@@ -668,3 +668,4 @@
             {AMLA_DEFAULT_BONUSES}
         [/advancement]
     ) "Duelist Wizard"}
+[/unit_type]

--- a/units/Duke.cfg
+++ b/units/Duke.cfg
@@ -331,3 +331,4 @@
             {AMLA_DEFAULT_BONUSES}
         [/advancement]
     ) "Duke"}
+[/unit_type]

--- a/units/Dwarvish_Battlerager.cfg
+++ b/units/Dwarvish_Battlerager.cfg
@@ -229,3 +229,4 @@
             [/effect]
         [/advancement]
     ) "Dwarvish Battlerager"}
+[/unit_type]

--- a/units/Dwarvish_Hero.cfg
+++ b/units/Dwarvish_Hero.cfg
@@ -489,5 +489,5 @@
             [/effect]
         [/advancement]
     ) "Dwarvish Hero"}
-
+[/unit_type]
 #undef LIGHTNING

--- a/units/Dwarvish_Protector.cfg
+++ b/units/Dwarvish_Protector.cfg
@@ -325,3 +325,4 @@
             [/effect]
         [/advancement]
     ) "Dwarvish Protector"}
+[/unit_type]

--- a/units/Dwarvish_Technocrat.cfg
+++ b/units/Dwarvish_Technocrat.cfg
@@ -406,3 +406,4 @@
             [/effect]
         [/advancement]
     ) "Dwarvish Technocrat"}
+[/unit_type]

--- a/units/Efraim_doppelganger.cfg
+++ b/units/Efraim_doppelganger.cfg
@@ -847,5 +847,5 @@
             {AMLA_DEFAULT_BONUSES}
         [/advancement]
     ) "Efraim_doppelganger"}
-
+[/unit_type]
 #undef LIGHTNING

--- a/units/Efraim_god.cfg
+++ b/units/Efraim_god.cfg
@@ -1937,5 +1937,5 @@ The leadership is equal to the leadership of a level 5 unit."
             {IMPROVED_AMLA_DEFAULT_BONUSES}
         [/advancement]
     ) "Efraim_god"}
-
+[/unit_type]
 #undef LIGHTNING

--- a/units/Efraim_lich-weakened.cfg
+++ b/units/Efraim_lich-weakened.cfg
@@ -743,3 +743,4 @@
             {GREATER_AMLA_DEFAULT_BONUSES}
         [/advancement]
     ) "Efraim_lich_weakened"}
+[/unit_type]

--- a/units/Efraim_lich.cfg
+++ b/units/Efraim_lich.cfg
@@ -1786,5 +1786,5 @@ Try to avoid learning from books, because while normal advancements add 20 to ma
             {GREATER_AMLA_DEFAULT_BONUSES}
         [/advancement]
     ) "Efraim_lich"}
-
+[/unit_type]
 #undef LIGHTNING

--- a/units/Elder_Mage.cfg
+++ b/units/Elder_Mage.cfg
@@ -959,6 +959,6 @@
             {AMLA_DEFAULT_BONUSES}
         [/advancement]
     ) "Elder Mage LotI"}
-
+[/unit_type]
 #undef ELDER_MAGE_LIGHTNING
 #undef ELDER_MAGE_FEMALE_LIGHTNING

--- a/units/Elvish_Assassin.cfg
+++ b/units/Elvish_Assassin.cfg
@@ -582,3 +582,4 @@
             {AMLA_DEFAULT_BONUSES}
         [/advancement]
     ) "Elvish Assassin"}
+[/unit_type]

--- a/units/Elvish_Gryphon_Rider.cfg
+++ b/units/Elvish_Gryphon_Rider.cfg
@@ -546,3 +546,4 @@
             {AMLA_DEFAULT_BONUSES}
         [/advancement]
     ) "Elvish Gryphon Rider"}
+[/unit_type]

--- a/units/Elvish_Juggernaut.cfg
+++ b/units/Elvish_Juggernaut.cfg
@@ -503,3 +503,4 @@
             {AMLA_DEFAULT_BONUSES}
         [/advancement]
     ) "Elvish Juggernaut"}
+[/unit_type]

--- a/units/Elvish_Nightprowler.cfg
+++ b/units/Elvish_Nightprowler.cfg
@@ -480,3 +480,4 @@
             {AMLA_DEFAULT_BONUSES}
         [/advancement]
     ) "Elvish Nightprowler"}
+[/unit_type]

--- a/units/Elvish_Overlord.cfg
+++ b/units/Elvish_Overlord.cfg
@@ -507,3 +507,4 @@
             {AMLA_DEFAULT_BONUSES}
         [/advancement]
     ) "Elvish Overlord"}
+[/unit_type]

--- a/units/Elvish_Warlord.cfg
+++ b/units/Elvish_Warlord.cfg
@@ -446,3 +446,4 @@
             {AMLA_DEFAULT_BONUSES}
         [/advancement]
     ) "Elvish Warlord"}
+[/unit_type]

--- a/units/Exterminator.cfg
+++ b/units/Exterminator.cfg
@@ -637,3 +637,4 @@
             [/effect]
         [/advancement]
     ) "Exterminator"}
+[/unit_type]

--- a/units/Forester.cfg
+++ b/units/Forester.cfg
@@ -387,3 +387,4 @@ Due to their solitude, they lack any relation to other humans, and so they do no
             {AMLA_DEFAULT_BONUSES}
         [/advancement]
     ) "Forester"}
+[/unit_type]

--- a/units/Goblin_Ravager.cfg
+++ b/units/Goblin_Ravager.cfg
@@ -419,3 +419,4 @@
             {AMLA_DEFAULT_BONUSES}
         [/advancement]
     ) "Goblin Ravager"}
+[/unit_type]

--- a/units/Goblin_Warbaner.cfg
+++ b/units/Goblin_Warbaner.cfg
@@ -380,3 +380,4 @@
             {AMLA_DEFAULT_BONUSES}
         [/advancement]
     ) "Goblin Warbanner"}
+[/unit_type]

--- a/units/Grim_Knight.cfg
+++ b/units/Grim_Knight.cfg
@@ -337,3 +337,4 @@
             {AMLA_DEFAULT_BONUSES}
         [/advancement]
     ) "Grim Knight"}
+[/unit_type]

--- a/units/Incarnation.cfg
+++ b/units/Incarnation.cfg
@@ -634,3 +634,4 @@
             [/effect]
         [/advancement]
     ) "Faerie Incarnation"}
+[/unit_type]

--- a/units/Infernal_Knight.cfg
+++ b/units/Infernal_Knight.cfg
@@ -341,3 +341,4 @@
             [/effect]
         [/advancement]
     ) "Infernal Knight"}
+[/unit_type]

--- a/units/Krux.cfg
+++ b/units/Krux.cfg
@@ -1189,5 +1189,5 @@ Being an offspring of an elf and human, he looks like a human to elves and like 
             [/effect]
         [/advancement]
     ) "Krux"}
-
+[/unit_type]
 #undef SPECTRAL_BLADE_MISSILE

--- a/units/Krux_later.cfg
+++ b/units/Krux_later.cfg
@@ -1285,5 +1285,5 @@ Being an offspring of an elf and human, he looks like a human to elves and like 
             [/effect]
         [/advancement]
     ) "Krux_later"}
-
+[/unit_type]
 #undef SPECTRAL_BLADE_MISSILE

--- a/units/Lethalia_doppelganger.cfg
+++ b/units/Lethalia_doppelganger.cfg
@@ -1014,5 +1014,5 @@
             {AMLA_DEFAULT_BONUSES}
         [/advancement]
     ) "Lethalia_doppelganger"}
-
+[/unit_type]
 #undef LIGHTNING

--- a/units/Lethalia_evil_good.cfg
+++ b/units/Lethalia_evil_good.cfg
@@ -719,5 +719,5 @@
             {AMLA_DEFAULT_BONUSES}
         [/advancement]
     ) "Lethalia_evil_good"}
-
+[/unit_type]
 #undef RED_LIGHTNING

--- a/units/Lethalia_god.cfg
+++ b/units/Lethalia_god.cfg
@@ -2125,5 +2125,5 @@
             {IMPROVED_AMLA_DEFAULT_BONUSES}
         [/advancement]
     ) "Lethalia_god"}
-
+[/unit_type]
 #undef LIGHTNING

--- a/units/Lethalia_lich-weakened.cfg
+++ b/units/Lethalia_lich-weakened.cfg
@@ -529,3 +529,4 @@
             {GREATER_AMLA_DEFAULT_BONUSES}
         [/advancement]
     ) "Lethalia_lich_weakened"}
+[/unit_type]

--- a/units/Lethalia_lich.cfg
+++ b/units/Lethalia_lich.cfg
@@ -2100,5 +2100,5 @@ Try to avoid learning from books, because while normal advancements add 20 to ma
             {GREATER_AMLA_DEFAULT_BONUSES}
         [/advancement]
     ) "Lethalia_lich"}
-
+[/unit_type]
 #undef LIGHTNING

--- a/units/Lich_King.cfg
+++ b/units/Lich_King.cfg
@@ -412,3 +412,4 @@
             [/effect]
         [/advancement]
     ) "Lich King"}
+[/unit_type]

--- a/units/Lilith_ally.cfg
+++ b/units/Lilith_ally.cfg
@@ -851,5 +851,5 @@
             {AMLA_DEFAULT_BONUSES}
         [/advancement]
     ) "Lilith_ally"}
-
+[/unit_type]
 #undef BATTLE_AXE_MISSILE

--- a/units/Lunatic_Knight.cfg
+++ b/units/Lunatic_Knight.cfg
@@ -262,3 +262,4 @@
             {AMLA_DEFAULT_BONUSES}
         [/advancement]
     ) "Lunatic Knight"}
+[/unit_type]

--- a/units/Monstrosity.cfg
+++ b/units/Monstrosity.cfg
@@ -275,3 +275,4 @@
             {AMLA_DEFAULT_BONUSES}
         [/advancement]
     ) "Monstrosity"}
+[/unit_type]

--- a/units/Orcish_Nightblade.cfg
+++ b/units/Orcish_Nightblade.cfg
@@ -462,3 +462,4 @@
             {AMLA_DEFAULT_BONUSES}
         [/advancement]
     ) "Orcish Nightblade loti"}
+[/unit_type]

--- a/units/Orcish_Strafer.cfg
+++ b/units/Orcish_Strafer.cfg
@@ -509,3 +509,4 @@
             {AMLA_DEFAULT_BONUSES}
         [/advancement]
     ) "Orcish Strafer"}
+[/unit_type]

--- a/units/Orcish_Warmonger.cfg
+++ b/units/Orcish_Warmonger.cfg
@@ -508,3 +508,4 @@
             {AMLA_DEFAULT_BONUSES}
         [/advancement]
     ) "Orcish Warmonger"}
+[/unit_type]

--- a/units/Phantom.cfg
+++ b/units/Phantom.cfg
@@ -316,3 +316,4 @@
             {AMLA_DEFAULT_BONUSES}
         [/advancement]
     ) "Phantom"}
+[/unit_type]

--- a/units/Pilum_Master.cfg
+++ b/units/Pilum_Master.cfg
@@ -315,3 +315,4 @@
             [/effect]
         [/advancement]
     ) "Pilum Master"}
+[/unit_type]

--- a/units/Predator.cfg
+++ b/units/Predator.cfg
@@ -431,3 +431,4 @@
             {AMLA_DEFAULT_BONUSES}
         [/advancement]
     ) "Predator"}
+[/unit_type]

--- a/units/Prophet.cfg
+++ b/units/Prophet.cfg
@@ -686,3 +686,4 @@
             {AMLA_DEFAULT_BONUSES}
         [/advancement]
     ) "Prophet"}
+[/unit_type]

--- a/units/Reaper.cfg
+++ b/units/Reaper.cfg
@@ -454,3 +454,4 @@
             [/effect]
         [/advancement]
     ) "Reaper"}
+[/unit_type]

--- a/units/Scythemaster.cfg
+++ b/units/Scythemaster.cfg
@@ -337,3 +337,4 @@
             {AMLA_DEFAULT_BONUSES}
         [/advancement]
     ) "Scythemaster"}
+[/unit_type]

--- a/units/Seer.cfg
+++ b/units/Seer.cfg
@@ -704,3 +704,4 @@
             [/effect]
         [/advancement]
     ) "Elvish Seer"}
+[/unit_type]

--- a/units/Shadow_Prince.cfg
+++ b/units/Shadow_Prince.cfg
@@ -378,3 +378,4 @@
             {AMLA_DEFAULT_BONUSES}
         [/advancement]
     ) "Shadow Prince"}
+[/unit_type]

--- a/units/Shadowalker.cfg
+++ b/units/Shadowalker.cfg
@@ -851,3 +851,4 @@
             [/effect]
         [/advancement]
     ) "Shadowalker"}
+[/unit_type]

--- a/units/Siege_Troll.cfg
+++ b/units/Siege_Troll.cfg
@@ -377,3 +377,4 @@
             {AMLA_DEFAULT_BONUSES}
         [/advancement]
     ) "Siege Troll"}
+[/unit_type]

--- a/units/Skeletal_Dragon.cfg
+++ b/units/Skeletal_Dragon.cfg
@@ -426,3 +426,4 @@ Keep in mind that this unit is a unique creation of magic, sacrificing it is not
             {AMLA_DEFAULT_BONUSES}
         [/advancement]
     ) "Skeletal Dragon LotI"}
+[/unit_type]

--- a/units/Sky_Goblin.cfg
+++ b/units/Sky_Goblin.cfg
@@ -292,3 +292,4 @@
             {AMLA_DEFAULT_BONUSES}
         [/advancement]
     ) "Sky Goblin"}
+[/unit_type]

--- a/units/Snow_Hunter.cfg
+++ b/units/Snow_Hunter.cfg
@@ -731,3 +731,4 @@ Because of the constant danger and harsh weather condition the Snow Elves live i
             {AMLA_DEFAULT_BONUSES}
         [/advancement]
     ) "Snow Hunter"}
+[/unit_type]

--- a/units/Soul_Shooter.cfg
+++ b/units/Soul_Shooter.cfg
@@ -383,3 +383,4 @@
             {AMLA_DEFAULT_BONUSES}
         [/advancement]
     ) "Soul Shooter"}
+[/unit_type]

--- a/units/Sprite.cfg
+++ b/units/Sprite.cfg
@@ -408,3 +408,4 @@
             [/effect]
         [/advancement]
     ) "Elvish Sprite"}
+[/unit_type]

--- a/units/Stormrider.cfg
+++ b/units/Stormrider.cfg
@@ -815,6 +815,6 @@
             {GREATER_AMLA_DEFAULT_BONUSES}
         [/advancement]
     ) "Stormrider"}
-
+[/unit_type]
 #undef LIGHTNING_STORMRIDER
 #undef LIGHTNING_STORMRIDER2

--- a/units/Swordmaster.cfg
+++ b/units/Swordmaster.cfg
@@ -337,3 +337,4 @@ Note: The ability upgrades may require some books to learn them from."
             {AMLA_DEFAULT_BONUSES}
         [/advancement]
     ) "Swordmaster"}
+[/unit_type]

--- a/units/Troll_Boulderlobber.cfg
+++ b/units/Troll_Boulderlobber.cfg
@@ -412,3 +412,4 @@
             {AMLA_DEFAULT_BONUSES}
         [/advancement]
     ) "Troll Boulderlobber"}
+[/unit_type]

--- a/units/Vritra_later.cfg
+++ b/units/Vritra_later.cfg
@@ -1063,5 +1063,5 @@
             [/effect]
         [/advancement]
     ) "Vritra_later"}
-
+[/unit_type]
 #undef RED_LIGHTNING

--- a/units/Warlock.cfg
+++ b/units/Warlock.cfg
@@ -1034,3 +1034,4 @@
             {AMLA_DEFAULT_BONUSES}
         [/advancement]
     ) "Warlock"}
+[/unit_type]

--- a/units/Werewolf_Rider.cfg
+++ b/units/Werewolf_Rider.cfg
@@ -340,3 +340,4 @@
             {AMLA_DEFAULT_BONUSES}
         [/advancement]
     ) "Werewolf Rider"}
+[/unit_type]

--- a/units/Zombie_Rider.cfg
+++ b/units/Zombie_Rider.cfg
@@ -298,3 +298,4 @@
             {AMLA_DEFAULT_BONUSES}
         [/advancement]
     ) "Zombie Rider"}
+[/unit_type]

--- a/utils/amla.cfg
+++ b/utils/amla.cfg
@@ -63,7 +63,6 @@
         image="chapter7.png"
         require_amla=""
     [/advancement]
-[/unit_type]
 #wmllint: unbalanced-off
 [unit_type]
     id=Advancing{TYPE}
@@ -3877,7 +3876,6 @@ Adjacent own units will do 25% more damage and will have 20% better resistances.
         image="chapter7.png"
         require_amla=""
     [/advancement]
-[/unit_type]
 #wmllint: unbalanced-off
 [unit_type]
     id=Advancing{TYPE}
@@ -4647,7 +4645,6 @@ Adjacent own units will do 25% more damage and will have 20% better resistances.
         image="chapter7.png"
         require_amla=""
     [/advancement]
-[/unit_type]
 #wmllint: unbalanced-off
 [unit_type]
     id=Advancing{TYPE}


### PR DESCRIPTION
the [/unit_type] line at the end of the files was not present for the majority of the unit, which prevented the wmlxgettext file from working, when trying to generate a .pot file for translation of the campaign.