### PR TITLE
Save Corruptia

### DIFF
--- a/scenarios2/10_Lilith.cfg
+++ b/scenarios2/10_Lilith.cfg
@@ -2052,6 +2052,31 @@ As the time comes for two suns to shine brightly in the sky."
             message= _ "Not until I allow it! This should prevent her from dying. We will worry about her later."
         [/message]
     [/event]
+    [event]
+        name=last breath
+        [filter]
+            id=Corruptia
+        [/filter]
+        [message]
+            speaker=unit
+            message= _ "No! Save me! Curse you, Lilith!"
+        [/message]
+        [message]
+            speaker=Efraim
+            message= _ "Among the leaders of Arach she was the only one who turned away from Lilith. She might be helpful to bring local people back to normal life."
+        [/message]
+        [message]
+            speaker=Lethalia
+            message= _ "Anghra-kha'sambghra, sei'ko osstap nalatho, ghelt dob'the ekthanathul."
+        [/message]
+        {MODIFY_UNIT id=Corruptia status.petrified yes}
+        {MODIFY_UNIT id=Corruptia hitpoints 40}
+        {MOVE_UNIT id=Corruptia 42 5}
+        [message]
+            speaker=Lethalia
+            message= _ "I agree. If she dies here, we'll have to restore the order ourselves. Without any help from old leaders it will take a lot of time and effort. This should prevent her from dying. We will worry about her later."
+        [/message]
+    [/event]
 
     [event]
         name=attacker_hits


### PR DESCRIPTION
Corruptia may be killed in the last battle. But her book is mentioned in Chapter 4, in the library. Instead of making it conditional or silently glossing over and supposing she survived somehow, maybe just save her the same way Delly is saved? Efraim and Lethalia have an incentive to keep her live: she's the only surviving leader of Arach, so she may help restoring the order after Lilith is defeated