### PR TITLE
S08 moved messages from prestart to start

### DIFF
--- a/scenarios1/08_Where_the_Sun_Does_not_Shine.cfg
+++ b/scenarios1/08_Where_the_Sun_Does_not_Shine.cfg
@@ -19,16 +19,6 @@
 
     [event]
         name=prestart
-        [message]
-            speaker=narrator
-            image="wesnoth-icon.png"
-            message= _ "Greor's bandits passed them to the orcs. They were kept in different dungeons, but still Lethalia's magic was capable of freeing her hands and her budding ability to fly posed a great threat to them. At first a party of eight Orcish Warlords were sent to guard them until the Orcish council decided on an appropriate public, humiliating death for them. But, as the orcs fought constantly, power changed hands several times, and soon the prisoners were almost forgotten."
-        [/message]
-        [message]
-            speaker=narrator
-            image="wesnoth-icon.png"
-            message= _ "After several escape attempts over the years the loss of high ranking Orcs became too costly, and eventually the orcs imprisoned them on a rock surrounded by a chasm full of lava, where the surrounding air was hot enough to melt lead, or in this case roast anyone trying to use some magic to fly. They were hopelessly marooned, bound to feed on bats, rats and cave mushrooms, the only accessible food."
-        [/message]
         [objectives]
             side=1
             [objective]
@@ -108,6 +98,16 @@
         {RARE_ITEM 20 6}
         {RARE_ITEM 17 33}
         {RARE_ITEM 38 23}
+        [message]
+            speaker=narrator
+            image="wesnoth-icon.png"
+            message= _ "Greor's bandits passed them to the orcs. They were kept in different dungeons, but still Lethalia's magic was capable of freeing her hands and her budding ability to fly posed a great threat to them. At first a party of eight Orcish Warlords were sent to guard them until the Orcish council decided on an appropriate public, humiliating death for them. But, as the orcs fought constantly, power changed hands several times, and soon the prisoners were almost forgotten."
+        [/message]
+        [message]
+            speaker=narrator
+            image="wesnoth-icon.png"
+            message= _ "After several escape attempts over the years the loss of high ranking Orcs became too costly, and eventually the orcs imprisoned them on a rock surrounded by a chasm full of lava, where the surrounding air was hot enough to melt lead, or in this case roast anyone trying to use some magic to fly. They were hopelessly marooned, bound to feed on bats, rats and cave mushrooms, the only accessible food."
+        [/message]
         [message]
             speaker=Lethalia
             message= _ "Efraim, we are in evil company! There is a Death Knight on the island next to us!"


### PR DESCRIPTION
Two messages have been sneaked into the prestart event, which has this undesired effect. Moved to start, immediately after.

![imagen](https://user-images.githubusercontent.com/40789364/227424028-b9a39297-8058-4c20-93d4-5a0dc5b64133.png)
