### PR TITLE
Advancing- unit types were not created

### DIFF
--- a/utils/amla.cfg
+++ b/utils/amla.cfg
@@ -64,6 +64,7 @@
         require_amla=""
     [/advancement]
 #wmllint: unbalanced-off
+[/unit_type]
 [unit_type]
     id=Advancing{TYPE}
     [base_unit]
@@ -74,7 +75,6 @@
 #endif
     {GENERIC_AMLA_ADVANCEMENTS {BASEFRAME} {CASTING_FRAME} {CASTING_FRAME2} {BASEFRAME_FEMALE} {CASTING_FRAME_FEMALE} {CASTING_FRAME2_FEMALE}}
     {AMLA}
-[/unit_type]
 #enddef
 #define GENERIC_AMLA_ADVANCEMENTS BASEFRAME CASTING_FRAME CASTING_FRAME2 BASEFRAME_FEMALE CASTING_FRAME_FEMALE CASTING_FRAME2_FEMALE
     #This serves as advancements that are added by items. Items add something like a prerequisite to these advancements, they are otherwise impossible to get.
@@ -3877,6 +3877,7 @@ Adjacent own units will do 25% more damage and will have 20% better resistances.
         require_amla=""
     [/advancement]
 #wmllint: unbalanced-off
+[/unit_type]
 [unit_type]
     id=Advancing{TYPE}
     [base_unit]
@@ -3887,7 +3888,6 @@ Adjacent own units will do 25% more damage and will have 20% better resistances.
     {GENERIC_AMLA_ADVANCEMENTS {BASEFRAME} {CASTING_FRAME} {CASTING_FRAME2} {BASEFRAME_FEMALE} {CASTING_FRAME_FEMALE} {CASTING_FRAME2_FEMALE}}
     {SOUL_EATER_AMLA_ADVANCEMENTS}
     {AMLA}
-[/unit_type]
 #enddef
 
 #define SOUL_EATER_AMLA_ADVANCEMENTS
@@ -4646,6 +4646,7 @@ Adjacent own units will do 25% more damage and will have 20% better resistances.
         require_amla=""
     [/advancement]
 #wmllint: unbalanced-off
+[/unit_type]
 [unit_type]
     id=Advancing{TYPE}
     [base_unit]
@@ -4656,7 +4657,6 @@ Adjacent own units will do 25% more damage and will have 20% better resistances.
     {GENERIC_AMLA_ADVANCEMENTS {BASEFRAME} {CASTING_FRAME} {CASTING_FRAME2} {BASEFRAME_FEMALE} {CASTING_FRAME_FEMALE} {CASTING_FRAME2_FEMALE}}
     {AMLA_GOD_ADVANCEMENTS}
     {AMLA}
-[/unit_type]
 #enddef
 
 #define AMLA_GOD_ADVANCEMENTS


### PR DESCRIPTION
The latest change to amla.cfg closed the tags in the wrong order, so during the macroexpansion it was like
[unit_type]
id=Type
[unit_type]
id=AdvancingType
[/unit_type]
[/unit_type]
so AdvancingType didn't get created and advancement didn't work

![изображение](https://user-images.githubusercontent.com/68666085/220628348-d56497b8-ccaf-4094-b379-6b78dca9edfe.png)
