### PR TITLE
Disable undo on DISABLE_UPKEEP macro to avoid desynchronizations

### DIFF
--- a/utils/utils.cfg
+++ b/utils/utils.cfg
@@ -747,6 +747,9 @@ $item_info.description"
             [/variables]
             upkeep=loyal
         [/modify_unit]
+        #Make the event undoable
+        {VARIABLE_OP disallow_undo rand(0..1)}
+        {CLEAR_VARIABLE disallow_undo}
     [/event]
     [event]
         name=victory


### PR DESCRIPTION
If you undo and redo a recall/recruit with this macro enabled, the game will fail and prompt you to save and exit. You can continue playing normally if you ignore it, but it's better to avoid the error.