### PR TITLE
The Library - typo on filter keys

### DIFF
--- a/scenarios6/12_The_Library.cfg
+++ b/scenarios6/12_The_Library.cfg
@@ -350,7 +350,7 @@
         first_time_only=no
         [filter]
             side=1
-            x,y=18,14
+            canrecruit=yes
             x,y=1,15
         [/filter]
         [message]
@@ -375,7 +375,7 @@
         name=moveto
         [filter]
             side=1
-            x,y=18,14
+            canrecruit=yes
             x,y=13,10
         [/filter]
         first_time_only=no


### PR DESCRIPTION
It's probably a copy/paste typo. This bug allows Phillip to read a book and activate the phoenix when he is not supposed to do that.