### PR TITLE
Clear shroud on Ch3 S01 final conversation

### DIFF
--- a/scenarios3/01_Thirst_for_Adventures.cfg
+++ b/scenarios3/01_Thirst_for_Adventures.cfg
@@ -452,6 +452,9 @@
                 [/advancement]
             [/modifications]
         [/unit]
+        [redraw]
+            clear_shroud=yes
+        [/redraw]
         [message]
             speaker=Argan
             message= _ "Finally we found you! We have been looking for you for quite some time."

--- a/scenarios3/01_Thirst_for_Adventures.cfg
+++ b/scenarios3/01_Thirst_for_Adventures.cfg
@@ -407,11 +407,10 @@
             name="Stormrider"
             x=123
             y=47
-            {IS_HERO}
             side=1
             ai_special=guardian
             [modifications]
-                {TRAIT_LOYAL}
+                {TRAIT_LOYAL_HERO}
                 {TRAIT_STRONG}
             [/modifications]
         [/unit]
@@ -423,9 +422,8 @@
             y=48
             ai_special=guardian
             side=1
-            {IS_HERO}
             [modifications]
-                {TRAIT_LOYAL}
+                {TRAIT_LOYAL_HERO}
                 {TRAIT_QUICK}
             [/modifications]
         [/unit]
@@ -437,9 +435,8 @@
             y=48
             ai_special=guardian
             side=1
-            {IS_HERO}
             [modifications]
-                {TRAIT_LOYAL}
+                {TRAIT_LOYAL_HERO}
                 {TRAIT_RESILIENT}
                 [advancement]
                     id=leadership


### PR DESCRIPTION
Without this, the conversation will take place by talking to invisible units if there is no unit near the human city.
Also changed trait_loyal + is_hero with trait_loyal_hero on this scenario

![imagen](https://user-images.githubusercontent.com/40789364/231948668-d0876c24-ef1f-4a4a-8b44-bfbb00bdd939.png)
