### PR TITLE
mass_produced variable on ghost+walking corpse

### DIFF
--- a/scenarios4/08_An_Army_Is_Born.cfg
+++ b/scenarios4/08_An_Army_Is_Born.cfg
@@ -376,6 +376,9 @@ A ghost will be raised from this one, because the body is already used."
                 {TRAIT_UNDEAD}
                 {TRAIT_LOYAL}
             [/modifications]
+            [variables]
+                mass_produced=yes
+            [/variables]
         [/unit]
         [update_stats]
             x,y=$x1,$y1

--- a/scenarios4/09_The_First_Blow.cfg
+++ b/scenarios4/09_The_First_Blow.cfg
@@ -433,6 +433,9 @@
                 {TRAIT_UNDEAD}
                 {TRAIT_LOYAL}
             [/modifications]
+            [variables]
+                mass_produced=yes
+            [/variables]
         [/unit]
         [update_stats]
             x,y=$x1,$y1

--- a/scenarios4/17_Any_Means_Necessary.cfg
+++ b/scenarios4/17_Any_Means_Necessary.cfg
@@ -501,6 +501,9 @@
                         {TRAIT_UNDEAD}
                         {TRAIT_LOYAL}
                     [/modifications]
+                    [variables]
+                        mass_produced=yes
+                    [/variables]
                 [/unit]
                 [update_stats]
                     x,y=$x1,$y1


### PR DESCRIPTION
When a walking corpse is spawned on a plague victim in these scenarios, a ghost is additionally created, but it does not receive the mass_produced variable, resulting in it ending up on the recall list instead of being summoned directly.

![imagen](https://github.com/Dugy/Legend_of_the_Invincibles/assets/40789364/0f0a1fd1-2a41-48b4-bff5-456f80955971)
