### PR TITLE
Devastating blow fixes

### DIFF
--- a/lua/stats.lua
+++ b/lua/stats.lua
@@ -291,7 +291,7 @@ function wesnoth.update_stats(original)
 				weap.description = bonuses.name
 			end
 			if bonuses.devastating_blow > 0 then
-				table.insert(wml.get_child(weap, "specials"), { "dummy", { id = "devastating_blow", name = _"devastating blow", description = (_"$chance% chance that the enemy will lose 20% of their health on each hit"):vformat{chance = bonuses.devastating_blow}, devastating_blow = bonuses.devastating_blow }})
+				table.insert(wml.get_child(weap, "specials"), { "dummy", { id = "devastating_blow", name = _"devastating blow", description = (_"$chance% chance that the enemy will lose 20% of their health on each hit. It cannot kill."):vformat{chance = bonuses.devastating_blow}, devastating_blow = bonuses.devastating_blow }})
 			end
 			for k = 1,#bonuses.specials do
 				table.insert(wml.get_child(weap, "specials"), bonuses.specials[k])

--- a/utils/abilities_events.cfg
+++ b/utils/abilities_events.cfg
@@ -1179,12 +1179,16 @@
                             name=random
                             less_than=$weapon.specials.dummy[$i].devastating_blow
                         [/variable]
+                        [variable]
+                            name=second_unit.hitpoints
+                            greater_than=1
+                        [/variable]
                         [then]
                             [floating_text]
                                 x=$second_unit.x
                                 y=$second_unit.y
                                 color="255,0,0"
-                                text="-20% HP"
+                                text=_"-20% HP"
                             [/floating_text]
                             [delay]
                                 time=300
@@ -1197,7 +1201,7 @@
                                 [filter_second]
                                     id=$unit.id
                                 [/filter_second]
-                                amount="$($second_unit.hitpoints - ($second_unit.hitpoints / 1.2)"
+                                amount="$($second_unit.hitpoints - ($second_unit.hitpoints * 0.8)"
                                 kill=no
                                 fire_event=yes
                                 animate=no


### PR DESCRIPTION
Fixes some things of #525 

- if a unit receives devastating blow while already dead, since the operation involves a variable already gone, this error is thrown, so I add a conditional so that units with 1 or less health do not receive this blow.
![imagen](https://github.com/Dugy/Legend_of_the_Invincibles/assets/40789364/8e06365b-c3c3-4fb7-a498-bbeb0939beec)

- Added in the description "It cannot kill"
- "-20% HP" translatable
- Wrong math operation. The previous subtracts 17%, not 20%

