### PR TITLE
Undo fire attack removal changes on Frozen Land

### DIFF
--- a/scenarios6/14_Frozen_Land.cfg
+++ b/scenarios6/14_Frozen_Land.cfg
@@ -291,10 +291,9 @@
             {CLEAR_VARIABLE unit.variables.former_attack_numbers}
 
             [if]
-                [variable]
-                    name=unit
-                    not_equals=$empty_variable
-                [/variable]
+                [have_unit]
+                    id=$unit.id
+                [/have_unit]
                 [then]
                     [unstore_unit]
                         variable=unit
@@ -302,17 +301,15 @@
                     [/unstore_unit]
                 [/then]
             [/if]
-
             {FOREACH second_unit.attack i}
                 {VARIABLE second_unit.attack[$i].number $second_unit.variables.former_attack_numbers[$i].number}
             {NEXT i}
             {CLEAR_VARIABLE second_unit.variables.former_attack_numbers}
 
             [if]
-                [variable]
-                    name=second_unit
-                    not_equals=$empty_variable
-                [/variable]
+                [have_unit]
+                    id=$second_unit.id
+                [/have_unit]
                 [then]
                     [unstore_unit]
                         variable=second_unit

--- a/scenarios6/14_Frozen_Land.cfg
+++ b/scenarios6/14_Frozen_Land.cfg
@@ -242,52 +242,85 @@
 
     #Disable fire attacks
     [event]
-        name=prestart
-        [modify_unit]
-            [filter]
-                [has_attack]
-                    type=fire
-                [/has_attack]
-            [/filter]
-            [object]
-                id=disable_fire_attacks
-                silent=yes
-                [effect]
-                    apply_to=remove_attacks
-                    type=fire
-                [/effect]
-            [/object]
-            [set_variable]
-                name=delete_fire
-                value=yes
-            [/set_variable]
-        [/modify_unit]
-    [/event]
+        name=attack
+        first_time_only=no
+        {FOREACH unit.attack i}
+            {VARIABLE unit.variables.former_attack_numbers[$i].number $unit.attack[$i].number}
+            [if]
+                [variable]
+                    name=unit.attack[$i].type
+                    equals=fire
+                [/variable]
 
-    [event]
-        name=victory
-        [remove_object]
-            object_id=disable_fire_attacks
-        [/modify_unit]
-        [update_stats]
-            [filter_wml]
-                [variables]
-                    delete_fire=yes
-                [/variables]
-            [/filter_wml]
-        [/update_stats]
-        [modify_unit]
-            [filter]
-                [filter_wml]
-                    [variables]
-                        delete_fire=yes
-                    [/variables]
-                [/filter_wml]
-            [/filter]
-            [clear_variable]
-                name=delete_fire
-            [/clear_variable]
-        [/modify_unit]
+                [then]
+                    {VARIABLE unit.attack[$i].number 0}
+                [/then]
+            [/if]
+        {NEXT i}
+
+        [unstore_unit]
+            variable=unit
+            find_vacant=no
+        [/unstore_unit]
+
+        {FOREACH second_unit.attack i}
+            {VARIABLE second_unit.variables.former_attack_numbers[$i].number $second_unit.attack[$i].number}
+            [if]
+                [variable]
+                    name=second_unit.attack[$i].type
+                    equals=fire
+                [/variable]
+
+                [then]
+                    {VARIABLE second_unit.attack[$i].number 0}
+                [/then]
+            [/if]
+        {NEXT i}
+
+        [unstore_unit]
+            variable=second_unit
+            find_vacant=no
+        [/unstore_unit]
+
+        [event]
+            name=attack end
+            delayed_variable_substitution=yes
+            {FOREACH unit.attack i}
+                {VARIABLE unit.attack[$i].number $unit.variables.former_attack_numbers[$i].number}
+            {NEXT i}
+            {CLEAR_VARIABLE unit.variables.former_attack_numbers}
+
+            [if]
+                [variable]
+                    name=unit
+                    not_equals=$empty_variable
+                [/variable]
+                [then]
+                    [unstore_unit]
+                        variable=unit
+                        find_vacant=no
+                    [/unstore_unit]
+                [/then]
+            [/if]
+
+            {FOREACH second_unit.attack i}
+                {VARIABLE second_unit.attack[$i].number $second_unit.variables.former_attack_numbers[$i].number}
+            {NEXT i}
+            {CLEAR_VARIABLE second_unit.variables.former_attack_numbers}
+
+            [if]
+                [variable]
+                    name=second_unit
+                    not_equals=$empty_variable
+                [/variable]
+                [then]
+                    [unstore_unit]
+                        variable=second_unit
+                        find_vacant=no
+                    [/unstore_unit]
+                [/then]
+            [/if]
+        [/event]
     [/event]
 
     {DROPS 6 8 (axe,axe,staff,sword,sword,knife,bow,dagger,xbow,spear,spear,bow,dagger,mace) yes 2}


### PR DESCRIPTION
The new change using [object] gives an insurmountable problem:
If the unit advances or changes weapons to one that gives it a new fire attack, the object doesn't apply to this new attack even if the unit is rebuilt, since according to the developers, objects and advancements are applied in the strict order they were obtained.
So I think it's better to go back to the previous method, simply adding a conditional to prevent any error from appearing on the screen in case unit or second_unit are not present on attack end event.
This is the only change from the old code.

Remember it still has a small inconvenient, but it doesn't affect the balance much:
- The attacker loses all its attacks for trying.
- Both units receives experience as if it had attacked.

Undo #539 