### PR TITLE
Premature message on "Umbra" scenario

### DIFF
--- a/scenarios2/05_Umbra.cfg
+++ b/scenarios2/05_Umbra.cfg
@@ -417,6 +417,9 @@
             race=elf
             side=5
         [/filter]
+        [filter_second]
+            side=1
+        [/filter_second]
         [message]
             speaker=Charon
             message= _ "Damn those two liches! They will make this battle turn against us!"


### PR DESCRIPTION
This message:
`"Damn those two liches! They will make this battle turn against us!"`
Can be triggered by the dwarves, before the liches has a chance to enter the caverns (with luck, even before the arrival of Umbra). It makes more sense if it's a unit from side 1 that triggers the message and turn the tables.