### PR TITLE
Avoid duplicate undead on Darkness Closing In

### DIFF
--- a/scenarios2/04_Darkness_Closing_In.cfg
+++ b/scenarios2/04_Darkness_Closing_In.cfg
@@ -1133,6 +1133,11 @@ That is a good idea, Efraim. I agree."
         [filter]
             side=1,2,4
         [/filter]
+        [filter_second_attack]
+            [not]
+                special_type=plague
+            [/not]
+        [/filter_second_attack]
         [message]
             speaker=Efraim
             message= _ "No! He is enslaving the spirits of fallen warriors."


### PR DESCRIPTION
If a plagued unit (the walking corpses) kills a good unit, two undead are created, the corpse and the ghost. By filtering the secondary weapon in this event, this duplication can be avoided.