### PR TITLE
Necromancy always takes precedence over infected

### DIFF
--- a/utils/abilities_events.cfg
+++ b/utils/abilities_events.cfg
@@ -2702,6 +2702,7 @@
             [/unstore_unit]
         {NEXT i}
         {CLEAR_VARIABLE unzombie_store}
+# To cover the case where the infected unit is a necromancer
         [store_unit]
             [filter]
                 status=infected

--- a/utils/abilities_events.cfg
+++ b/utils/abilities_events.cfg
@@ -2702,7 +2702,7 @@
             [/unstore_unit]
         {NEXT i}
         {CLEAR_VARIABLE unzombie_store}
-# To cover the case where the infected unit is a necromancer
+        # To cover the case where the infected unit is a necromancer
         [store_unit]
             [filter]
                 status=infected
@@ -2728,11 +2728,18 @@
         [foreach]
             array=necromancy_store
             [do]
-                [kill]
-                    id=$this_item.id
-                    fire_event=yes
-                    animate=yes
-                [/kill]
+                [fire_event]
+                    name=last_breath
+                    [primary_unit]
+                        id=$this_item.id
+                    [/primary_unit]
+                [/fire_event]
+                [fire_event]
+                    name=die
+                    [primary_unit]
+                        id=$this_item.id
+                    [/primary_unit]
+                [/fire_event]
             [/do]
         [/foreach]
         {CLEAR_VARIABLE necromancy_store}

--- a/utils/abilities_events.cfg
+++ b/utils/abilities_events.cfg
@@ -2640,6 +2640,9 @@
                         terrain=*^V*
                     [/filter_location]
                 [/not]
+                [not]
+                    ability=necromancy
+                [/not]
             [/filter]
             variable=zombie_store
             kill=yes
@@ -2656,18 +2659,6 @@
                 attacks_left=0
                 animate=no
             [/unit]
-            [fire_event]
-                name=last_breath
-                [primary_unit]
-                    x,y=$zombie_store[$i].x,$zombie_store[$i].y
-                [/primary_unit]
-            [/fire_event]
-            [fire_event]
-                name=die
-                [primary_unit]
-                    x,y=$zombie_store[$i].x,$zombie_store[$i].y
-                [/primary_unit]
-            [/fire_event]
         {NEXT i}
         {CLEAR_VARIABLE zombie_store}
 
@@ -2711,6 +2702,39 @@
             [/unstore_unit]
         {NEXT i}
         {CLEAR_VARIABLE unzombie_store}
+        [store_unit]
+            [filter]
+                status=infected
+                ability=necromancy
+                [and]
+                    [filter_side]
+                        side=$side_number
+                    [/filter_side]
+                [/and]
+                [and]
+                    [filter_wml]
+                        hitpoints=1
+                    [/filter_wml]
+                [/and]
+                [not]
+                    [filter_location]
+                        terrain=*^V*
+                    [/filter_location]
+                [/not]
+            [/filter]
+            variable=necromancy_store
+        [/store_unit]
+        [foreach]
+            array=necromancy_store
+            [do]
+                [kill]
+                    id=$this_item.id
+                    fire_event=yes
+                    animate=yes
+                [/kill]
+            [/do]
+        [/foreach]
+        {CLEAR_VARIABLE necromancy_store}
     [/event]
     [event]
         name=die
@@ -6120,7 +6144,6 @@
             [/then]
         [/if]
     [/event]
-
 
     [event]
         name=attack


### PR DESCRIPTION
In the case that an Arch Necromancer infects another Arch Necromancer, and the Arch Necromancer dies from the poison on turn_refresh, it becomes walking corpse instead of a lich. This does not happen if he dies from other causes while infected, so it should be considered a bug. I assume necromancy should take precedence.
I also delete two unnecessary fire_event when unit becomes walking corpse. These events are executed as if the killed unit was the walking corpse, when it should be the necromancer. However, these events are not needed in this situation.