### PR TITLE
Soulgate: spawn random units on passable hex

### DIFF
--- a/utils/chapter5_utils.cfg
+++ b/utils/chapter5_utils.cfg
@@ -482,6 +482,7 @@ Spells remaining: " + ${VARIABLE_NAME}
                                                             type=$summon_type
                                                             side=1
                                                             x,y=$x1,$y1
+                                                            passable=yes
                                                         [/unit]
                                                     [/else]
                                                 [/if]


### PR DESCRIPTION
Simple fix. I realized this when I summoned all the Valhalla units.