### PR TITLE
Remove units from add list already on autorecall list

### DIFF
--- a/utils/chapter9_utils.cfg
+++ b/utils/chapter9_utils.cfg
@@ -2294,7 +2294,30 @@
                                                 kill=no
                                             [/store_unit]
                                             #Add them to the list
+                                            # Begin remove units on autorecall from list of units to add
+                                            [lua]
+                                                code=<<
+        local ul = wml.array_access.get "unit_list"
+        local ar = wml.array_access.get "autorecall"
+        local newul = {}
 
+        for _,a in pairs(ul) do
+            local found_match = 0
+            for _,b in pairs(ar) do
+                if a.id == b.id then
+                    found_match = 1
+                    break
+                end
+            end
+            if found_match == 0 then
+                table.insert(newul,a)
+            end
+        end
+
+        wml.array_access.set("unit_list", newul)
+    >>
+                                            [/lua]
+                                            # End remove units on autorecall from list of units to add
                                             # Begin sort add unit list
                                             [lua]
                                                 code=<<
@@ -2319,7 +2342,7 @@
 
                                                     wml.array_access.set("unit_list", l)
                                                 >>
-                                            [/lua]  
+                                            [/lua]
                                             # End sort add unit list
                                             [foreach]
                                                 array=unit_list
@@ -2336,7 +2359,7 @@
                                                     [/set_variables]
                                                 [/do]
                                             [/foreach]
-     
+
                                             {CLEAR_VARIABLE unit_list}
                                             [insert_tag]
                                                 name=message
@@ -2453,8 +2476,8 @@
                                         less_than=$next_autorecall_price
                                     [/variable]
                                 [/show_if]
-                             [/option] 
-                             [option]
+                            [/option]
+                            [option]
                                 label=_ "Buy space to recall more units automatically ($next_autorecall_price)"
                                 [show_if]
                                     [variable]


### PR DESCRIPTION
Currently, "Add units" includes units that are already on the autorecall list.

There's probably a more elegant way in lua to check if an object is already a member than iterating through the lists, but I couldn't find it.