### PR TITLE
Better removal of fire attacks on Frozen Land

### DIFF
--- a/scenarios6/14_Frozen_Land.cfg
+++ b/scenarios6/14_Frozen_Land.cfg
@@ -242,78 +242,20 @@
 
     #Disable fire attacks
     [event]
-        name=attack
-        first_time_only=no
-        [for]
-            array=unit.attack
-            [do]
-                {VARIABLE unit.variables.former_attack_numbers[$i].number $unit.attack[$i].number}
-                [if]
-                    [variable]
-                        name=unit.attack[$i].type
-                        equals=fire
-                    [/variable]
-
-                    [then]
-                        {VARIABLE unit.attack[$i].number 0}
-                    [/then]
-                [/if]
-            [/do]
-        [/for]
-        [unstore_unit]
-            variable=unit
-            find_vacant=no
-        [/unstore_unit]
-        [for]
-            array=second_unit.attack
-            [do]
-                {VARIABLE second_unit.variables.former_attack_numbers[$i].number $second_unit.attack[$i].number}
-                [if]
-                    [variable]
-                        name=second_unit.attack[$i].type
-                        equals=fire
-                    [/variable]
-
-                    [then]
-                        {VARIABLE second_unit.attack[$i].number 0}
-                    [/then]
-                [/if]
-            [/do]
-        [/for]
-
-        [unstore_unit]
-            variable=second_unit
-            find_vacant=no
-        [/unstore_unit]
-
-        [event]
-            name=attack end
-            delayed_variable_substitution=yes
-            [for]
-                array=unit.attack
-                [do]
-                    {VARIABLE unit.attack[$i].number $unit.variables.former_attack_numbers[$i].number}
-                [/do]
-            [/for]
-            {CLEAR_VARIABLE unit.variables.former_attack_numbers}
-
-            [unstore_unit]
-                variable=unit
-                find_vacant=no
-            [/unstore_unit]
-            [for]
-                array=second_unit.attack
-                [do]
-                    {VARIABLE second_unit.attack[$i].number $second_unit.variables.former_attack_numbers[$i].number}
-                [/do]
-            [/for]
-            {CLEAR_VARIABLE second_unit.variables.former_attack_numbers}
-
-            [unstore_unit]
-                variable=second_unit
-                find_vacant=no
-            [/unstore_unit]
-        [/event]
+        name=prestart
+        [modify_unit]
+            [filter]
+            [/filter]
+            [object]
+                id=disable_fire_attacks
+                silent=yes
+                duration=scenario
+                [effect]
+                    apply_to=remove_attacks
+                    type=fire
+                [/effect]
+            [/object]
+        [/modify_unit]
     [/event]
 
     {DROPS 6 8 (axe,axe,staff,sword,sword,knife,bow,dagger,xbow,spear,spear,bow,dagger,mace) yes 2}

--- a/scenarios6/14_Frozen_Land.cfg
+++ b/scenarios6/14_Frozen_Land.cfg
@@ -245,16 +245,48 @@
         name=prestart
         [modify_unit]
             [filter]
+                [has_attack]
+                    type=fire
+                [/has_attack]
             [/filter]
             [object]
                 id=disable_fire_attacks
                 silent=yes
-                duration=scenario
                 [effect]
                     apply_to=remove_attacks
                     type=fire
                 [/effect]
             [/object]
+            [set_variable]
+                name=delete_fire
+                value=yes
+            [/set_variable]
+        [/modify_unit]
+    [/event]
+
+    [event]
+        name=victory
+        [remove_object]
+            object_id=disable_fire_attacks
+        [/modify_unit]
+        [update_stats]
+            [filter_wml]
+                [variables]
+                    delete_fire=yes
+                [/variables]
+            [/filter_wml]
+        [/update_stats]
+        [modify_unit]
+            [filter]
+                [filter_wml]
+                    [variables]
+                        delete_fire=yes
+                    [/variables]
+                [/filter_wml]
+            [/filter]
+            [clear_variable]
+                name=delete_fire
+            [/clear_variable]
         [/modify_unit]
     [/event]
 


### PR DESCRIPTION
Instead of a complicated event system, the effect of which is that if you try to attack with a fire attack, the attack does not occur and the unit loses all its attacks instantly.
With this method, the fire attacks disappear for this scenario and that's it.

Also resolves a problem described on #538 with an ocasional lua error (not related with the knockback of the Solid Phoenix)