### PR TITLE
Make Configure Autorecall menu more user-friendly

### DIFF
--- a/utils/chapter9_utils.cfg
+++ b/utils/chapter9_utils.cfg
@@ -1541,14 +1541,6 @@
         [objective]
             description=_ "Death of Efraim or Lethalia"
             condition=lose
-            [show_if]
-                [not]
-                    [variable]
-                        name=crusade_difficulty
-                        greater_than_equal_to=10
-                    [/variable]
-                [/not]
-            [/show_if]
         [/objective]
         [objective]
             description=_ "Death of Lilith"
@@ -2151,227 +2143,245 @@
             id=5confautorecall
             description=_ "Configure Autorecall"
             [command]
-                [if]
+                {VARIABLE conf_autorecall_done no}
+
+                [while]
                     [variable]
-                        name=max_autorecall
-                        greater_than_equal_to=8
+                        name=conf_autorecall_done
+                        equals=no
                     [/variable]
-                    [else]
-                        {VARIABLE max_autorecall 8}
-                    [/else]
-                [/if]
-                {VARIABLE next_autorecall_price "$($($max_autorecall-7)*100)"}
-#ifdef EASY
-                {VARIABLE_OP next_autorecall_price divide 1.5}
-#endif
-#ifdef NORMAL
-                {VARIABLE_OP next_autorecall_price divide 1.2}
-#endif
-                {VARIABLE_OP next_autorecall_price round floor}
-                [store_gold]
-                    side=1
-                    variable=gold
-                [/store_gold]
-                #Initialise the variable listing them
-                {VARIABLE autorecall_listing[0].entry "Here is a list of all units you have set to be autorecalled. You can add any number of units, but only the first $max_autorecall units are autorecalled."}
-                #Clear the units that are already dead from the list, add those who are still alive in the list in the message
-                {FOREACH autorecall i}
-                    [store_unit]
-                        [filter]
-                            id=$autorecall[$i].id
-                        [/filter]
-                        variable=to_autorecall
-                        kill=no
-                    [/store_unit]
-                    [if]
-                        [variable]
-                            name=to_autorecall.length
-                            equals=0
-                        [/variable]
-                        [then]
-                            {CLEAR_VARIABLE autorecall[$i]}
-                        [/then]
-                        [else]
-                            {VARIABLE autorecall_listing[$autorecall_listing.length].entry "$to_autorecall.name| ($to_autorecall.language_name|)"}
-                            {VARIABLE "autorecall_listing[$($autorecall_listing.length-1)].id" $to_autorecall.id}
-                        [/else]
-                    [/if]
-                    #Remove duplicates
-                    {VARIABLE authentic yes}
-                    {FOREACH unique j}
+                    [do]
                         [if]
                             [variable]
-                                name=unique[$j].id
-                                equals=$autorecall[$i].id
+                                name=max_autorecall
+                                greater_than_equal_to=8
                             [/variable]
-                            [then]
-                                {VARIABLE authentic no}
-                            [/then]
+                            [else]
+                                {VARIABLE max_autorecall 8}
+                            [/else]
                         [/if]
-                    {NEXT j}
-                    [if]
-                        [variable]
-                            name=authentic
-                            equals=yes
-                        [/variable]
-                        [then]
-                            {VARIABLE unique[$unique.length].id $autorecall[$i].id}
-                        [/then]
-                        [else]
-                            {CLEAR_VARIABLE autorecall[$i]}
-                            {VARIABLE_OP i sub 1}
-                        [/else]
-                    [/if]
-                    {CLEAR_VARIABLE to_autorecall}
-                {NEXT i}
-                {CLEAR_VARIABLE unique}
-                #Now, we have the list free of dead units, it's time show a message
-                [set_variable]
-                    name=intro_message
-                    [join]
-                        variable=autorecall_listing
-                        key=entry
-                        separator="
-"
-                        remove_empty=yes
-                    [/join]
-                [/set_variable]
-                [message]
-                    speaker=narrator
-                    image="wesnoth-icon.png"
-                    message=$intro_message
-                    [option]
-                        label=_ "Add units"
-                        [command]
-                            #Repeat until done
-                            {VARIABLE done no}
-                            [while]
+                        {VARIABLE next_autorecall_price "$($($max_autorecall-7)*100)"}
+#ifdef EASY
+                        {VARIABLE_OP next_autorecall_price divide 1.5}
+#endif
+#ifdef NORMAL
+                        {VARIABLE_OP next_autorecall_price divide 1.2}
+#endif
+                        {VARIABLE_OP next_autorecall_price round floor}
+                        [store_gold]
+                            side=1
+                            variable=gold
+                        [/store_gold]
+                        #Initialise the variable listing them
+                        {VARIABLE autorecall_listing[0].entry "Here is a list of all units you have set to be autorecalled. You can add any number of units, but only the first $max_autorecall units are autorecalled."}
+                        #Clear the units that are already dead from the list, add those who are still alive in the list in the message
+                        {FOREACH autorecall i}
+                            [store_unit]
+                                [filter]
+                                    id=$autorecall[$i].id
+                                [/filter]
+                                variable=to_autorecall
+                                kill=no
+                            [/store_unit]
+                            [if]
                                 [variable]
-                                    name=done
-                                    equals=no
+                                    name=to_autorecall.length
+                                    equals=0
                                 [/variable]
-                                [do]
-                                    [set_variables]
-                                        name=add_message
-                                        mode=replace
-                                        [value]
-                                            speaker=narrator
-                                            image="wesnoth-icon.png"
-                                            message= _ "Which unit would you like to add?"
-                                            [option]
-                                                label=_ "Back"
-                                                [command]
-                                                    {VARIABLE done yes}
-                                                [/command]
-                                            [/option]
-                                        [/value]
-                                    [/set_variables]
-                                    #Store all units
-                                    [store_unit]
-                                        [filter]
-                                            side=1
-                                            [not]
-                                                id=Efraim
-                                            [/not]
-                                            [not]
-                                                id=Lethalia
-                                            [/not]
-                                            [not]
-                                                id=Lethalia_evil
-                                            [/not]
-                                            [not]
-                                                id=Lilith
-                                            [/not]
-                                        [/filter]
-                                        variable=unit_list
-                                        kill=no
-                                    [/store_unit]
-                                    #Add them to the list
-                                    {FOREACH unit_list i}
-                                        [set_variables]
-                                            name=add_message.option[$add_message.option.length]
-                                            mode=replace
-                                            [value]
-                                                message=_ "$unit_list[$i].name| ($unit_list[$i].language_name|)"
-                                                [command]
-                                                    {VARIABLE autorecall[$autorecall.length].id $unit_list[$i].id}
-                                                [/command]
-                                            [/value]
-                                        [/set_variables]
-                                    {NEXT i}
-                                    {CLEAR_VARIABLE unit_list}
-                                    [insert_tag]
-                                        name=message
-                                        variable=add_message
-                                    [/insert_tag]
-                                [/do]
-                            [/while]
-                            {CLEAR_VARIABLE add_message,done}
-                            #Remove duplicates
-                            {FOREACH autorecall i}
-                                [store_unit]
-                                    [filter]
-                                        id=$autorecall[$i].id
-                                    [/filter]
-                                    variable=to_autorecall
-                                    kill=no
-                                [/store_unit]
-                                {VARIABLE authentic yes}
-                                {FOREACH unique j}
+                                [then]
+                                    {CLEAR_VARIABLE autorecall[$i]}
+                                [/then]
+                                [else]
+                                    {VARIABLE list_index ""}
+                                    [lua]
+                                        code=<<
+wml.variables.list_index = string.format("%4d",wml.variables.i+1)
+>>
+                                    [/lua]
+
                                     [if]
                                         [variable]
-                                            name=unique[$j].id
-                                            equals=$autorecall[$i].id
+                                            name=i
+                                            less_than=$max_autorecall
                                         [/variable]
                                         [then]
-                                            {VARIABLE authentic no}
+                                            {VARIABLE autorecall_listing[$autorecall_listing.length].entry "<span font_family='monospace'>$list_index)</span> $to_autorecall.name| ($to_autorecall.language_name|)"}
                                         [/then]
+                                        [else]
+                                            {VARIABLE autorecall_listing[$autorecall_listing.length].entry "<span font_family='monospace'>$list_index)</span><span font-style='oblique'> $to_autorecall.name| ($to_autorecall.language_name|)</span>"}
+                                        [/else]
                                     [/if]
-                                {NEXT j}
+                                    {CLEAR_VARIABLE list_index}
+                                [/else]
+                            [/if]
+                            #Remove duplicates
+                            {VARIABLE authentic yes}
+                            {FOREACH unique j}
                                 [if]
                                     [variable]
-                                        name=authentic
-                                        equals=yes
+                                        name=unique[$j].id
+                                        equals=$autorecall[$i].id
                                     [/variable]
                                     [then]
-                                        {VARIABLE unique[$unique.length].id $autorecall[$i].id}
+                                        {VARIABLE authentic no}
                                     [/then]
-                                    [else]
-                                        {CLEAR_VARIABLE autorecall[$i]}
-                                        {VARIABLE_OP i sub 1}
-                                    [/else]
                                 [/if]
-                                {CLEAR_VARIABLE to_autorecall}
-                            {NEXT i}
-                            {CLEAR_VARIABLE unique}
-                        [/command]
-                    [/option]
-                    [option]
-                        label=_ "Remove units"
-                        [command]
-                            #Repeat until done
-                            {VARIABLE done no}
-                            [while]
+                            {NEXT j}
+                            [if]
                                 [variable]
-                                    name=done
-                                    equals=no
+                                    name=authentic
+                                    equals=yes
                                 [/variable]
-                                [do]
-                                    [set_variables]
-                                        name=remove_message
-                                        mode=replace
-                                        [value]
-                                            speaker=narrator
-                                            image="wesnoth-icon.png"
-                                            message= _ "Which unit would you like to remove?"
-                                            [option]
-                                                label=_ "Back"
-                                                [command]
-                                                    {VARIABLE done yes}
-                                                [/command]
-                                            [/option]
-                                        [/value]
-                                    [/set_variables]
+                                [then]
+                                    {VARIABLE unique[$unique.length].id $autorecall[$i].id}
+                                [/then]
+                                [else]
+                                    {CLEAR_VARIABLE autorecall[$i]}
+                                    {VARIABLE_OP i sub 1}
+                                [/else]
+                            [/if]
+                            {CLEAR_VARIABLE to_autorecall}
+                        {NEXT i}
+                        {CLEAR_VARIABLE unique}
+                        #Now, we have the list free of dead units, it's time show a message
+                        [set_variable]
+                            name=intro_message
+                            [join]
+                                variable=autorecall_listing
+                                key=entry
+                                separator="
+"
+                                remove_empty=yes
+                            [/join]
+                        [/set_variable]
+                        [message]
+                            speaker=narrator
+                            image="wesnoth-icon.png"
+                            message=$intro_message
+                            [option]
+                                label=_ "Add units"
+                                [command]
+                                    #Repeat until done
+                                    {VARIABLE done no}
+                                    [while]
+                                        [variable]
+                                            name=done
+                                            equals=no
+                                        [/variable]
+                                        [do]
+                                            [set_variables]
+                                                name=add_message
+                                                mode=replace
+                                                [value]
+                                                    speaker=narrator
+                                                    image="wesnoth-icon.png"
+                                                    message= _ "Which unit would you like to add?"
+                                                    [option]
+                                                        label=_ "Back"
+                                                        [command]
+                                                            {VARIABLE done yes}
+                                                        [/command]
+                                                    [/option]
+                                                [/value]
+                                            [/set_variables]
+                                            #Store all units
+                                            [store_unit]
+                                                [filter]
+                                                    side=1
+                                                    [not]
+                                                        id=Efraim
+                                                    [/not]
+                                                    [not]
+                                                        id=Lethalia
+                                                    [/not]
+                                                    [not]
+                                                        id=Lethalia_evil
+                                                    [/not]
+                                                    [not]
+                                                        id=Lilith
+                                                    [/not]
+                                                [/filter]
+                                                variable=unit_list
+                                                kill=no
+                                            [/store_unit]
+                                            #Add them to the list
+
+                                            # Begin remove units on autorecall from list of units to add
+                                            [lua]
+                                                code=<<
+        local ul = wml.array_access.get "unit_list" 
+        local ar = wml.array_access.get "autorecall" 
+        local newul = {}
+
+        for i,a in pairs(ul) do
+            local found_match = 0
+            for j,b in pairs(ar) do
+                if a.id == b.id then     
+                    found_match = 1
+                    break
+                end 
+            end                   
+            if found_match == 0 then 
+                 table.insert(newul,a)
+            end  
+        end
+
+        wml.array_access.set("unit_list", newul)
+    >>
+                                            [/lua]
+                                            # End remove units on autorecall from list of units to add
+
+                                            # Begin sort list of units to add
+                                            [lua]
+                                                code=<<
+        local l = wml.array_access.get "unit_list"
+
+        -- Sort units alphabetically with named units first 
+        -- as they are more likely to be used.  If two units share the
+        -- same name (including ""), sort them by unit type.
+        table.sort(l, function (a, b)
+            if ((a.name ~= "") and (b.name ~= "")) then          -- Both have a name, sort alphabetically
+                return ((a.name < b.name) or                        -- Names are different, choose the first alphabetically
+                    ((a.name == b.name) and                         -- Names are the same, sort by unit type 
+                     (a.language_name < b.language_name)))
+	    elseif ((a.name ~= "") and (b.name == "")) then      -- First has name, second does not.  Choose first, so blank names end up last
+                return true
+	    elseif ((a.name == "") and (b.name ~= "")) then      -- First has no name, second does.  Choose second, so blank names end up last
+                return false                                     -- Both names are blank, sort by unit type
+            else 
+                return (a.language_name < b.language_name)       
+            end
+        end )
+
+        wml.array_access.set("unit_list", l)
+    >>
+                                            [/lua]
+                                            # End sort list of units to add
+                                            [foreach]
+                                                array=unit_list
+                                                [do]
+                                                    [set_variables]
+                                                        name=add_message.option[$add_message.option.length]
+                                                        mode=replace
+                                                        [value]
+                                                            message=_ "$unit_list[$i].name| ($unit_list[$i].language_name|)"
+                                                            [command]
+                                                                {VARIABLE autorecall[$autorecall.length].id $unit_list[$i].id}
+                                                            [/command]
+                                                        [/value]
+                                                    [/set_variables]
+                                                [/do]
+                                            [/foreach]
+
+                                            {CLEAR_VARIABLE unit_list}
+                                            [insert_tag]
+                                                name=message
+                                                variable=add_message
+                                            [/insert_tag]
+                                        [/do]
+                                    [/while]
+                                    {CLEAR_VARIABLE add_message,done}
+                                    #Remove duplicates
                                     {FOREACH autorecall i}
                                         [store_unit]
                                             [filter]
@@ -2380,56 +2390,159 @@
                                             variable=to_autorecall
                                             kill=no
                                         [/store_unit]
-                                        [set_variables]
-                                            name=remove_message.option[$remove_message.option.length]
-                                            mode=replace
-                                            [value]
-                                                message=_ "$to_autorecall.name| ($to_autorecall.language_name|)"
-                                                [command]
-                                                    {CLEAR_VARIABLE autorecall[$i]}
-                                                [/command]
-                                            [/value]
-                                        [/set_variables]
+                                        {VARIABLE authentic yes}
+                                        {FOREACH unique j}
+                                            [if]
+                                                [variable]
+                                                    name=unique[$j].id
+                                                    equals=$autorecall[$i].id
+                                                [/variable]
+                                                [then]
+                                                    {VARIABLE authentic no}
+                                                [/then]
+                                            [/if]
+                                        {NEXT j}
+                                        [if]
+                                            [variable]
+                                                name=authentic
+                                                equals=yes
+                                            [/variable]
+                                            [then]
+                                                {VARIABLE unique[$unique.length].id $autorecall[$i].id}
+                                            [/then]
+                                            [else]
+                                                {CLEAR_VARIABLE autorecall[$i]}
+                                                {VARIABLE_OP i sub 1}
+                                            [/else]
+                                        [/if]
                                         {CLEAR_VARIABLE to_autorecall}
                                     {NEXT i}
-                                    [insert_tag]
-                                        name=message
-                                        variable=remove_message
-                                    [/insert_tag]
-                                [/do]
-                            [/while]
-                            {CLEAR_VARIABLE remove_message,done}
-                        [/command]
-                        [show_if]
-                            [variable]
-                                name=autorecall.length
-                                greater_than=0
-                            [/variable]
-                        [/show_if]
-                    [/option]
-                    [option]
-                        label=_ "Buy space to recall more units automatically ($next_autorecall_price)"
-                        [show_if]
-                            [variable]
-                                name=gold
-                                greater_than_equal_to=$next_autorecall_price
-                            [/variable]
-                        [/show_if]
-                        [command]
-                            [gold]
-                                side=1
-                                amount="$(-1*$next_autorecall_price)"
-                            [/gold]
-                            {VARIABLE_OP max_autorecall add 1}
-                        [/command]
-                    [/option]
-                    [option]
-                        label=_ "Back"
-                        [command]
-                        [/command]
-                    [/option]
-                [/message]
-                {CLEAR_VARIABLE to_autorecall,intro_message,autorecall_listing,authentic,unique,next_autorecall_price,gold}
+                                    {CLEAR_VARIABLE unique}
+                                [/command]
+                            [/option]
+                            [option]
+                                label=_ "Remove units"
+                                [command]
+                                    #Repeat until done
+                                    {VARIABLE done no}
+                                    [while]
+                                        [variable]
+                                            name=done
+                                            equals=no
+                                        [/variable]
+                                        [do]
+                                            [set_variables]
+                                                name=remove_message
+                                                mode=replace
+                                                [value]
+                                                    speaker=narrator
+                                                    image="wesnoth-icon.png"
+                                                    message= _ "Which unit would you like to remove?"
+                                                    [option]
+                                                        label=_ "Back"
+                                                        [command]
+                                                            {VARIABLE done yes}
+                                                        [/command]
+                                                    [/option]
+                                                [/value]
+                                            [/set_variables]
+                                            {FOREACH autorecall i}
+                                                [store_unit]
+                                                    [filter]
+                                                        id=$autorecall[$i].id
+                                                    [/filter]
+                                                    variable=to_autorecall
+                                                    kill=no
+                                                [/store_unit]
+
+                                                {VARIABLE list_index ""}
+                                                [lua]
+                                                    code=<<
+wml.variables.list_index = string.format("%4d",wml.variables.i+1)
+>>
+                                                [/lua]
+
+                                                [if]
+                                                    [variable]
+                                                        name=i
+                                                        less_than=$max_autorecall
+                                                    [/variable]
+                                                    [then]
+                                                        {VARIABLE my_message "<span font_family='monospace'>$list_index|)</span> $to_autorecall.name| ($to_autorecall.language_name|)" }
+                                                    [/then]
+                                                    [else]
+                                                        {VARIABLE my_message "<span font_family='monospace'>$list_index|)</span><span font-style='oblique'> $to_autorecall.name| ($to_autorecall.language_name|)</span>"}
+                                                    [/else]
+                                                [/if]
+                                                {CLEAR_VARIABLE list_index}
+                                                [set_variables]
+                                                    name=remove_message.option[$remove_message.option.length]
+                                                    mode=replace
+                                                    [value]
+                                                        message=_ "$my_message|"
+                                                        [command]
+                                                            {CLEAR_VARIABLE autorecall[$i]}
+                                                        [/command]
+                                                    [/value]
+                                                [/set_variables]
+                                                {CLEAR_VARIABLE my_message}
+                                                {CLEAR_VARIABLE to_autorecall}
+                                            {NEXT i}
+                                            [insert_tag]
+                                                name=message
+                                                variable=remove_message
+                                            [/insert_tag]
+                                        [/do]
+                                    [/while]
+                                    {CLEAR_VARIABLE remove_message,done}
+                                [/command]
+                                [show_if]
+                                    [variable]
+                                        name=autorecall.length
+                                        greater_than=0
+                                    [/variable]
+                                [/show_if]
+                            [/option]
+
+                            ## This probably shouldn't be a clickable option, but I don't know how
+                            ## else to set it up.
+                            [option]
+                                label=_ "Not enough gold to buy space to recall more units automatically (need $next_autorecall_price)"
+                                [show_if]
+                                    [variable]
+                                        name=gold
+                                        less_than=$next_autorecall_price
+                                    [/variable]
+                                [/show_if]
+                            [/option]
+
+                            [option]
+                                label=_ "Buy space to recall more units automatically ($next_autorecall_price)"
+                                [show_if]
+                                    [variable]
+                                        name=gold
+                                        greater_than_equal_to=$next_autorecall_price
+                                    [/variable]
+                                [/show_if]
+                                [command]
+                                    [gold]
+                                        side=1
+                                        amount="$(-1*$next_autorecall_price)"
+                                    [/gold]
+                                    {VARIABLE_OP max_autorecall add 1}
+                                [/command]
+                            [/option]
+                            [option]
+                                label=_ "Back"
+                                [command]
+                                    {VARIABLE conf_autorecall_done yes}
+                                [/command]
+                            [/option]
+                        [/message]
+                        {CLEAR_VARIABLE to_autorecall,intro_message,autorecall_listing,authentic,unique,next_autorecall_price,gold}
+                    [/do]   # configure autorecall
+                [/while]
+                {CLEAR_VARIABLE conf_autorecall_done}
             [/command]
         [/set_menu_item]
         [if]


### PR DESCRIPTION
 - remove units that are already on the autorecall list from the list of units to add
 - sort autorecall list, units by name (with blank names at end), then by unit type
 - show "not enough gold to add to recall" message
 - keep Configure Autorecall open until you're done
 - add numbers/oblique to units on recall list to differentiate those that will be recalled

I was going to add a new option to move existing units up/down in the autorecall list, which I think would be a big help.  But then I realized that would be enough work that I really should just go all the way and replace the existing menu with:

Initially, show Back/Add Slot using Gold/Select Unit When user selects unit, new options appear:
 - Move unit up/down
 - Add unit(s) above
 - Add unit(s) below
 - Remove unit

Consistent, easy to use, and way more WML than I care to take on.