### PR TITLE
Secondary unit on kill events

### DIFF
--- a/utils/abilities_events.cfg
+++ b/utils/abilities_events.cfg
@@ -529,9 +529,6 @@
                             animate=no
                             experience=yes
                             fire_event=yes
-                            [filter_second]
-                                x,y=$x1,$y1
-                            [/filter_second]
                             [secondary_unit]
                                 x,y=$x1,$y1
                             [/secondary_unit]
@@ -3019,6 +3016,9 @@
         {FOREACH burn_store ti}
             [kill]
                 id=$burn_store[$ti].id
+                [secondary_unit]
+                    id=$burn_store[$ti].variables.incinerator
+                [/secondary_unit]
                 animate=yes
                 fire_event=yes
             [/kill]
@@ -3768,9 +3768,6 @@
             [then]
                 [kill]
                     find_in=second_unit
-                    [filter_second]
-                        find_in=unit
-                    [/filter_second]
                     [secondary_unit]
                         find_in=unit
                     [/secondary_unit]
@@ -5803,6 +5800,9 @@
                 [/animate_unit]
                 [kill]
                     id=$second_unit.id
+                    [secondary_unit]
+                        id=$unit.id
+                    [/secondary_unit]
                     animate=no
                     fire_event=yes
                 [/kill]


### PR DESCRIPTION
Two fixes:
[filter_second] isn't a valid tag on [kill] (no effect deleting them).
Added [secondary_unit] to [kill]. Without this, the unit killed isn't reflected in statistics.
This does not give experience to the assassin (For that is used [harm_unit] with kill=yes), so the mechanic remains the same.