### PR TITLE
Warlord rule doesn't applies to both

### DIFF
--- a/utils/abilities.cfg
+++ b/utils/abilities.cfg
@@ -1721,7 +1721,6 @@ Enemy units cannot see this unit at night, except if they have units next to it.
         cumulative=no
         affect_self=no
         affect_allies=yes
-        apply_to=both
         [affect_adjacent]
         [/affect_adjacent]
     [/damage]


### PR DESCRIPTION
I took a strange look at the tooltips that warlord's rule applies to attacker and defender at the same time, which in practice is similar to "charge". I think this key is a mistake.