### PR TITLE
Part II fixes

### DIFF
--- a/scenarios6/01_The_Awakening.cfg
+++ b/scenarios6/01_The_Awakening.cfg
@@ -61,36 +61,6 @@
                 [/show_if]
             [/objective]
         [/objectives]
-        [message]
-            speaker=narrator
-            image="wesnoth-icon.png"
-            message= _ "In the dark, in a forgotten tomb deep under all places known to mankind..."
-        [/message]
-        [message]
-            speaker=narrator
-            image="wesnoth-icon.png"
-            message= _ "She awoke. Everything was black, there was nothing but wide and deep darkness. She was almost unable to move. Something was preventing her from moving. With all her strength, she managed to tear these things away from her. She fell on the ground."
-        [/message]
-        [message]
-            speaker=narrator
-            image="wesnoth-icon.png"
-            message= _ "She tried to stand up. She fell back on the ground, but her second try was successful. She could not see a thing, nonetheless she tried to walk. A few paces further she realised that the shuffle of her steps sounded quite weird. She was not used to that sound. After a moment of reflection, she became aware that she was naked."
-        [/message]
-        [message]
-            speaker=narrator
-            image="wesnoth-icon.png"
-            message= _ "After deciding to find some clothes, she made another step. And another. She started walking. She no longer crashed into walls, that made her realise that she could see in the dark, but she did not know about it at the start. She looked at the thing that was holding her when she awoke. Terrified, she realised that she had been hanging on chains attached to her body by large hooks. A quick look at her shoulder made her notice that her wounds were healing quickly, and did not hurt."
-        [/message]
-        [message]
-            speaker=narrator
-            image="wesnoth-icon.png"
-            message= _ "She continued to walk. There were numerous tables around her. No, these things were not tables, they were coffins. She opened them, one by one, and found just bare skeletons. In another room, the coffins contained also bodies with armours. After a few tries, she found one that fitted her size. She also took a sword, but after a few swings with it, she gave it up, she was unable to fight with a sword. In another room, she found an axe, and she felt somehow she knew to fight with this weapon much better."
-        [/message]
-        [message]
-            speaker=narrator
-            image="wesnoth-icon.png"
-            message= _ "When she was finally geared up, she noticed she was not alone. Dark shapes were crawling towards her, awakened by her movements."
-        [/message]
         {UPDATE_ATTACKS 7 9}
         [store_unit]
             variable=Efraim_store
@@ -311,6 +281,36 @@
     [/event]
     [event]
         name=start
+        [message]
+            speaker=narrator
+            image="wesnoth-icon.png"
+            message= _ "In the dark, in a forgotten tomb deep under all places known to mankind..."
+        [/message]
+        [message]
+            speaker=narrator
+            image="wesnoth-icon.png"
+            message= _ "She awoke. Everything was black, there was nothing but wide and deep darkness. She was almost unable to move. Something was preventing her from moving. With all her strength, she managed to tear these things away from her. She fell on the ground."
+        [/message]
+        [message]
+            speaker=narrator
+            image="wesnoth-icon.png"
+            message= _ "She tried to stand up. She fell back on the ground, but her second try was successful. She could not see a thing, nonetheless she tried to walk. A few paces further she realised that the shuffle of her steps sounded quite weird. She was not used to that sound. After a moment of reflection, she became aware that she was naked."
+        [/message]
+        [message]
+            speaker=narrator
+            image="wesnoth-icon.png"
+            message= _ "After deciding to find some clothes, she made another step. And another. She started walking. She no longer crashed into walls, that made her realise that she could see in the dark, but she did not know about it at the start. She looked at the thing that was holding her when she awoke. Terrified, she realised that she had been hanging on chains attached to her body by large hooks. A quick look at her shoulder made her notice that her wounds were healing quickly, and did not hurt."
+        [/message]
+        [message]
+            speaker=narrator
+            image="wesnoth-icon.png"
+            message= _ "She continued to walk. There were numerous tables around her. No, these things were not tables, they were coffins. She opened them, one by one, and found just bare skeletons. In another room, the coffins contained also bodies with armours. After a few tries, she found one that fitted her size. She also took a sword, but after a few swings with it, she gave it up, she was unable to fight with a sword. In another room, she found an axe, and she felt somehow she knew to fight with this weapon much better."
+        [/message]
+        [message]
+            speaker=narrator
+            image="wesnoth-icon.png"
+            message= _ "When she was finally geared up, she noticed she was not alone. Dark shapes were crawling towards her, awakened by her movements."
+        [/message]
         [message]
             speaker=Lethalia
             message= _ "Those... things are faltering toward me... Danger..."

--- a/scenarios6/02_Who_Am_I.cfg
+++ b/scenarios6/02_Who_Am_I.cfg
@@ -125,7 +125,7 @@
 
     [side]
         type=Ancient Lich
-        max_moves=0
+        ai_special=guardian
         name= _ "Quer'krath"
         id=Antediluvian
         recruit=Dark Adept,Soulless,Ghost


### PR DESCRIPTION
- Messages prestart to start (In prestart they overlap and it looks bad)
- Antediluvian movement fix max_moves=0 not supported under [side], better use ai_special=guardian

Still in draft until I finish part II