### PR TITLE
Fixed hotkey for unit info

### DIFF
--- a/utils/global_events.cfg
+++ b/utils/global_events.cfg
@@ -869,14 +869,14 @@ Do you want to change it for something else?"
                 [have_unit]
                     x,y=$x1,$y1
                     side=$side_number
+                    [not]
+                        [filter_wml]
+                            [variables]
+                                cant_pick=yes
+                            [/variables]
+                        [/filter_wml]
+                    [/not]
                 [/have_unit]
-                [not]
-                    [filter_wml]
-                        [variables]
-                            cant_pick=yes
-                        [/variables]
-                    [/filter_wml]
-                [/not]
             [/show_if]
             [command]
                 [fire_event]


### PR DESCRIPTION
Have you noticed that when you press shift+c and select a unit, you get an error message? So, the hotkey to "Unit info" doesn't work. The error was simple, the filter was badly placed.