### PR TITLE
"Into the light" scenario - soul eater variable error

### DIFF
--- a/scenarios6/03_Into_the_Light.cfg
+++ b/scenarios6/03_Into_the_Light.cfg
@@ -212,7 +212,7 @@
         [unstore_unit]
             variable=lethalia
             {COLOR_HEAL}
-            text="$eater.variables.devour_count|/$eater.variables.max_devour_count"
+            text="$lethalia.variables.devour_count|/$lethalia.variables.max_devour_count"
             find_vacant=no
         [/unstore_unit]
         [objectives]


### PR DESCRIPTION
$eater is the variable that uses the soul eater event and is deleted each time, you have to use the variable saved in the unit.

Do you prefer this type of small fixes in different PRs like you told me, or do you prefer me to join them in Part II fixes?