### PR TITLE
Translatable "Prince" unit

### DIFF
--- a/units/The_Prince.cfg
+++ b/units/The_Prince.cfg
@@ -5,7 +5,6 @@
     race=human
     image="units/enemies/the_prince.png"
     profile="portraits/humans/fencer.png"
-#textdomain wesnoth-units
     [leading_anim]
         start_time=-150
         [frame]
@@ -48,6 +47,7 @@
     [abilities]
         {ABILITY_LEADERSHIP}
     [/abilities]
+#textdomain wesnoth-units
     [attack]
         name=sword
         description=_"longsword"

--- a/units/The_Prince.cfg
+++ b/units/The_Prince.cfg
@@ -1,10 +1,11 @@
-#textdomain wesnoth-units
+#textdomain wesnoth-loti
 [unit_type]
     id=The Prince
     name= _ "Prince"
     race=human
     image="units/enemies/the_prince.png"
     profile="portraits/humans/fencer.png"
+#textdomain wesnoth-units
     [leading_anim]
         start_time=-150
         [frame]


### PR DESCRIPTION
In this case it is an error in textdomain, "Prince" and his description does not exist on wesnoth-units, but longsword and thunderstick do, so the textdomains are adjusted.