### PR TITLE
Improved knockback

### DIFF
--- a/utils/abilities_events.cfg
+++ b/utils/abilities_events.cfg
@@ -489,7 +489,7 @@
             [then]
                 [kill]
                     id=$second_unit.id
-                    animate=no
+                    animate=yes
                     experience=yes
                     fire_event=yes
                     [secondary_unit]

--- a/utils/abilities_events.cfg
+++ b/utils/abilities_events.cfg
@@ -486,62 +486,39 @@
                 name=second_unit.hitpoints
                 less_than_equal_to=1
             [/variable]
+            [then]
+                [kill]
+                    id=$second_unit.id
+                    animate=no
+                    experience=yes
+                    fire_event=yes
+                    [secondary_unit]
+                        x,y=$x1,$y1
+                    [/secondary_unit]
+                [/kill]
+                [fire_event]
+                    name=force respec
+                    [primary_unit]
+                        id=$unit.id
+                    [/primary_unit]
+                [/fire_event]
+            [/then]
             [else]
-                [store_unit]
-                    [filter]
-                        x,y=$x2,$y2
-                    [/filter]
-                    variable=knockbacked
-                    kill=yes
-                [/store_unit]
                 {VARIABLE knock_x $x2}
                 {VARIABLE knock_y $y2}
                 {VARIABLE_OP knock_x sub $x1}
                 {VARIABLE_OP knock_y sub $y1}
-                {VARIABLE_OP knockbacked.x add $knock_x}
-                {VARIABLE_OP knockbacked.y add $knock_y}
-                [unstore_unit]
-                    variable=knockbacked
-                    find_vacant=yes
+                {VARIABLE_OP knock_x add $x2}
+                {VARIABLE_OP knock_y add $y2}
+                [teleport]
+                    [filter]
+                        id=$second_unit.id
+                    [/filter]
+                    animate=no
+                    x,y=$knock_x,$knock_y
                     check_passability=yes
-                [/unstore_unit]
-                [if]
-                    [have_unit]
-                        id=$knockbacked.id
-                    [/have_unit]
-                    [else]
-                        [unstore_unit]
-                            variable=knockbacked
-                            find_vacant=yes
-                            x,y=$x2,$y2
-                            advance=no
-                        [/unstore_unit]
-                    [/else]
-                [/if]
-                [if]
-                    [variable]
-                        name=knockbacked.hitpoints
-                        less_than_equal_to=1
-                    [/variable]
-                    [then]
-                        [kill]
-                            id=$knockbacked.id
-                            animate=no
-                            experience=yes
-                            fire_event=yes
-                            [secondary_unit]
-                                x,y=$x1,$y1
-                            [/secondary_unit]
-                        [/kill]
-                        [fire_event]
-                            name=force respec
-                            [primary_unit]
-                                id=$unit.id
-                            [/primary_unit]
-                        [/fire_event]
-                    [/then]
-                [/if]
-                {CLEAR_VARIABLE knock_x,knock_y,knockbacked}
+                [/teleport]
+                {CLEAR_VARIABLE knock_x,knock_y}
             [/else]
         [/if]
     [/event]


### PR DESCRIPTION
- Change use of store/unstore to teleport
- check_passability works better inside [teleport] than in [unstore_unit], so it's more bug-proof
- Simplified code
- Immobile units cannot be knockbacked
- Since unstore_unit is not used, the unit dies on the spot if it has 1 or less health, as in the original code, so it can be animated without glitches.
- Resolves #538 