### PR TITLE
Fix pr523

### DIFF
--- a/scenarios1/00_Tutorial.cfg
+++ b/scenarios1/00_Tutorial.cfg
@@ -586,8 +586,8 @@ Take this item?"
                                         delayed_variable_substitution=no
                                         {VARIABLE tutorial.proceed 0}
                                         [remove_event]
-					    id=dont_take_it
-					[/remove_event]
+                                            id=dont_take_it
+                                        [/remove_event]
                                         [while]
                                             [variable]
                                                 name=tutorial.proceed

--- a/scenarios6/05_Friends_No_More.cfg
+++ b/scenarios6/05_Friends_No_More.cfg
@@ -90,10 +90,10 @@
                     kill=yes
                 [/store_unit]
                 [for]
-		    array=undead_store 
+                    array=undead_store
                     [do]
-			{CLEAR_VARIABLE undead_store[$i].advancement}
-		    [/do]
+                        {CLEAR_VARIABLE undead_store[$i].advancement}
+                    [/do]
                 [/for]
                 [store_unit]
                     [filter]

--- a/scenarios6/09_Across_the_Barren_Land.cfg
+++ b/scenarios6/09_Across_the_Barren_Land.cfg
@@ -609,8 +609,8 @@ You can teleport all units to your leader once per ten turns (see option in the 
                     variable=teleport_store
                 [/store_unit]
                 [foreach]
-		    array=teleport_store
-		    [do]
+                    array=teleport_store
+                    [do]
                         [teleport]
                             [filter]
                                 id=$teleport_store[$i].id
@@ -619,7 +619,7 @@ You can teleport all units to your leader once per ten turns (see option in the 
                             clear_shroud=yes
                             animate=no
                         [/teleport]
-		    [/do]
+                    [/do]
                 [/foreach]
                 {CLEAR_VARIABLE teleport_store}
             [/command]
@@ -747,10 +747,10 @@ You can teleport all units to your leader once per ten turns (see option in the 
             side=1
             variable=gold
         [/store_gold]
-	[while]
-	    {VARIABLE_CONDITIONAL loti_shop not_equals yes}
-	    [do]
-        	[message]
+        [while]
+            {VARIABLE_CONDITIONAL loti_shop not_equals yes}
+            [do]
+                [message]
                     speaker=trader
                     message= _ "Hello, I am a trader. I sell items. Look at my stock and tell me what would you like to look at more closely."
                     {SELL_GEMS}
@@ -761,7 +761,7 @@ You can teleport all units to your leader once per ten turns (see option in the 
                     [option]
                         label=_"Nothing"
                         [command]
-	        	    {VARIABLE loti_shop yes}
+                            {VARIABLE loti_shop yes}
                         [/command]
                     [/option]
                 [/message]

--- a/scenarios6/14_Frozen_Land.cfg
+++ b/scenarios6/14_Frozen_Land.cfg
@@ -244,9 +244,9 @@
     [event]
         name=attack
         first_time_only=no
-	[for]
-	    array=unit.attack
-	    [do]
+        [for]
+            array=unit.attack
+            [do]
                 {VARIABLE unit.variables.former_attack_numbers[$i].number $unit.attack[$i].number}
                 [if]
                     [variable]
@@ -258,14 +258,14 @@
                         {VARIABLE unit.attack[$i].number 0}
                     [/then]
                 [/if]
-	    [/do]
+            [/do]
         [/for]
         [unstore_unit]
             variable=unit
             find_vacant=no
         [/unstore_unit]
         [for]
-	    array=second_unit.attack
+            array=second_unit.attack
             [do]
                 {VARIABLE second_unit.variables.former_attack_numbers[$i].number $second_unit.attack[$i].number}
                 [if]
@@ -278,7 +278,7 @@
                         {VARIABLE second_unit.attack[$i].number 0}
                     [/then]
                 [/if]
-	    [/do]
+            [/do]
         [/for]
 
         [unstore_unit]
@@ -289,11 +289,11 @@
         [event]
             name=attack end
             delayed_variable_substitution=yes
-	    [for]
-		array=unit.attack
-		[do]
+            [for]
+                array=unit.attack
+                [do]
                     {VARIABLE unit.attack[$i].number $unit.variables.former_attack_numbers[$i].number}
-		[/do]
+                [/do]
             [/for]
             {CLEAR_VARIABLE unit.variables.former_attack_numbers}
 
@@ -302,10 +302,10 @@
                 find_vacant=no
             [/unstore_unit]
             [for]
-		array=second_unit.attack 
+                array=second_unit.attack
                 [do]
-		    {VARIABLE second_unit.attack[$i].number $second_unit.variables.former_attack_numbers[$i].number}
-		[/do]
+                    {VARIABLE second_unit.attack[$i].number $second_unit.variables.former_attack_numbers[$i].number}
+                [/do]
             [/for]
             {CLEAR_VARIABLE second_unit.variables.former_attack_numbers}
 

--- a/scenarios7/08_Eruption.cfg
+++ b/scenarios7/08_Eruption.cfg
@@ -207,233 +207,232 @@
             x,y=8,12
             terrain=Qlf
         [/terrain]
-        {EARTHQUAKE (           [redraw]
-    [/redraw])}
-    [redraw]
-    [/redraw]
-    [message]
-        speaker=ally_ch7sc7
-        message= _ "No! The earth is waking! This cave will soon be filled with lava! We must make haste!"
-    [/message]
-    [message]
-        speaker=Efraim
-        message= _ "Our enemies will not be able to follow us, so this is rather good."
-    [/message]
-    [message]
-        speaker=ally_ch7sc7
-        message= _ "But lava is very dangerous! Especially in caves! And there is a lot of treasures here we are not very likely to rescue!"
-    [/message]
-    [message]
-        speaker=narrator
-        image="wesnoth-icon.png"
-        message= _ "Units on lava take 48 fire damage per turn. Units that can fly take 24 points of damage when above lava."
-    [/message]
-[/event]
-[event]
-    name=turn 4
-    [unit]
-        type=Corrupted Elvish Juggernaut
-        id=enemy
-        x,y=8,27
-        canrecruit=yes
-        side=3
-        random_traits=yes
-        generate_name=yes
-    [/unit]
-    [unit]
-        type=Demonologist
-        x,y=3,27
-        canrecruit=yes
-        side=4
-        random_traits=yes
-        generate_name=yes
-    [/unit]
-    {GENERIC_UNIT 2 "Corrupted Elvish Champion" 6 27}
-    {GENERIC_UNIT 2 "Corrupted Elvish Fighter" 6 27}
-    {GENERIC_UNIT 2 "Corrupted Elvish Hero" 6 27}
-    {GENERIC_UNIT 2 "Corrupted Orcish Slayer" 6 27}
-    {GENERIC_UNIT 2 "Corrupted Elvish Hero" 6 27}
-    {GENERIC_UNIT 2 "Corrupted Elvish Archer" 6 27}
-    {GENERIC_UNIT 2 "Corrupted Elvish Ranger" 6 27}
-    {GENERIC_UNIT 2 "Corrupted Elvish Hero" 6 27}
-    {GENERIC_UNIT 2 "Corrupted Elvish Ranger" 6 27}
-    {GENERIC_UNIT 2 "Spell Eater" 6 27}
-    {GENERIC_UNIT 2 "Corrupted Snow Hunter" 6 27}
-    {GENERIC_UNIT 2 "Spell Eater" 6 27}
-    {GENERIC_UNIT 2 "Corrupted Naga Warrior" 6 27}
-    [message]
-        speaker=enemy
-        message= _ "Prepare to die, fools! There is no escape! You shall die or rot away down here."
-    [/message]
-[/event]
-[event]
-    name=moveto
-    [filter]
-        x,y=43-44,27-33
-        side=1
-    [/filter]
-    [message]
-        speaker=ally_ch7sc7
-        message= _ "Run, quickly!"
-    [/message]
-    {CLEAR_VARIABLE lava_turns}
-    [endlevel]
-        result=victory
-        bonus=no
-        {NEW_GOLD_CARRYOVER 40}
-    [/endlevel]
-[/event]
-[event]
-    name=last breath
-    [filter]
-        id=ally_ch7sc7
-    [/filter]
-    [message]
-        speaker=Efraim
-        message= _ "No, we needed him!"
-    [/message]
-    [endlevel]
-        result=defeat
-    [/endlevel]
-[/event]
-[event]
-    name=turn refresh
-    first_time_only=no
-    [if]
-        [variable]
-            name=side_number
-            equals=1
-        [/variable]
-        [then]
+        {EARTHQUAKE (           [redraw] [/redraw])}
+        [redraw]
+        [/redraw]
+        [message]
+            speaker=ally_ch7sc7
+            message= _ "No! The earth is waking! This cave will soon be filled with lava! We must make haste!"
+        [/message]
+        [message]
+            speaker=Efraim
+            message= _ "Our enemies will not be able to follow us, so this is rather good."
+        [/message]
+        [message]
+            speaker=ally_ch7sc7
+            message= _ "But lava is very dangerous! Especially in caves! And there is a lot of treasures here we are not very likely to rescue!"
+        [/message]
+        [message]
+            speaker=narrator
+            image="wesnoth-icon.png"
+            message= _ "Units on lava take 48 fire damage per turn. Units that can fly take 24 points of damage when above lava."
+        [/message]
+    [/event]
+    [event]
+        name=turn 4
+        [unit]
+            type=Corrupted Elvish Juggernaut
+            id=enemy
+            x,y=8,27
+            canrecruit=yes
+            side=3
+            random_traits=yes
+            generate_name=yes
+        [/unit]
+        [unit]
+            type=Demonologist
+            x,y=3,27
+            canrecruit=yes
+            side=4
+            random_traits=yes
+            generate_name=yes
+        [/unit]
+        {GENERIC_UNIT 2 "Corrupted Elvish Champion" 6 27}
+        {GENERIC_UNIT 2 "Corrupted Elvish Fighter" 6 27}
+        {GENERIC_UNIT 2 "Corrupted Elvish Hero" 6 27}
+        {GENERIC_UNIT 2 "Corrupted Orcish Slayer" 6 27}
+        {GENERIC_UNIT 2 "Corrupted Elvish Hero" 6 27}
+        {GENERIC_UNIT 2 "Corrupted Elvish Archer" 6 27}
+        {GENERIC_UNIT 2 "Corrupted Elvish Ranger" 6 27}
+        {GENERIC_UNIT 2 "Corrupted Elvish Hero" 6 27}
+        {GENERIC_UNIT 2 "Corrupted Elvish Ranger" 6 27}
+        {GENERIC_UNIT 2 "Spell Eater" 6 27}
+        {GENERIC_UNIT 2 "Corrupted Snow Hunter" 6 27}
+        {GENERIC_UNIT 2 "Spell Eater" 6 27}
+        {GENERIC_UNIT 2 "Corrupted Naga Warrior" 6 27}
+        [message]
+            speaker=enemy
+            message= _ "Prepare to die, fools! There is no escape! You shall die or rot away down here."
+        [/message]
+    [/event]
+    [event]
+        name=moveto
+        [filter]
+            x,y=43-44,27-33
+            side=1
+        [/filter]
+        [message]
+            speaker=ally_ch7sc7
+            message= _ "Run, quickly!"
+        [/message]
+        {CLEAR_VARIABLE lava_turns}
+        [endlevel]
+            result=victory
+            bonus=no
+            {NEW_GOLD_CARRYOVER 40}
+        [/endlevel]
+    [/event]
+    [event]
+        name=last breath
+        [filter]
+            id=ally_ch7sc7
+        [/filter]
+        [message]
+            speaker=Efraim
+            message= _ "No, we needed him!"
+        [/message]
+        [endlevel]
+            result=defeat
+        [/endlevel]
+    [/event]
+    [event]
+        name=turn refresh
+        first_time_only=no
+        [if]
+            [variable]
+                name=side_number
+                equals=1
+            [/variable]
+            [then]
 #ifdef EASY
-            {VARIABLE_OP spawn_type rand (Skeleton,Skeleton Archer,Ghost,Walking Corpse,Revenant,Deathblade,Necrophage,Spell Eater)}
+                {VARIABLE_OP spawn_type rand (Skeleton,Skeleton Archer,Ghost,Walking Corpse,Revenant,Deathblade,Necrophage,Spell Eater)}
 #endif
 #ifdef NORMAL
-            {VARIABLE_OP spawn_type rand (Skeleton,Skeleton Archer,Ghost,Walking Corpse,Revenant,Deathblade,Bone Shooter,Necrophage,Spell Eater)}
+                {VARIABLE_OP spawn_type rand (Skeleton,Skeleton Archer,Ghost,Walking Corpse,Revenant,Deathblade,Bone Shooter,Necrophage,Spell Eater)}
 #endif
 #ifdef HARD
-            {VARIABLE_OP spawn_type rand (Skeleton,Skeleton Archer,Ghost,Walking Corpse,Revenant,Deathblade,Bone Shooter,Draug,Necrophage,Spell Eater)}
+                {VARIABLE_OP spawn_type rand (Skeleton,Skeleton Archer,Ghost,Walking Corpse,Revenant,Deathblade,Bone Shooter,Draug,Necrophage,Spell Eater)}
 #endif
-            {GENERIC_UNIT 4 $spawn_type 44 30}
-            {CLEAR_VARIABLE spawn_type}
-            [if]
-                [variable]
-                    name=lava_turns
-                    greater_than_equal_to=0
-                [/variable]
-                [then]
-                    [store_locations]
-                        [filter_adjacent_location]
-                            terrain=Qlf
-                        [/filter_adjacent_location]
-                        [not]
-                            terrain=Xuc,Xu
-                        [/not]
-                        variable=to_melt
-                    [/store_locations]
-                    [foreach]
-                        array=to_melt
-                        [do]
-                            [terrain]
+                {GENERIC_UNIT 4 $spawn_type 44 30}
+                {CLEAR_VARIABLE spawn_type}
+                [if]
+                    [variable]
+                        name=lava_turns
+                        greater_than_equal_to=0
+                    [/variable]
+                    [then]
+                        [store_locations]
+                            [filter_adjacent_location]
                                 terrain=Qlf
-                                x,y=$this_item.x,$this_item.y
-                            [/terrain]
-                        [/do]
-                    [/foreach]
-                    {CLEAR_VARIABLE to_melt}
-                    [redraw]
-                    [/redraw]
-                    [store_unit]
-                        [filter]
-                            [filter_location]
-                                terrain=Qlf,Ql
-                            [/filter_location]
-                        [/filter]
-                        variable=burning_store
-                        kill=no
-                    [/store_unit]
-                    [foreach]
-                        array=burning_store
-                        [do]
-                            [if]
-                                [variable]
-                                    name=this_item.flying
-                                    equals="yes"
-                                [/variable]
-                                [then]
-                                    {VARIABLE lava_damage 24}
-                                [/then]
-                                [else]
-                                    {VARIABLE lava_damage 48}
-                                [/else]
-                            [/if]
-                            [harm_unit]
-                                [filter]
-                                    id=$this_item.id
-                                [/filter]
-                                amount=$lava_damage
-                                damage_type=fire
-                                fire_event=yes
-                                experience=no
-                                kill=yes
-                            [/harm_unit]
-                            {CLEAR_VARIABLE lava_damage}
-                        [/do]
-                    [/foreach]
-                    {VARIABLE_OP lava_turns add 1}
-                [/then]
-            [/if]
-            [if]
-                [variable]
-                    name=side_number
-                    equals=2
-                [/variable]
-                [then]
-                    [if]
-                        [variable]
-                            name=lava_turns
-                            greater_than_equal_to=6
-                        [/variable]
-                        [then]
-                            [store_locations]
-                                [filter_adjacent_location]
+                            [/filter_adjacent_location]
+                            [not]
+                                terrain=Xuc,Xu
+                            [/not]
+                            variable=to_melt
+                        [/store_locations]
+                        [foreach]
+                            array=to_melt
+                            [do]
+                                [terrain]
                                     terrain=Qlf
-                                [/filter_adjacent_location]
-                                [not]
-                                    terrain=Xuc,Xu
-                                [/not]
-                                variable=to_melt
-                            [/store_locations]
-                            [foreach]
-                                array=to_melt
-                                [do]
-                                    [terrain]
+                                    x,y=$this_item.x,$this_item.y
+                                [/terrain]
+                            [/do]
+                        [/foreach]
+                        {CLEAR_VARIABLE to_melt}
+                        [redraw]
+                        [/redraw]
+                        [store_unit]
+                            [filter]
+                                [filter_location]
+                                    terrain=Qlf,Ql
+                                [/filter_location]
+                            [/filter]
+                            variable=burning_store
+                            kill=no
+                        [/store_unit]
+                        [foreach]
+                            array=burning_store
+                            [do]
+                                [if]
+                                    [variable]
+                                        name=this_item.flying
+                                        equals="yes"
+                                    [/variable]
+                                    [then]
+                                        {VARIABLE lava_damage 24}
+                                    [/then]
+                                    [else]
+                                        {VARIABLE lava_damage 48}
+                                    [/else]
+                                [/if]
+                                [harm_unit]
+                                    [filter]
+                                        id=$this_item.id
+                                    [/filter]
+                                    amount=$lava_damage
+                                    damage_type=fire
+                                    fire_event=yes
+                                    experience=no
+                                    kill=yes
+                                [/harm_unit]
+                                {CLEAR_VARIABLE lava_damage}
+                            [/do]
+                        [/foreach]
+                        {VARIABLE_OP lava_turns add 1}
+                    [/then]
+                [/if]
+                [if]
+                    [variable]
+                        name=side_number
+                        equals=2
+                    [/variable]
+                    [then]
+                        [if]
+                            [variable]
+                                name=lava_turns
+                                greater_than_equal_to=6
+                            [/variable]
+                            [then]
+                                [store_locations]
+                                    [filter_adjacent_location]
                                         terrain=Qlf
-                                        x,y=$this_item.x,$this_item.y
-                                    [/terrain]
-                                [/do]
-                            [/foreach]
-                            {CLEAR_VARIABLE to_melt}
-                            [redraw]
-                            [/redraw]
-                        [/then]
-                    [/if]
-                [/then]
-            [/if]
-        [/then]
-    [/if]
-[/event]
-[event]
-    name=time over
-    [message]
-        speaker=Efraim
-        message= _ "This is desperate, the air is terribly polluted by lava fumes that we cannot even breathe properly."
-    [/message]
-    [endlevel]
-        result=defeat
-    [/endlevel]
-[/event]
+                                    [/filter_adjacent_location]
+                                    [not]
+                                        terrain=Xuc,Xu
+                                    [/not]
+                                    variable=to_melt
+                                [/store_locations]
+                                [foreach]
+                                    array=to_melt
+                                    [do]
+                                        [terrain]
+                                            terrain=Qlf
+                                            x,y=$this_item.x,$this_item.y
+                                        [/terrain]
+                                    [/do]
+                                [/foreach]
+                                {CLEAR_VARIABLE to_melt}
+                                [redraw]
+                                [/redraw]
+                            [/then]
+                        [/if]
+                    [/then]
+                [/if]
+            [/then]
+        [/if]
+    [/event]
+    [event]
+        name=time over
+        [message]
+            speaker=Efraim
+            message= _ "This is desperate, the air is terribly polluted by lava fumes that we cannot even breathe properly."
+        [/message]
+        [endlevel]
+            result=defeat
+        [/endlevel]
+    [/event]
 
-{GENERIC_DEATHS}
-{DROPS 5 7 (axe,axe,staff,staff,sword,sword,sword,knife,bow,bow,xbow,spear,spear,bow,dagger,mace) yes 2,3,4}
+    {GENERIC_DEATHS}
+    {DROPS 5 7 (axe,axe,staff,staff,sword,sword,sword,knife,bow,bow,xbow,spear,spear,bow,dagger,mace) yes 2,3,4}
 [/scenario]


### PR DESCRIPTION
I changed the EARTHQUAKE line in Eruption, and now wmlindent doesn't complain about it.  It used to say 

wmlindent: "08_Eruption.cfg", line 439: close tag [/scenario] with indent already zero.

It still looks odd to me, and I haven't tried to figure out what that line is up to (my guess is it's a typo and there's a couple redraws that don't belong?).  

No changes to the rest of the files except running wmlindent.