### PR TITLE
[variable] with missing name=

### DIFF
--- a/utils/abilities_events.cfg
+++ b/utils/abilities_events.cfg
@@ -4598,7 +4598,7 @@
                 {VARIABLE unit.side $second_unit.side}
                 [if]
                     [variable]
-                        variable=transform_type
+                        name=transform_type
                         equals=Elvish Shaman
                     [/variable]
                     [then]


### PR DESCRIPTION
Every time I use purify, I get "error wml: [variable] with missing name=".

Haven't tested this, hopefully it's an obvious one.