### PR TITLE
Sort add units, not enough gold message

### DIFF
--- a/utils/chapter9_utils.cfg
+++ b/utils/chapter9_utils.cfg
@@ -2287,7 +2287,36 @@
                                         kill=no
                                     [/store_unit]
                                     #Add them to the list
-                                    {FOREACH unit_list i}
+
+# Begin sort add unit list
+[lua]   
+    code=<<
+        local l = wml.array_access.get "unit_list"
+
+        -- Sort units alphabetically with named units first 
+        -- as they are more likely to be used.  If two units share the
+        -- same name (including ""), sort them by unit type.
+        table.sort(l, function (a, b)
+            if ((a.name ~= "") and (b.name ~= "")) then
+                return ((a.name < b.name) or
+                    ((a.name == b.name) and 
+                     (a.language_name < b.language_name)))
+	    elseif ((a.name ~= "") and (b.name == "")) then
+                return true
+	    elseif ((a.name == "") and (b.name ~= "")) then
+                return false
+            else 
+                return (a.language_name < b.language_name)
+            end
+        end )
+
+        wml.array_access.set("unit_list", l)
+    >>
+[/lua]  
+# End sort add unit list
+				     [foreach]
+					array=unit_list
+					[do]
                                         [set_variables]
                                             name=add_message.option[$add_message.option.length]
                                             mode=replace
@@ -2298,7 +2327,9 @@
                                                 [/command]
                                             [/value]
                                         [/set_variables]
-                                    {NEXT i}
+			                [/do]
+                                    [/foreach]
+ 
                                     {CLEAR_VARIABLE unit_list}
                                     [insert_tag]
                                         name=message
@@ -2407,7 +2438,16 @@
                             [/variable]
                         [/show_if]
                     [/option]
-                    [option]
+  		    [option]
+			label=_ "Not enough gold to buy space to recall more units automatically (need $next_autorecall_price)"
+                        [show_if]
+                            [variable]
+                                name=gold
+                                less_than=$next_autorecall_price
+                            [/variable]
+                        [/show_if]
+                     [/option] 
+                     [option]
                         label=_ "Buy space to recall more units automatically ($next_autorecall_price)"
                         [show_if]
                             [variable]


### PR DESCRIPTION
- Sort the list of units when adding units.  First by name, with the units without names last (assume most players are less interested in unnamed undead units), then by unit type.
- When you don't have enough gold to add to the list, present a message telling you how much you need instead of just not showing the option to add.
- Replaced one {FOREACH} with [foreach] since I was there