### PR TITLE
Keep Configure Autorecall menu open

### DIFF
--- a/utils/chapter9_utils.cfg
+++ b/utils/chapter9_utils.cfg
@@ -2151,146 +2151,153 @@
             id=5confautorecall
             description=_ "Configure Autorecall"
             [command]
-                [if]
+                {VARIABLE conf_autorecall_done no}
+                [while]
                     [variable]
-                        name=max_autorecall
-                        greater_than_equal_to=8
+                        name=conf_autorecall_done
+                        equals=no
                     [/variable]
-                    [else]
-                        {VARIABLE max_autorecall 8}
-                    [/else]
-                [/if]
-                {VARIABLE next_autorecall_price "$($($max_autorecall-7)*100)"}
-#ifdef EASY
-                {VARIABLE_OP next_autorecall_price divide 1.5}
-#endif
-#ifdef NORMAL
-                {VARIABLE_OP next_autorecall_price divide 1.2}
-#endif
-                {VARIABLE_OP next_autorecall_price round floor}
-                [store_gold]
-                    side=1
-                    variable=gold
-                [/store_gold]
-                #Initialise the variable listing them
-                {VARIABLE autorecall_listing[0].entry "Here is a list of all units you have set to be autorecalled. You can add any number of units, but only the first $max_autorecall units are autorecalled."}
-                #Clear the units that are already dead from the list, add those who are still alive in the list in the message
-                {FOREACH autorecall i}
-                    [store_unit]
-                        [filter]
-                            id=$autorecall[$i].id
-                        [/filter]
-                        variable=to_autorecall
-                        kill=no
-                    [/store_unit]
-                    [if]
-                        [variable]
-                            name=to_autorecall.length
-                            equals=0
-                        [/variable]
-                        [then]
-                            {CLEAR_VARIABLE autorecall[$i]}
-                        [/then]
-                        [else]
-                            {VARIABLE autorecall_listing[$autorecall_listing.length].entry "$to_autorecall.name| ($to_autorecall.language_name|)"}
-                            {VARIABLE "autorecall_listing[$($autorecall_listing.length-1)].id" $to_autorecall.id}
-                        [/else]
-                    [/if]
-                    #Remove duplicates
-                    {VARIABLE authentic yes}
-                    {FOREACH unique j}
+                    [do]
                         [if]
                             [variable]
-                                name=unique[$j].id
-                                equals=$autorecall[$i].id
+                                name=max_autorecall
+                                greater_than_equal_to=8
                             [/variable]
-                            [then]
-                                {VARIABLE authentic no}
-                            [/then]
+                            [else]
+                                {VARIABLE max_autorecall 8}
+                            [/else]
                         [/if]
-                    {NEXT j}
-                    [if]
-                        [variable]
-                            name=authentic
-                            equals=yes
-                        [/variable]
-                        [then]
-                            {VARIABLE unique[$unique.length].id $autorecall[$i].id}
-                        [/then]
-                        [else]
-                            {CLEAR_VARIABLE autorecall[$i]}
-                            {VARIABLE_OP i sub 1}
-                        [/else]
-                    [/if]
-                    {CLEAR_VARIABLE to_autorecall}
-                {NEXT i}
-                {CLEAR_VARIABLE unique}
-                #Now, we have the list free of dead units, it's time show a message
-                [set_variable]
-                    name=intro_message
-                    [join]
-                        variable=autorecall_listing
-                        key=entry
-                        separator="
-"
-                        remove_empty=yes
-                    [/join]
-                [/set_variable]
-                [message]
-                    speaker=narrator
-                    image="wesnoth-icon.png"
-                    message=$intro_message
-                    [option]
-                        label=_ "Add units"
-                        [command]
-                            #Repeat until done
-                            {VARIABLE done no}
-                            [while]
+                        {VARIABLE next_autorecall_price "$($($max_autorecall-7)*100)"}
+#ifdef EASY
+                        {VARIABLE_OP next_autorecall_price divide 1.5}
+#endif
+#ifdef NORMAL
+                        {VARIABLE_OP next_autorecall_price divide 1.2}
+#endif
+                        {VARIABLE_OP next_autorecall_price round floor}
+                        [store_gold]
+                            side=1
+                            variable=gold
+                        [/store_gold]
+                        #Initialise the variable listing them
+                        {VARIABLE autorecall_listing[0].entry "Here is a list of all units you have set to be autorecalled. You can add any number of units, but only the first $max_autorecall units are autorecalled."}
+                        #Clear the units that are already dead from the list, add those who are still alive in the list in the message
+                        {FOREACH autorecall i}
+                            [store_unit]
+                                [filter]
+                                    id=$autorecall[$i].id
+                                [/filter]
+                                variable=to_autorecall
+                                kill=no
+                            [/store_unit]
+                            [if]
                                 [variable]
-                                    name=done
-                                    equals=no
+                                    name=to_autorecall.length
+                                    equals=0
                                 [/variable]
-                                [do]
-                                    [set_variables]
-                                        name=add_message
-                                        mode=replace
-                                        [value]
-                                            speaker=narrator
-                                            image="wesnoth-icon.png"
-                                            message= _ "Which unit would you like to add?"
-                                            [option]
-                                                label=_ "Back"
-                                                [command]
-                                                    {VARIABLE done yes}
-                                                [/command]
-                                            [/option]
-                                        [/value]
-                                    [/set_variables]
-                                    #Store all units
-                                    [store_unit]
-                                        [filter]
-                                            side=1
-                                            [not]
-                                                id=Efraim
-                                            [/not]
-                                            [not]
-                                                id=Lethalia
-                                            [/not]
-                                            [not]
-                                                id=Lethalia_evil
-                                            [/not]
-                                            [not]
-                                                id=Lilith
-                                            [/not]
-                                        [/filter]
-                                        variable=unit_list
-                                        kill=no
-                                    [/store_unit]
-                                    #Add them to the list
+                                [then]
+                                    {CLEAR_VARIABLE autorecall[$i]}
+                                [/then]
+                                [else]
+                                    {VARIABLE autorecall_listing[$autorecall_listing.length].entry "$to_autorecall.name| ($to_autorecall.language_name|)"}
+                                    {VARIABLE "autorecall_listing[$($autorecall_listing.length-1)].id" $to_autorecall.id}
+                                [/else]
+                            [/if]
+                            #Remove duplicates
+                            {VARIABLE authentic yes}
+                            {FOREACH unique j}
+                                [if]
+                                    [variable]
+                                        name=unique[$j].id
+                                        equals=$autorecall[$i].id
+                                    [/variable]
+                                    [then]
+                                        {VARIABLE authentic no}
+                                    [/then]
+                                [/if]
+                            {NEXT j}
+                            [if]
+                                [variable]
+                                    name=authentic
+                                    equals=yes
+                                [/variable]
+                                [then]
+                                    {VARIABLE unique[$unique.length].id $autorecall[$i].id}
+                                [/then]
+                                [else]
+                                    {CLEAR_VARIABLE autorecall[$i]}
+                                    {VARIABLE_OP i sub 1}
+                                [/else]
+                            [/if]
+                            {CLEAR_VARIABLE to_autorecall}
+                        {NEXT i}
+                        {CLEAR_VARIABLE unique}
+                        #Now, we have the list free of dead units, it's time show a message
+                        [set_variable]
+                            name=intro_message
+                            [join]
+                                variable=autorecall_listing
+                                key=entry
+                                separator="
+"
+                                remove_empty=yes
+                            [/join]
+                        [/set_variable]
+                        [message]
+                            speaker=narrator
+                            image="wesnoth-icon.png"
+                            message=$intro_message
+                            [option]
+                                label=_ "Add units"
+                                [command]
+                                    #Repeat until done
+                                    {VARIABLE done no}
+                                    [while]
+                                        [variable]
+                                            name=done
+                                            equals=no
+                                        [/variable]
+                                        [do]
+                                            [set_variables]
+                                                name=add_message
+                                                mode=replace
+                                                [value]
+                                                    speaker=narrator
+                                                    image="wesnoth-icon.png"
+                                                    message= _ "Which unit would you like to add?"
+                                                    [option]
+                                                        label=_ "Back"
+                                                        [command]
+                                                            {VARIABLE done yes}
+                                                        [/command]
+                                                    [/option]
+                                                [/value]
+                                            [/set_variables]
+                                            #Store all units
+                                            [store_unit]
+                                                [filter]
+                                                    side=1
+                                                    [not]
+                                                        id=Efraim
+                                                    [/not]
+                                                    [not]
+                                                        id=Lethalia
+                                                    [/not]
+                                                    [not]
+                                                        id=Lethalia_evil
+                                                    [/not]
+                                                    [not]
+                                                        id=Lilith
+                                                    [/not]
+                                                [/filter]
+                                                variable=unit_list
+                                                kill=no
+                                            [/store_unit]
+                                            #Add them to the list
 
-# Begin sort add unit list
-[lua]   
-    code=<<
+                                            # Begin sort add unit list
+                                            [lua]
+                                                code=<<
         local l = wml.array_access.get "unit_list"
 
         -- Sort units alphabetically with named units first 
@@ -2312,97 +2319,33 @@
 
         wml.array_access.set("unit_list", l)
     >>
-[/lua]  
-# End sort add unit list
-				     [foreach]
-					array=unit_list
-					[do]
-                                        [set_variables]
-                                            name=add_message.option[$add_message.option.length]
-                                            mode=replace
-                                            [value]
-                                                message=_ "$unit_list[$i].name| ($unit_list[$i].language_name|)"
-                                                [command]
-                                                    {VARIABLE autorecall[$autorecall.length].id $unit_list[$i].id}
-                                                [/command]
-                                            [/value]
-                                        [/set_variables]
-			                [/do]
-                                    [/foreach]
- 
-                                    {CLEAR_VARIABLE unit_list}
-                                    [insert_tag]
-                                        name=message
-                                        variable=add_message
-                                    [/insert_tag]
-                                [/do]
-                            [/while]
-                            {CLEAR_VARIABLE add_message,done}
-                            #Remove duplicates
-                            {FOREACH autorecall i}
-                                [store_unit]
-                                    [filter]
-                                        id=$autorecall[$i].id
-                                    [/filter]
-                                    variable=to_autorecall
-                                    kill=no
-                                [/store_unit]
-                                {VARIABLE authentic yes}
-                                {FOREACH unique j}
-                                    [if]
-                                        [variable]
-                                            name=unique[$j].id
-                                            equals=$autorecall[$i].id
-                                        [/variable]
-                                        [then]
-                                            {VARIABLE authentic no}
-                                        [/then]
-                                    [/if]
-                                {NEXT j}
-                                [if]
-                                    [variable]
-                                        name=authentic
-                                        equals=yes
-                                    [/variable]
-                                    [then]
-                                        {VARIABLE unique[$unique.length].id $autorecall[$i].id}
-                                    [/then]
-                                    [else]
-                                        {CLEAR_VARIABLE autorecall[$i]}
-                                        {VARIABLE_OP i sub 1}
-                                    [/else]
-                                [/if]
-                                {CLEAR_VARIABLE to_autorecall}
-                            {NEXT i}
-                            {CLEAR_VARIABLE unique}
-                        [/command]
-                    [/option]
-                    [option]
-                        label=_ "Remove units"
-                        [command]
-                            #Repeat until done
-                            {VARIABLE done no}
-                            [while]
-                                [variable]
-                                    name=done
-                                    equals=no
-                                [/variable]
-                                [do]
-                                    [set_variables]
-                                        name=remove_message
-                                        mode=replace
-                                        [value]
-                                            speaker=narrator
-                                            image="wesnoth-icon.png"
-                                            message= _ "Which unit would you like to remove?"
-                                            [option]
-                                                label=_ "Back"
-                                                [command]
-                                                    {VARIABLE done yes}
-                                                [/command]
-                                            [/option]
-                                        [/value]
-                                    [/set_variables]
+                                            [/lua]
+                                            # End sort add unit list
+                                            [foreach]
+                                                array=unit_list
+                                                [do]
+                                                    [set_variables]
+                                                        name=add_message.option[$add_message.option.length]
+                                                        mode=replace
+                                                        [value]
+                                                            message=_ "$unit_list[$i].name| ($unit_list[$i].language_name|)"
+                                                            [command]
+                                                                {VARIABLE autorecall[$autorecall.length].id $unit_list[$i].id}
+                                                            [/command]
+                                                        [/value]
+                                                    [/set_variables]
+                                                [/do]
+                                            [/foreach]
+
+                                            {CLEAR_VARIABLE unit_list}
+                                            [insert_tag]
+                                                name=message
+                                                variable=add_message
+                                            [/insert_tag]
+                                        [/do]
+                                    [/while]
+                                    {CLEAR_VARIABLE add_message,done}
+                                    #Remove duplicates
                                     {FOREACH autorecall i}
                                         [store_unit]
                                             [filter]
@@ -2411,65 +2354,133 @@
                                             variable=to_autorecall
                                             kill=no
                                         [/store_unit]
-                                        [set_variables]
-                                            name=remove_message.option[$remove_message.option.length]
-                                            mode=replace
-                                            [value]
-                                                message=_ "$to_autorecall.name| ($to_autorecall.language_name|)"
-                                                [command]
-                                                    {CLEAR_VARIABLE autorecall[$i]}
-                                                [/command]
-                                            [/value]
-                                        [/set_variables]
+                                        {VARIABLE authentic yes}
+                                        {FOREACH unique j}
+                                            [if]
+                                                [variable]
+                                                    name=unique[$j].id
+                                                    equals=$autorecall[$i].id
+                                                [/variable]
+                                                [then]
+                                                    {VARIABLE authentic no}
+                                                [/then]
+                                            [/if]
+                                        {NEXT j}
+                                        [if]
+                                            [variable]
+                                                name=authentic
+                                                equals=yes
+                                            [/variable]
+                                            [then]
+                                                {VARIABLE unique[$unique.length].id $autorecall[$i].id}
+                                            [/then]
+                                            [else]
+                                                {CLEAR_VARIABLE autorecall[$i]}
+                                                {VARIABLE_OP i sub 1}
+                                            [/else]
+                                        [/if]
                                         {CLEAR_VARIABLE to_autorecall}
                                     {NEXT i}
-                                    [insert_tag]
-                                        name=message
-                                        variable=remove_message
-                                    [/insert_tag]
-                                [/do]
-                            [/while]
-                            {CLEAR_VARIABLE remove_message,done}
-                        [/command]
-                        [show_if]
-                            [variable]
-                                name=autorecall.length
-                                greater_than=0
-                            [/variable]
-                        [/show_if]
-                    [/option]
-  		    [option]
-			label=_ "Not enough gold to buy space to recall more units automatically (need $next_autorecall_price)"
-                        [show_if]
-                            [variable]
-                                name=gold
-                                less_than=$next_autorecall_price
-                            [/variable]
-                        [/show_if]
-                     [/option] 
-                     [option]
-                        label=_ "Buy space to recall more units automatically ($next_autorecall_price)"
-                        [show_if]
-                            [variable]
-                                name=gold
-                                greater_than_equal_to=$next_autorecall_price
-                            [/variable]
-                        [/show_if]
-                        [command]
-                            [gold]
-                                side=1
-                                amount="$(-1*$next_autorecall_price)"
-                            [/gold]
-                            {VARIABLE_OP max_autorecall add 1}
-                        [/command]
-                    [/option]
-                    [option]
-                        label=_ "Back"
-                        [command]
-                        [/command]
-                    [/option]
-                [/message]
-                {CLEAR_VARIABLE to_autorecall,intro_message,autorecall_listing,authentic,unique,next_autorecall_price,gold}
+                                    {CLEAR_VARIABLE unique}
+                                [/command]
+                            [/option]
+                            [option]
+                                label=_ "Remove units"
+                                [command]
+                                    #Repeat until done
+                                    {VARIABLE done no}
+                                    [while]
+                                        [variable]
+                                            name=done
+                                            equals=no
+                                        [/variable]
+                                        [do]
+                                            [set_variables]
+                                                name=remove_message
+                                                mode=replace
+                                                [value]
+                                                    speaker=narrator
+                                                    image="wesnoth-icon.png"
+                                                    message= _ "Which unit would you like to remove?"
+                                                    [option]
+                                                        label=_ "Back"
+                                                        [command]
+                                                            {VARIABLE done yes}
+                                                        [/command]
+                                                    [/option]
+                                                [/value]
+                                            [/set_variables]
+                                            {FOREACH autorecall i}
+                                                [store_unit]
+                                                    [filter]
+                                                        id=$autorecall[$i].id
+                                                    [/filter]
+                                                    variable=to_autorecall
+                                                    kill=no
+                                                [/store_unit]
+                                                [set_variables]
+                                                    name=remove_message.option[$remove_message.option.length]
+                                                    mode=replace
+                                                    [value]
+                                                        message=_ "$to_autorecall.name| ($to_autorecall.language_name|)"
+                                                        [command]
+                                                            {CLEAR_VARIABLE autorecall[$i]}
+                                                        [/command]
+                                                    [/value]
+                                                [/set_variables]
+                                                {CLEAR_VARIABLE to_autorecall}
+                                            {NEXT i}
+                                            [insert_tag]
+                                                name=message
+                                                variable=remove_message
+                                            [/insert_tag]
+                                        [/do]
+                                    [/while]
+                                    {CLEAR_VARIABLE remove_message,done}
+                                [/command]
+                                [show_if]
+                                    [variable]
+                                        name=autorecall.length
+                                        greater_than=0
+                                    [/variable]
+                                [/show_if]
+                            [/option]
+                            [option]
+                                label=_ "Not enough gold to buy space to recall more units automatically (need $next_autorecall_price)"
+                                [show_if]
+                                    [variable]
+                                        name=gold
+                                        less_than=$next_autorecall_price
+                                    [/variable]
+                                [/show_if]
+                            [/option]
+                            [option]
+                                label=_ "Buy space to recall more units automatically ($next_autorecall_price)"
+                                [show_if]
+                                    [variable]
+                                        name=gold
+                                        greater_than_equal_to=$next_autorecall_price
+                                    [/variable]
+                                [/show_if]
+                                [command]
+                                    [gold]
+                                        side=1
+                                        amount="$(-1*$next_autorecall_price)"
+                                    [/gold]
+                                    {VARIABLE_OP max_autorecall add 1}
+                                [/command]
+                            [/option]
+                            [option]
+                                label=_ "Back"
+                                [command]
+                                    {VARIABLE conf_autorecall_done yes}
+                                [/command]
+                            [/option]
+                        [/message]
+                        {CLEAR_VARIABLE to_autorecall,intro_message,autorecall_listing,authentic,unique,next_autorecall_price,gold}
+                    [/do]   # configure autorecall
+                [/while]
+                {CLEAR_VARIABLE conf_autorecall_done}
             [/command]
         [/set_menu_item]
         [if]


### PR DESCRIPTION
If you want to add a unit and remove a unit, for example, you shouldn't need to open Configure Autorecall multiple times.

Probably should rename top level Back button to Exit