### PR TITLE
RARE_ITEM -> INVENTORY_ITEM

### DIFF
--- a/scenarios9/30_Nightmare_Cellar.cfg
+++ b/scenarios9/30_Nightmare_Cellar.cfg
@@ -69,9 +69,9 @@
     [event]
         name=start
         {INFERNO_RECALL_ALL}
-        {RARE_ITEM 23 5}
-        {RARE_ITEM 36 6}
-        {RARE_ITEM 28 8}
+	{INFERNO_ITEM 23 5 sc30_item1}
+	{INFERNO_ITEM 36 6 sc30_item2}
+	{INFERNO_ITEM 28 8 sc30_item3}
         [if]
             [variable]
                 name=quests.entered_sc30


### PR DESCRIPTION
I don't have a save to test this against, but I think it's just a simple oversight.

I went to Nightmare Cellar and left on turn 1.  All of the loot was automatically picked up for me.  Since every other scenario in ch9 uses INF_ITEM, I bet this is the fix.