### PR TITLE
Fixed tripled enemy id

### DIFF
--- a/scenarios5/11_Northern_Guardian_Room.cfg
+++ b/scenarios5/11_Northern_Guardian_Room.cfg
@@ -91,7 +91,7 @@
     [/side]
     [side]
         generate_name=yes
-        id=enemy
+        id=enemy2
         type=Royal Guard_steel
         side=3
         canrecruit=yes
@@ -115,7 +115,7 @@
     [/side]
     [side]
         generate_name=yes
-        id=enemy
+        id=enemy3
         type=Necromancer_steel
         side=4
         canrecruit=yes

--- a/scenarios5/18_Eastern_Guardian_Room.cfg
+++ b/scenarios5/18_Eastern_Guardian_Room.cfg
@@ -91,7 +91,7 @@
     [/side]
     [side]
         generate_name=yes
-        id=enemy
+        id=enemy2
         type=Royal Guard_steel
         side=3
         canrecruit=yes
@@ -115,7 +115,7 @@
     [/side]
     [side]
         generate_name=yes
-        id=enemy
+        id=enemy3
         type=Necromancer_steel
         side=4
         canrecruit=yes

--- a/scenarios5/20_Southern_Guardian_Room.cfg
+++ b/scenarios5/20_Southern_Guardian_Room.cfg
@@ -91,7 +91,7 @@
     [/side]
     [side]
         generate_name=yes
-        id=enemy
+        id=enemy2
         type=Royal Guard_steel
         side=3
         canrecruit=yes
@@ -115,7 +115,7 @@
     [/side]
     [side]
         generate_name=yes
-        id=enemy
+        id=enemy3
         type=Necromancer_steel
         side=4
         canrecruit=yes

--- a/scenarios5/23_Akulas_Place.cfg
+++ b/scenarios5/23_Akulas_Place.cfg
@@ -115,7 +115,7 @@
     [/side]
     [side]
         generate_name=yes
-        id=enemy
+        id=enemy2
         type=Necromancer_steel
         side=4
         canrecruit=yes
@@ -139,7 +139,7 @@
     [/side]
     [side]
         generate_name=yes
-        id=enemy
+        id=enemy3
         type=Necromancer_steel
         side=5
         canrecruit=yes


### PR DESCRIPTION
All these scenarios have the same serious error. As all the enemy bosses have the same id, only the last one appears.