### PR TITLE
Make Efraim hidden on P1-C2-S3

### DIFF
--- a/scenarios2/03s_In_the_Magical_Mirror.cfg
+++ b/scenarios2/03s_In_the_Magical_Mirror.cfg
@@ -791,5 +791,6 @@
             result=victory
             bonus=yes
         [/endlevel]
+        {CLEAR_VARIABLE efraim_stored}
     [/event]
 [/scenario]

--- a/scenarios2/03s_In_the_Magical_Mirror.cfg
+++ b/scenarios2/03s_In_the_Magical_Mirror.cfg
@@ -373,6 +373,13 @@
         {GENERIC_UNIT 5 "Elvish Fighter" 26 17}
         {GENERIC_UNIT 5 "Elvish Fighter" 26 18}
 #endif
+        [store_unit]
+            [filter]
+                id=Efraim
+            [/filter]
+            variable=efraim_stored
+            kill=yes
+        [/store_unit]
     [/event]
     [event]
         name=start
@@ -776,6 +783,10 @@
             speaker=Verderber
             message= _ "The Council has spoken, then!"
         [/message]
+        [unstore_unit]
+            variable=efraim_stored
+            x,y=recall,recall
+        [/unstore_unit]
         [endlevel]
             result=victory
             bonus=yes


### PR DESCRIPTION
As you can see in the image, Efraim is present on this scenario at the bottom, visible if you zoom out or after the victory event. And it's not supposed to be there, not even in secret. With this PR, he will be hidden all the time, from prestart to victory event (and then go straight to recall).

![imagen](https://user-images.githubusercontent.com/40789364/229338050-1ceece00-688c-4b9a-b150-1a3c74eaf862.png)
