### PR TITLE
Recall new advancement Fire Wraith

### DIFF
--- a/scenarios5/03_Pirates.cfg
+++ b/scenarios5/03_Pirates.cfg
@@ -97,7 +97,7 @@
             [do]
                 {VARIABLE_OP recall_count add -1}
                 [recall]
-                    type=Ghost,Wraith,Shadow,Nightgaunt,Spectre,Reaper,Fire Guardian
+                    type=Ghost,Wraith,Shadow,Nightgaunt,Spectre,Reaper,Fire Guardian,Fire Guardian
                     x,y=32,44
                 [/recall]
             [/do]

--- a/scenarios5/03_Pirates.cfg
+++ b/scenarios5/03_Pirates.cfg
@@ -97,7 +97,7 @@
             [do]
                 {VARIABLE_OP recall_count add -1}
                 [recall]
-                    type=Ghost,Wraith,Shadow,Nightgaunt,Spectre,Reaper,Fire Guardian,Fire Guardian
+                    type=Ghost,Wraith,Shadow,Nightgaunt,Spectre,Reaper,Fire Guardian,Fire Wraith
                     x,y=32,44
                 [/recall]
             [/do]

--- a/utils/help.cfg
+++ b/utils/help.cfg
@@ -1159,7 +1159,7 @@ Do you want to read this anyway?"
                 [command]
                     [message]
                         speaker=narrator
-                        message=_"A lot of weaker enemies will attack you, use the fire spirits to wear them down (they will never advance to anything, unlike the ghosts). All you have to do is to reach the western border of the map, so don't annoy yourself with the enemies too much."
+                        message=_"A lot of weaker enemies will attack you, use the fire spirits to wear them down. All you have to do is to reach the western border of the map, so don't annoy yourself with the enemies too much."
                         side_for=$side_number
                         image="wesnoth-icon.png"
                     [/message]


### PR DESCRIPTION
Also, the chapter 5 scenario 1 FAQ says that fire guardians don't level up, which is not true, so I'm assuming there was an update time ago where you forgot about these changes.