### PR TITLE
Fixed incinerate on defense

### DIFF
--- a/utils/abilities_events.cfg
+++ b/utils/abilities_events.cfg
@@ -2839,45 +2839,52 @@
         [/filter_second_attack]
         {VARIABLE unit.status.incinerated yes}
         {VARIABLE unit.variables.incinerator $second_unit.id}
-        [unstore_unit]
-            variable=unit
-            find_vacant=no
-        [/unstore_unit]
-
-        {VARIABLE is_red no}
-        {FOREACH unit.modifications.object i}
-            [if]
-                [variable]
-                    name=unit.modifications.object[$i].incineration
-                    equals=yes
-                [/variable]
-                [then]
-                    {VARIABLE is_red yes}
-                [/then]
-            [/if]
-        {NEXT i}
         [if]
-            [variable]
-                name=is_red
-                equals=no
-            [/variable]
+            [have_unit]
+                find_in=unit
+            [/have_unit]
             [then]
-                [object]
-                    silent=yes
-                    sort=potion-like
-                    remove_on_heal=yes
-                    incineration=yes
-                    [filter]
-                        find_in=unit
-                    [/filter]
-                    [effect]
-                        apply_to=image_mod
-                        add="CS(100,50,0)"
-                    [/effect]
-                [/object]
+                [unstore_unit]
+                    variable=unit
+                    find_vacant=no
+                [/unstore_unit]
+
+                {VARIABLE is_red no}
+                {FOREACH unit.modifications.object i}
+                    [if]
+                        [variable]
+                            name=unit.modifications.object[$i].incineration
+                            equals=yes
+                        [/variable]
+                        [then]
+                            {VARIABLE is_red yes}
+                        [/then]
+                    [/if]
+                {NEXT i}
+                [if]
+                    [variable]
+                        name=is_red
+                        equals=no
+                    [/variable]
+                    [then]
+                        [object]
+                            silent=yes
+                            sort=potion-like
+                            remove_on_heal=yes
+                            incineration=yes
+                            [filter]
+                                find_in=unit
+                            [/filter]
+                            [effect]
+                                apply_to=image_mod
+                                add="CS(100,50,0)"
+                            [/effect]
+                        [/object]
+                    [/then]
+                [/if]
+                {CLEAR_VARIABLE is_red}
             [/then]
         [/if]
-        {CLEAR_VARIABLE is_red}
     [/event]
     [event]
         name=turn refresh


### PR DESCRIPTION
In rare cases, when the unit is already dead and the incinerate event try to do unstore_unit here, you get an error on the screen and various errors in the log:

```
20230428 15:43:48 error engine: failed to auto-store $unit at (39,26)
20230428 15:43:48 error engine: failed to auto-store $unit at (39,26)
20230428 15:43:48 error wml: [unstore_unit]: variable 'unit' doesn't contain unit data

20230428 15:43:48 error engine: failed to auto-store $unit at (39,26)
20230428 15:43:48 error engine: failed to auto-store $unit at (39,26)
20230428 15:43:48 error engine: failed to auto-store $unit at (39,26)
20230428 15:43:48 error engine: failed to auto-store $unit at (39,26)
```

To avoid this, simply use the same method as in the attacker_hits incinerate event, with the conditional
```
         [if]
             [have_unit]
                 find_in=unit
             [/have_unit]
```

[have_unit] will filter out units that are still alive after the attack. If the unit is died, the filter will do negative and it will stop.