### PR TITLE
Remove the lose condition (Death of Efraim or Lethalia) in the Last Crusade from some point

### DIFF
--- a/utils/chapter9_utils.cfg
+++ b/utils/chapter9_utils.cfg
@@ -1541,6 +1541,14 @@
         [objective]
             description=_ "Death of Efraim or Lethalia"
             condition=lose
+            [show_if]
+                [not]
+                    [variable]
+                        name=crusade_difficulty
+                        greater_than_equal_to=10
+                    [/variable]
+                [/not]
+            [/show_if]
         [/objective]
         [objective]
             description=_ "Death of Lilith"


### PR DESCRIPTION
I've noticed recently several complaints that people not getting how to break the cycle in the Last Crusade and proceed on. Someone proposed to remove "Death of Efraim or Lethalia" from lose conditions after some time to make it more obvious. I removed it after the 9th cycle, but maybe you think the other time will be better (if you agree on this change)