### PR TITLE
Autorecall ordered oblique

### DIFF
--- a/utils/chapter9_utils.cfg
+++ b/utils/chapter9_utils.cfg
@@ -2294,7 +2294,30 @@
                                                 kill=no
                                             [/store_unit]
                                             #Add them to the list
+                                            # Begin remove units on autorecall from list of units to add
+                                            [lua]
+                                                code=<<
+        local ul = wml.array_access.get "unit_list"
+        local ar = wml.array_access.get "autorecall"
+        local newul = {}
 
+        for _,a in pairs(ul) do
+            local found_match = 0
+            for _,b in pairs(ar) do
+                if a.id == b.id then
+                    found_match = 1
+                    break
+                end
+            end
+            if found_match == 0 then
+                table.insert(newul,a)
+            end
+        end
+
+        wml.array_access.set("unit_list", newul)
+    >>
+                                            [/lua]
+                                            # End remove units on autorecall from list of units to add
                                             # Begin sort add unit list
                                             [lua]
                                                 code=<<
@@ -2319,7 +2342,7 @@
 
                                                     wml.array_access.set("unit_list", l)
                                                 >>
-                                            [/lua]  
+                                            [/lua]
                                             # End sort add unit list
                                             [foreach]
                                                 array=unit_list
@@ -2336,7 +2359,7 @@
                                                     [/set_variables]
                                                 [/do]
                                             [/foreach]
-     
+
                                             {CLEAR_VARIABLE unit_list}
                                             [insert_tag]
                                                 name=message
@@ -2453,8 +2476,8 @@
                                         less_than=$next_autorecall_price
                                     [/variable]
                                 [/show_if]
-                             [/option] 
-                             [option]
+                            [/option]
+                            [option]
                                 label=_ "Buy space to recall more units automatically ($next_autorecall_price)"
                                 [show_if]
                                     [variable]

--- a/utils/chapter9_utils.cfg
+++ b/utils/chapter9_utils.cfg
@@ -2199,8 +2199,26 @@
                                     {CLEAR_VARIABLE autorecall[$i]}
                                 [/then]
                                 [else]
-                                    {VARIABLE autorecall_listing[$autorecall_listing.length].entry "$to_autorecall.name| ($to_autorecall.language_name|)"}
-                                    {VARIABLE "autorecall_listing[$($autorecall_listing.length-1)].id" $to_autorecall.id}
+                                    {VARIABLE list_index ""}
+                                    [lua]
+                                        code=<<
+wml.variables.list_index = string.format("%4d",wml.variables.i+1)
+>>
+                                    [/lua]
+
+                                    [if]
+                                        [variable]
+                                            name=i
+                                            less_than=$max_autorecall
+                                        [/variable]
+                                        [then]
+                                            {VARIABLE autorecall_listing[$autorecall_listing.length].entry "<span font_family='monospace'>$list_index)</span> $to_autorecall.name| ($to_autorecall.language_name|)"}
+                                        [/then]
+                                        [else]
+                                            {VARIABLE autorecall_listing[$autorecall_listing.length].entry "<span font_family='monospace'>$list_index)</span><span font-style='oblique'> $to_autorecall.name| ($to_autorecall.language_name|)</span>"}
+                                        [/else]
+                                    [/if]
+                                    {CLEAR_VARIABLE list_index}
                                 [/else]
                             [/if]
                             #Remove duplicates
@@ -2441,17 +2459,38 @@
                                                     variable=to_autorecall
                                                     kill=no
                                                 [/store_unit]
+                                                {VARIABLE list_index ""}
+                                                [lua]
+                                                    code=<<
+wml.variables.list_index = string.format("%4d",wml.variables.i+1)
+>>
+                                                [/lua]
+
+                                                [if]
+                                                    [variable]
+                                                        name=i
+                                                        less_than=$max_autorecall
+                                                    [/variable]
+                                                    [then]
+                                                        {VARIABLE my_message "<span font_family='monospace'>$list_index|)</span> $to_autorecall.name| ($to_autorecall.language_name|)" }
+                                                    [/then]
+                                                    [else]
+                                                        {VARIABLE my_message "<span font_family='monospace'>$list_index|)</span><span font-style='oblique'> $to_autorecall.name| ($to_autorecall.language_name|)</span>"}
+                                                    [/else]
+                                                [/if]
+                                                {CLEAR_VARIABLE list_index}
                                                 [set_variables]
                                                     name=remove_message.option[$remove_message.option.length]
                                                     mode=replace
                                                     [value]
-                                                        message=_ "$to_autorecall.name| ($to_autorecall.language_name|)"
+                                                        message=_ "$my_message|"
                                                         [command]
                                                             {CLEAR_VARIABLE autorecall[$i]}
                                                         [/command]
                                                     [/value]
                                                 [/set_variables]
                                                 {CLEAR_VARIABLE to_autorecall}
+                                                {CLEAR_VARIABLE my_message}
                                             {NEXT i}
                                             [insert_tag]
                                                 name=message


### PR DESCRIPTION
Present autorecall list as ordered list, with units that won't be recalled flagged with oblique font.

I'm a little embarrassed by the "my_message" stuff.  Worked well enough to minimize changes to existing code while testing.  When I tried to move the if i < max_autorecall conditional inside the value block it didn't work any more, and I just don't care enough about style to beat my head against wml to make it pretty.

Trying something new (to me) with branches here, hopefully it makes sense, otherwise I can redo.