### PR TITLE
Changed special= for special_id or special_type

### DIFF
--- a/scenarios2/10_Lilith.cfg
+++ b/scenarios2/10_Lilith.cfg
@@ -2091,7 +2091,7 @@ As the time comes for two suns to shine brightly in the sky."
         first_time_only=no
 
         [filter_attack]
-            special=storm_lilith
+            special_id=storm_lilith
         [/filter_attack]
         [harm_unit]
             [filter]

--- a/scenarios4/08_An_Army_Is_Born.cfg
+++ b/scenarios4/08_An_Army_Is_Born.cfg
@@ -250,7 +250,7 @@
         [/filter]
         [filter_second_attack]
             [not]
-                special=plague
+                special_type=plague
             [/not]
         [/filter_second_attack]
         {VARIABLE_OP kill_count add -1}
@@ -359,7 +359,7 @@ What should be raised from this orc?"
             side=2
         [/filter]
         [filter_second_attack]
-            special=plague
+            special_type=plague
         [/filter_second_attack]
         {VARIABLE_OP kill_count add -1}
         [message]

--- a/scenarios4/09_The_First_Blow.cfg
+++ b/scenarios4/09_The_First_Blow.cfg
@@ -327,7 +327,7 @@
         [/filter]
         [filter_second_attack]
             [not]
-                special=plague
+                special_type=plague
             [/not]
         [/filter_second_attack]
         [message]
@@ -418,7 +418,7 @@
             side=2,3,4,5,6
         [/filter]
         [filter_second_attack]
-            special=plague
+            special_type=plague
         [/filter_second_attack]
         [message]
             image="wesnoth-icon.png"

--- a/scenarios4/17_Any_Means_Necessary.cfg
+++ b/scenarios4/17_Any_Means_Necessary.cfg
@@ -389,7 +389,7 @@
         [/filter]
         [filter_second_attack]
             [not]
-                special=plague
+                special_type=plague
             [/not]
         [/filter_second_attack]
         [if]
@@ -480,7 +480,7 @@
             side=3,4,5
         [/filter]
         [filter_second_attack]
-            special=plague
+            special_type=plague
         [/filter_second_attack]
         [if]
             [variable]

--- a/scenarios8/01_Invasion.cfg
+++ b/scenarios8/01_Invasion.cfg
@@ -474,7 +474,7 @@
     [event]
         name=attack
         [filter_attack]
-            special=corruption
+            special_id=corruption
         [/filter_attack]
         [message]
             speaker=Efraim

--- a/spinoffs/Affably_Evil/units/Krux.cfg
+++ b/spinoffs/Affably_Evil/units/Krux.cfg
@@ -243,7 +243,7 @@ You can unlock fireball with magic advancements."
     [/attack_anim]
     [attack_anim]
         [filter_attack]
-            special=whirlwind
+            special_id=whirlwind
         [/filter_attack]
         [frame]
             begin=-500

--- a/spinoffs/The_Beautiful_Child/units/Manhunter.cfg
+++ b/spinoffs/The_Beautiful_Child/units/Manhunter.cfg
@@ -253,7 +253,7 @@
                     first_time_only=no
                     id=suicide_attacker_hits
                     [filter_attack]
-                        special=suicide
+                        special_id=suicide
                     [/filter_attack]
                     [kill]
                         id=$unit.id

--- a/units/Vritra.cfg
+++ b/units/Vritra.cfg
@@ -799,7 +799,7 @@ A unit afflicted by this ability may lose up to 16 HP per turn, except for poiso
         name=attacker hits
         first_time_only=no
         [filter_attack]
-            special=corruption
+            special_id=corruption
         [/filter_attack]
         [store_unit]
             [filter]

--- a/units/corruption.cfg
+++ b/units/corruption.cfg
@@ -4138,7 +4138,7 @@
         first_time_only=no
 
         [filter_attack]
-            special=explosive damage enemy
+            special_id=explosive damage enemy
         [/filter_attack]
 
         [harm_unit]

--- a/utils/amla.cfg
+++ b/utils/amla.cfg
@@ -5947,9 +5947,9 @@ Adjacent own units will do 25% more damage and will have 20% better resistances.
             apply_to=attack
             range=melee
             [not]
-                special=whirlwind
+                special_id=whirlwind
                 [or]
-                    special=cleave
+                    special_id=cleave
                 [/or]
             [/not]
             [set_specials]

--- a/utils/chapter9_utils.cfg
+++ b/utils/chapter9_utils.cfg
@@ -7759,7 +7759,7 @@ The map can be viewed through the right-click menu."}
         first_time_only=no
 
         [filter_attack]
-            special=storm_demon
+            special_id=storm_demon
         [/filter_attack]
         [harm_unit]
             [filter]


### PR DESCRIPTION
special_id refers to id, and special_type to the tag [plague] (the only case on LOTI).
This message appears on every attack by some characters in debug mode:
![imagen](https://user-images.githubusercontent.com/40789364/230729908-22dfdb85-341c-477e-901b-18c9c2c2eab8.png)

Don't worry about compatibility, all three keys have existed since they were created, just special= will be deprecated