### PR TITLE
unit.side instead of side_number on attack related events

### DIFF
--- a/utils/abilities_events.cfg
+++ b/utils/abilities_events.cfg
@@ -584,7 +584,7 @@
                 # We do not hurt our own units.
                 [filter_side]
                     [enemy_of]
-                        side=$side_number
+                        side=$unit.side
                     [/enemy_of]
                 [/filter_side]
                 # The defender was already damaged.
@@ -609,7 +609,7 @@
                 # We do not hurt our own units.
                 [filter_side]
                     [enemy_of]
-                        side=$side_number
+                        side=$unit.side
                     [/enemy_of]
                 [/filter_side]
                 # The defender was already damaged.
@@ -642,7 +642,7 @@
                 # We do not hurt our own units.
                 [filter_side]
                     [enemy_of]
-                        side=$side_number
+                        side=$unit.side
                     [/enemy_of]
                 [/filter_side]
             [/filter]
@@ -670,7 +670,7 @@
                 # We do not hurt our own units.
                 [filter_side]
                     [enemy_of]
-                        side=$side_number
+                        side=$unit.side
                     [/enemy_of]
                 [/filter_side]
             [/filter]
@@ -866,7 +866,7 @@
                         [/filter_adjacent]
                         [filter_side]
                             [allied_with]
-                                side=$side_number
+                                side=$unit.side
                             [/allied_with]
                         [/filter_side]
                         [or]
@@ -985,7 +985,7 @@
                         [/filter_adjacent]
                         [filter_side]
                             [enemy_of]
-                                side=$side_number
+                                side=$unit.side
                             [/enemy_of]
                         [/filter_side]
                     [/filter]
@@ -1011,7 +1011,7 @@
                         [/filter_adjacent]
                         [filter_side]
                             [enemy_of]
-                                side=$side_number
+                                side=$unit.side
                             [/enemy_of]
                         [/filter_side]
                     [/filter]
@@ -1053,7 +1053,7 @@
                         [/filter_adjacent]
                         [filter_side]
                             [allied_with]
-                                side=$side_number
+                                side=$unit.side
                             [/allied_with]
                         [/filter_side]
                     [/filter]
@@ -1079,7 +1079,7 @@
                         [/filter_adjacent]
                         [filter_side]
                             [allied_with]
-                                side=$side_number
+                                side=$unit.side
                             [/allied_with]
                         [/filter_side]
                     [/filter]
@@ -1223,7 +1223,7 @@
                 [/filter_adjacent]
                 [filter_side]
                     [enemy_of]
-                        side=$side_number
+                        side=$harmer.side
                     [/enemy_of]
                 [/filter_side]
                 [not]
@@ -1245,7 +1245,7 @@
                 [/filter_adjacent]
                 [filter_side]
                     [enemy_of]
-                        side=$side_number
+                        side=$harmer.side
                     [/enemy_of]
                 [/filter_side]
                 [not]
@@ -3767,7 +3767,7 @@
                 [/filter_adjacent]
                 [filter_side]
                     [enemy_of]
-                        side=$side_number
+                        side=$unit.side
                     [/enemy_of]
                 [/filter_side]
             [/filter]
@@ -3824,7 +3824,7 @@
                 [/filter_adjacent]
                 [filter_side]
                     [enemy_of]
-                        side=$side_number
+                        side=$unit.side
                     [/enemy_of]
                 [/filter_side]
             [/filter]
@@ -4192,7 +4192,7 @@
                     x,y=$x2,$y2
                 [/filter_adjacent]
                 [not]
-                    side=$side_number
+                    side=$unit.side
                 [/not]
                 [not]
                     x,y=$x2,$y2
@@ -6301,7 +6301,7 @@
         [/set_variable]
         [set_variable]
             name=second_unit.variables.side_turn_dazzled
-            value=$side_number
+            value=$unit.side
         [/set_variable]
         [unstore_unit]
             variable=second_unit
@@ -6366,7 +6366,7 @@
         [/set_variable]
         [set_variable]
             name=unit.variables.side_turn_dazzled
-            value=$side_number
+            value=$second_unit.side
         [/set_variable]
         [unstore_unit]
             variable=unit


### PR DESCRIPTION
This is more reliable on attacks events. Fine on side events, but when active attack is caused by some kind of event or ability, `side_number `is the active side, not the attacker side.
I don't know if there is any event or ability like this in all of LOTI that can interact in this way, since I detected the error with my own addon (Advanced Wesnoth Wars ambush feature), but it doesn't hurt to trust the variables used in these events.

You can compare the before and after here;
Using $side_number

https://user-images.githubusercontent.com/40789364/232260685-38e5a7b7-3d60-4b6d-9820-473fc5625876.mp4

Using $unit.side (don't worry about the lua warning, this video is recorded in debug mode and always appear with [harm_unit_loti])

https://user-images.githubusercontent.com/40789364/232260691-e54b8612-1231-42ee-ba2e-4c9b0d0e1401.mp4

All attack related events have been checked so that the correct variable side is used, **_dazzled_** uses `second_unit.side` for **`defender hits`** event.