### PR TITLE
Avoid "Damage decreased by 0%"

### DIFF
--- a/lua/items.lua
+++ b/lua/items.lua
@@ -602,7 +602,7 @@ loti.item.describe_item = function(number, sort, set_items)
 		if variable then
 			if variable > 0 then
 				table.insert(desc, "<span color='green'>" .. _"Damage increased by " .. tostring(variable) .. ending)
-			else
+			elseif variable < 0 then
 				table.insert(desc, "<span color='red'>" .. _"Damage decreased by " .. tostring(variable * -1) .. ending)
 			end
 		end


### PR DESCRIPTION
Small cosmetic fix, for the case where an item has damage=0 (due to difficulty mode). Now, it just won't display the phrase.