### PR TITLE
Soulgate fires event unit_placed

### DIFF
--- a/utils/chapter5_utils.cfg
+++ b/utils/chapter5_utils.cfg
@@ -456,6 +456,7 @@ Spells remaining: " + ${VARIABLE_NAME}
                                                     find_vacant=yes
                                                     x=$x1
                                                     y=$y1
+                                                    fire_event=yes
                                                 [/unstore_unit]
                                                 {CLEAR_VARIABLE Valhalla[0]}
                                             [/then]
@@ -471,6 +472,7 @@ Spells remaining: " + ${VARIABLE_NAME}
                                                             find_vacant=yes
                                                             x=$x1
                                                             y=$y1
+                                                            fire_event=yes
                                                         [/unstore_unit]
                                                         {CLEAR_VARIABLE Valhalla2[0]}
                                                     [/then]


### PR DESCRIPTION
Without this, Soulgate does not support the DISABLE_UPKEEP macro and summoned units will cost upkeep.
[unit] tag (the third option in case there are no units left in valhalla) fires unit_placed by default, so this is only need on [unstore_unit]