### PR TITLE
[harm_unit] type= > damage_type= fix

### DIFF
--- a/scenarios10/03_Fimbulwinter.cfg
+++ b/scenarios10/03_Fimbulwinter.cfg
@@ -529,7 +529,7 @@
     find_in=unit
 [/filter]
 amount=30
-type=cold
+damage_type=cold
 animate=yes
 [/harm_unit])}
 {RUNE_TRAP 43 4 3 ([heal_unit]
@@ -545,7 +545,7 @@ animate=yes
     find_in=unit
 [/filter]
 amount=40
-type=fire
+damage_type=fire
 animate=yes
 [/harm_unit])}
 {RUNE_TRAP 37 17 5 ([object]

--- a/scenarios5/23_Akulas_Place.cfg
+++ b/scenarios5/23_Akulas_Place.cfg
@@ -443,7 +443,7 @@
                         x,y=$x2,$y2
                     [/filter_second]
                     amount=10
-                    type=pierce
+                    damage_type=pierce
                     fire_event=yes
                     experience=no
                     animate=no
@@ -464,7 +464,7 @@
                         x,y=$x2,$y2
                     [/filter_second]
                     amount=20
-                    type=pierce
+                    damage_type=pierce
                     fire_event=yes
                     experience=no
                     animate=no
@@ -485,7 +485,7 @@
                         x,y=$x2,$y2
                     [/filter_second]
                     amount=30
-                    type=pierce
+                    damage_type=pierce
                     fire_event=yes
                     experience=no
                     animate=no
@@ -506,7 +506,7 @@
                         x,y=$x2,$y2
                     [/filter_second]
                     amount=40
-                    type=pierce
+                    damage_type=pierce
                     fire_event=yes
                     experience=no
                     animate=no
@@ -527,7 +527,7 @@
                         x,y=$x2,$y2
                     [/filter_second]
                     amount=50
-                    type=pierce
+                    damage_type=pierce
                     fire_event=yes
                     experience=no
                     animate=no
@@ -558,7 +558,7 @@
                         x,y=$x1,$y1
                     [/filter_second]
                     amount=10
-                    type=pierce
+                    damage_type=pierce
                     fire_event=yes
                     experience=no
                     animate=no
@@ -579,7 +579,7 @@
                         x,y=$x1,$y1
                     [/filter_second]
                     amount=20
-                    type=pierce
+                    damage_type=pierce
                     fire_event=yes
                     experience=no
                     animate=no
@@ -600,7 +600,7 @@
                         x,y=$x1,$y1
                     [/filter_second]
                     amount=30
-                    type=pierce
+                    damage_type=pierce
                     fire_event=yes
                     experience=no
                     animate=no
@@ -621,7 +621,7 @@
                         x,y=$x1,$y1
                     [/filter_second]
                     amount=40
-                    type=pierce
+                    damage_type=pierce
                     fire_event=yes
                     experience=no
                     animate=no
@@ -642,7 +642,7 @@
                         x,y=$x1,$y1
                     [/filter_second]
                     amount=50
-                    type=pierce
+                    damage_type=pierce
                     fire_event=yes
                     experience=no
                     animate=no
@@ -721,7 +721,7 @@
                         x,y=$x1,$y1
                     [/filter]
                     amount=2
-                    type=fire
+                    damage_type=fire
                     fire_event=yes
                     experience=no
                     animate=no
@@ -739,7 +739,7 @@
                         x,y=$x1,$y1
                     [/filter]
                     amount=3
-                    type=fire
+                    damage_type=fire
                     fire_event=yes
                     experience=no
                     animate=no
@@ -757,7 +757,7 @@
                         x,y=$x1,$y1
                     [/filter]
                     amount=5
-                    type=fire
+                    damage_type=fire
                     fire_event=yes
                     experience=no
                     animate=no
@@ -775,7 +775,7 @@
                         x,y=$x1,$y1
                     [/filter]
                     amount=7
-                    type=fire
+                    damage_type=fire
                     fire_event=yes
                     experience=no
                     animate=no
@@ -793,7 +793,7 @@
                         x,y=$x1,$y1
                     [/filter]
                     amount=10
-                    type=fire
+                    damage_type=fire
                     fire_event=yes
                     experience=no
                     animate=no
@@ -872,7 +872,7 @@
                         x,y=$x2,$y2
                     [/filter]
                     amount=2
-                    type=fire
+                    damage_type=fire
                     fire_event=yes
                     experience=no
                     animate=no
@@ -890,7 +890,7 @@
                         x,y=$x2,$y2
                     [/filter]
                     amount=3
-                    type=fire
+                    damage_type=fire
                     fire_event=yes
                     experience=no
                     animate=no
@@ -908,7 +908,7 @@
                         x,y=$x2,$y2
                     [/filter]
                     amount=5
-                    type=fire
+                    damage_type=fire
                     fire_event=yes
                     experience=no
                     animate=no
@@ -926,7 +926,7 @@
                         x,y=$x2,$y2
                     [/filter]
                     amount=7
-                    type=fire
+                    damage_type=fire
                     fire_event=yes
                     experience=no
                     animate=no
@@ -944,7 +944,7 @@
                         x,y=$x2,$y2
                     [/filter]
                     amount=10
-                    type=fire
+                    damage_type=fire
                     fire_event=yes
                     experience=no
                     animate=no

--- a/scenarios5/25_Prison.cfg
+++ b/scenarios5/25_Prison.cfg
@@ -326,7 +326,7 @@
                         id=Efraim
                     [/filter_second]
                     fire_event=no
-                    type=cold
+                    damage_type=cold
                     amount=200		#Should be enough to kill
                     kill=yes
                     animate=yes

--- a/scenarios6/14_Frozen_Land.cfg
+++ b/scenarios6/14_Frozen_Land.cfg
@@ -172,7 +172,7 @@
                         [/or]
                     [/filter]
                     fire_event=no
-                    type=cold
+                    damage_type=cold
                     amount=3
                     kill=no
                     animate=no

--- a/scenarios7/01_Another_Orcish_Assault.cfg
+++ b/scenarios7/01_Another_Orcish_Assault.cfg
@@ -457,7 +457,7 @@
                             [filter]
                                 x,y=$bomb_x,$bomb_y
                             [/filter]
-                            type=fire
+                            damage_type=fire
                             amount=40
                             fire_event=yes
                         [/harm_unit]

--- a/spinoffs/The_Beautiful_Child/units/Bringer_of_Light.cfg
+++ b/spinoffs/The_Beautiful_Child/units/Bringer_of_Light.cfg
@@ -629,7 +629,7 @@
                     side=$side_number
                     [/filter]
                     amount=24
-                    type=fire
+                    damage_type=fire
                 [/harm_unit]
             [/else]
         [/if]

--- a/spinoffs/The_Beautiful_Child/units/Bringer_of_Light3.cfg
+++ b/spinoffs/The_Beautiful_Child/units/Bringer_of_Light3.cfg
@@ -627,7 +627,7 @@
                           x,y=$target_x,$targets[$i].y
                         [/filter]
                         amount=32
-                        type=impact
+                        damage_type=impact
                         kill=yes
                         fire_event=yes
                     [/harm_unit]

--- a/spinoffs/The_Beautiful_Child/units/Manhunter.cfg
+++ b/spinoffs/The_Beautiful_Child/units/Manhunter.cfg
@@ -308,7 +308,7 @@
                         id=$targets[$target].id
                     [/filter]
                     amount=24
-                    type=impact
+                    damage_type=impact
                     fire_event=yes
                     animate=yes
                     experience=no

--- a/units/Akula_steel.cfg
+++ b/units/Akula_steel.cfg
@@ -370,7 +370,7 @@
                 x,y=$x1,$y1
             [/filter]
             amount=10
-            type=pierce
+            damage_type=pierce
             fire_event=yes
             experience=no
             animate=no
@@ -390,7 +390,7 @@
                 x,y=$x2,$y2
             [/filter]
             amount=10
-            type=pierce
+            damage_type=pierce
             fire_event=yes
             experience=no
             animate=no

--- a/utils/chapter5_utils.cfg
+++ b/utils/chapter5_utils.cfg
@@ -1158,7 +1158,7 @@ Spells remaining: " + ${VARIABLE_NAME}
                 x,y=$x2,$y2
             [/filter_second]
             amount=10
-            type=impact
+            damage_type=impact
             fire_event=yes
             experience=no
             animate=no
@@ -1184,7 +1184,7 @@ Spells remaining: " + ${VARIABLE_NAME}
                 x,y=$x1,$y1
             [/filter_second]
             amount=10
-            type=impact
+            damage_type=impact
             fire_event=yes
             experience=no
             animate=no

--- a/utils/chapter9_utils.cfg
+++ b/utils/chapter9_utils.cfg
@@ -8280,7 +8280,7 @@ The map can be viewed through the right-click menu."}
                             x,y=$near_void[$i].x,$near_void[$i].y
                         [/filter]
                         amount=32
-                        type=arcane
+                        damage_type=arcane
                         kill=yes
                     [/harm_unit]
                 [/then]
@@ -8306,7 +8306,7 @@ The map can be viewed through the right-click menu."}
                     x,y=$near_void[$i].x,$near_void[$i].y
                 [/filter]
                 amount=32
-                type=arcane
+                damage_type=arcane
                 kill=yes
             [/harm_unit]
             [if]


### PR DESCRIPTION
There are numerous places where `type=` is used instead of `damage_type=` in `[harm_unit]`, so it has no effect and always does the same damage.