### PR TITLE
Into the light

### DIFF
--- a/scenarios6/03_Into_the_Light.cfg
+++ b/scenarios6/03_Into_the_Light.cfg
@@ -102,27 +102,11 @@
         [filter]
             side=2
         [/filter]
-        [for]
-	    array=unit.modifications.trait 
-	    [do]
-                [if]
-                    [variable]
-                        name=unit.modifications.trait[$i].id
-                        equals=slimy
-                    [/variable]
-                    [or]
-                        [variable]
-                            name=unit.modifications.trait[$i].id
-                            equals=regrowing
-                        [/variable]
-                    [/or]
-                    [then]
-                        {CLEAR_VARIABLE unit.modifications.trait[$i]}
-                        {VARIABLE_OP i sub 1}
-                    [/then]
-                [/if]
-	    [/do]
-	[/for]
+        #
+        # Removing the trait doesn't actually remove the effects, so this isn't accomplishing much
+        #
+        {REMOVE_TRAIT_BY_ID unit "regrowing"}
+        {REMOVE_TRAIT_BY_ID unit "physresist"}
         [unstore_unit]
             variable=unit
             find_vacant=no

--- a/utils/abilities.cfg
+++ b/utils/abilities.cfg
@@ -543,11 +543,11 @@ Enemy units cannot see this unit during dawn or dusk, except if they have units 
 #define ABILITY_EXTRA_DAMAGE_AURA NAME INTENSITY
     [leadership]
         id=extra damage aura {INTENSITY}
-        #ifver WESNOTH_VERSION <= 1.17.4
-           add={INTENSITY}
-        #else
-            value={INTENSITY}
-        #endif
+#ifver WESNOTH_VERSION <= 1.17.4
+        add={INTENSITY}
+#else
+        value={INTENSITY}
+#endif
         cumulative=yes
         name={NAME}+_" ("+{INTENSITY}+_")"
         female_name={NAME}+_" ("+{INTENSITY}+_")"
@@ -569,7 +569,7 @@ Enemy units cannot see this unit during dawn or dusk, except if they have units 
         description= _ "This unit can lead your own units that are next to it, making them fight better.
 
 Adjacent own units of lower level will do more damage in battle. When a unit adjacent to, of a lower level than, and on the same side as a unit with Leadership engages in combat, its attacks do 25% more damage times the difference in their levels."
-    special_note = _"The leadership of this unit enables adjacent units of the same side to deal more damage in combat, though this only applies to units of lower level."
+        special_note = _"The leadership of this unit enables adjacent units of the same side to deal more damage in combat, though this only applies to units of lower level."
         affect_self=no
         [affect_adjacent]
             [filter]
@@ -1850,3 +1850,20 @@ _" When this unit is attacked in melee range, the attacker takes a huge amount o
 
 #define SPECIAL_NOTES_DEMON_ARCANE
 _" Demons are creatures of magic, and arcane attacks have only a little effect on them."#enddef
+
+#define REMOVE_TRAIT_BY_ID UNIT TRAIT_ID
+    [for]
+        array={UNIT}.modifications.trait
+        [do]
+            [variable]
+                name={UNIT}.modifications.trait[$i].id
+                equals={TRAIT_ID}
+            [/variable]
+            [then]
+                {CLEAR_VARIABLE {UNIT}.modifications.trait[$i]}
+                {VARIABLE_OP i sub 1}
+            [/then]
+        [/if]
+    [/do]
+[/for]
+#enddef


### PR DESCRIPTION
Fixes logical error removing trait slimy.

Moves said code to utils/abilities.cfg
  1) Now that I think of it, that may not be the right place (I was originally trying to remove abilities, not traits)
  2) I'm not entirely sure if "passing" unit makes sense.  Not sure if unit is a reserved word, default variable or what.  What I have is tested and working, but.
  3) I think this could be used in other scenarios.  
  4) I don't see any other areas where only a single trait is removed, so moving this won't break consistency.
  3) I have a copy of this scenario that just fixes the slimy issue with the remove code in place if you prefer.

Code works, better now, but still doesn't do what I think it was intended to.  Ref: https://github.com/Dugy/Legend_of_the_Invincibles/issues/517