### PR TITLE
Prisoner Nightstalk fix

### DIFF
--- a/scenarios5/25_Prison.cfg
+++ b/scenarios5/25_Prison.cfg
@@ -174,7 +174,7 @@
                     number=50
                     [effect]
                         apply_to=attack
-                        name=dagger
+                        name=shadow wave
                         remove_specials=backstab
                         [set_specials]
                             mode=append


### PR DESCRIPTION
One of the prisoners has a modification similar to the Nightstalk object on a weapon he does not own. Deducing from the code and the description, it is obvious that it refers to "shadow wave", which already has a normal backstab, like the one the code intend to replace.