### PR TITLE
Fix moveto onto Ziggurat only working the first time

### DIFF
--- a/spinoffs/The_Beautiful_Child/scenarios/Ziggurat_Town.cfg
+++ b/spinoffs/The_Beautiful_Child/scenarios/Ziggurat_Town.cfg
@@ -380,6 +380,7 @@
 
     [event]
         name=moveto
+        first_time_only=no
         [filter]
             x,y=17-23,7-8
             side=1


### PR DESCRIPTION
Because of my lack of situational awareness (I didn't notice the shops :smile:), I ran into a bug where you only get the option to enter the ziggurat once. This should fix it (I haven't tested it, but referencing the rest of the file and my rusty WML knowledge give me reasonable confidence this works).