### PR TITLE
prevamp_store restore HP and status

### DIFF
--- a/scenarios4/11_Invasion.cfg
+++ b/scenarios4/11_Invasion.cfg
@@ -119,6 +119,11 @@
         [/while]
         {CLEAR_VARIABLE recall_count}
         {FOREACH prevamp_store i}
+            {VARIABLE prevamp_store[$i].hitpoints $this_item.max_hitpoints}
+            {VARIABLE prevamp_store[$i].status.poisoned "no"}
+            {VARIABLE prevamp_store[$i].status.slowed "no"}
+            {VARIABLE prevamp_store[$i].status.infected "no"}
+            {VARIABLE prevamp_store[$i].status.petrified "no"}
             [unstore_unit]
                 variable=prevamp_store[$i]
                 x=recall


### PR DESCRIPTION
Without this, units are recalled with the status and HP they had when saved to the variable.

infected and petrified are there just in case, but probably not needed