### PR TITLE
Update [print] duration

### DIFF
--- a/scenarios5/10_Guards_Quarters.cfg
+++ b/scenarios5/10_Guards_Quarters.cfg
@@ -102,7 +102,7 @@
                 [/message]
                 [print]
                     text= _ "Enemies to slay: $(50-$enemies_slain)"
-                    duration=100
+                    duration=5000
                     red,green,blue=255,255,255
                 [/print]
             [/else]
@@ -142,7 +142,7 @@
                             [else]
                                 [print]
                                     text= _ "Enemies to slay: $(50-$enemies_slain)"
-                                    duration=100
+                                    duration=5000
                                     red,green,blue=255,255,255
                                 [/print]
                             [/else]

--- a/scenarios5/19_Soldiers_Training_Room.cfg
+++ b/scenarios5/19_Soldiers_Training_Room.cfg
@@ -125,7 +125,7 @@
                 [/message]
                 [print]
                     text= _ "Enemies to slay: $(50-$enemies_slain)"
-                    duration=100
+                    duration=5000
                     red,green,blue=255,255,255
                 [/print]
             [/else]
@@ -165,7 +165,7 @@
                             [else]
                                 [print]
                                     text= _ "Enemies to slay: $(50-$enemies_slain)"
-                                    duration=100
+                                    duration=5000
                                     red,green,blue=255,255,255
                                 [/print]
                             [/else]

--- a/scenarios5/21_Soldiers_Quarters.cfg
+++ b/scenarios5/21_Soldiers_Quarters.cfg
@@ -122,7 +122,7 @@
                 [/message]
                 [print]
                     text= _ "Enemies to slay: $(50-$enemies_slain)"
-                    duration=100
+                    duration=5000
                     red,green,blue=255,255,255
                 [/print]
             [/else]
@@ -162,7 +162,7 @@
                             [else]
                                 [print]
                                     text= _ "Enemies to slay: $(50-$enemies_slain)"
-                                    duration=100
+                                    duration=5000
                                     red,green,blue=255,255,255
                                 [/print]
                             [/else]

--- a/scenarios5/27_Power_Station.cfg
+++ b/scenarios5/27_Power_Station.cfg
@@ -117,7 +117,7 @@
                 [/message]
                 [print]
                     text= _ "Generators to destroy: $(5-$enemies_slain)"
-                    duration=100
+                    duration=5000
                     red,green,blue=255,255,255
                 [/print]
             [/else]
@@ -158,7 +158,7 @@
                             [else]
                                 [print]
                                     text= _ "Generators to destroy: $(5-$enemies_slain)"
-                                    duration=100
+                                    duration=5000
                                     red,green,blue=255,255,255
                                 [/print]
                             [/else]

--- a/scenarios7/15_Annihilation.cfg
+++ b/scenarios7/15_Annihilation.cfg
@@ -461,7 +461,7 @@
                 [/unit]
                 [print]
                     text= _ "Lethalia's energy: $lethalia_power_remaining|/$lethalia_power"
-                    duration=150
+                    duration=5000
                     red,green,blue=255,255,255
                 [/print]
             [/then]

--- a/utils/chapter5_utils.cfg
+++ b/utils/chapter5_utils.cfg
@@ -29,7 +29,7 @@
                         [else]
                             [print]
                                 text= _ "Items to take: $($items_to_take-$items_taken*1)"
-                                duration=100
+                                duration=5000
                                 red,green,blue=255,255,255
                             [/print]
                         [/else]


### PR DESCRIPTION
> (Before 1.15.4) This is measured in the number of 'frames', and the default is 50. A frame in Wesnoth is usually displayed for around 30ms.
> ([Version 1.15.4 and later only](https://wiki.wesnoth.org/DevFeature)) This is measured in milliseconds.

So 100 ms is clearly insufficient and there is barely time to see anything. Updated to the new default, 5 seconds (5000 ms)
If you prefer another duration, tell me