### PR TITLE
Clear Lethargy/Wrath and Redeem between scenarios

### DIFF
--- a/utils/abilities_events.cfg
+++ b/utils/abilities_events.cfg
@@ -5568,6 +5568,7 @@
                 [/unstore_unit]
             [/do]
         [/for]
+        {CLEAR_VARIABLE wrathful}
     [/event]
 
     [event]

--- a/utils/abilities_events.cfg
+++ b/utils/abilities_events.cfg
@@ -5522,6 +5522,44 @@
     [/event]
 
     [event]
+        name=start,victory
+        first_time_only=no
+
+        [store_unit]
+            [filter]
+                [filter_wml]
+                    [variables]
+                        wrath=yes
+                    [/variables]
+                [/filter_wml]
+            [/filter]
+            variable=wrathful
+        [/store_unit]
+
+        {FOREACH wrathful h}
+            {CLEAR_VARIABLE wrathful[$h].variables.wrath,wrathful[$h].variables.wrath_intensity}
+            {FOREACH wrathful[$h].attack i}
+                {FOREACH wrathful[$h].attack[$i].specials.damage j}
+                    [if]
+                        [variable]
+                            name=wrathful[$h].attack[$i].specials.damage[$j].id
+                            equals=latent_wrath
+                        [/variable]
+                        [then]
+                            {VARIABLE wrathful[$h].attack[$i].specials.damage[$j].add 0}
+                        [/then]
+                    [/if]
+                {NEXT j}
+            {NEXT i}
+            [unstore_unit]
+                variable=wrathful[$h]
+                find_vacant=no
+                advance=no
+            [/unstore_unit]
+        {NEXT h}
+    [/event]
+
+    [event]
         name=attacker hits
         first_time_only=no
         [filter_second]

--- a/utils/abilities_events.cfg
+++ b/utils/abilities_events.cfg
@@ -5535,28 +5535,39 @@
             [/filter]
             variable=wrathful
         [/store_unit]
-
-        {FOREACH wrathful h}
-            {CLEAR_VARIABLE wrathful[$h].variables.wrath,wrathful[$h].variables.wrath_intensity}
-            {FOREACH wrathful[$h].attack i}
-                {FOREACH wrathful[$h].attack[$i].specials.damage j}
-                    [if]
-                        [variable]
-                            name=wrathful[$h].attack[$i].specials.damage[$j].id
-                            equals=latent_wrath
-                        [/variable]
-                        [then]
-                            {VARIABLE wrathful[$h].attack[$i].specials.damage[$j].add 0}
-                        [/then]
-                    [/if]
-                {NEXT j}
-            {NEXT i}
-            [unstore_unit]
-                variable=wrathful[$h]
-                find_vacant=no
-                advance=no
-            [/unstore_unit]
-        {NEXT h}
+        [for]
+            variable=h
+            array=wrathful
+            [do]
+                {CLEAR_VARIABLE wrathful[$h].variables.wrath,wrathful[$h].variables.wrath_intensity}
+                [for]
+                    variable=i
+                    array=wrathful[$h].attack
+                    [do]
+                        [for]
+                            variable=j
+                            array=wrathful[$h].attack[$i].specials.damage
+                            [do]
+                                [if]
+                                    [variable]
+                                        name=wrathful[$h].attack[$i].specials.damage[$j].id
+                                        equals=latent_wrath
+                                    [/variable]
+                                    [then]
+                                        {VARIABLE wrathful[$h].attack[$i].specials.damage[$j].add 0}
+                                    [/then]
+                                [/if]
+                            [/do]
+                        [/for]
+                    [/do]
+                [/for]
+                [unstore_unit]
+                    variable=wrathful[$h]
+                    find_vacant=no
+                    advance=no
+                [/unstore_unit]
+            [/do]
+        [/for]
     [/event]
 
     [event]

--- a/utils/redeeming.cfg
+++ b/utils/redeeming.cfg
@@ -1289,25 +1289,32 @@
             [/filter]
             variable=redeemer
         [/store_unit]
-
-        {FOREACH redeemer i}
-            {CLEAR_VARIABLE redeemer[$i].status.redeem_waiting}
-            {CLEAR_VARIABLE redeemer[$i].variables.redeem_wait}
-            {FOREACH redeemer[$i].attack l}
-                [if]
-                    [variable]
-                        name=redeemer[$i].attack[$l].name
-                        equals=redeem
-                    [/variable]
-                    [then]
-                        {CLEAR_VARIABLE redeemer[$i].attack[$l].attack_weight}
-                    [/then]
-                [/if]
-            {NEXT l}
-            [unstore_unit]
-                variable=redeemer[$i]
-            [/unstore_unit]
-        {NEXT i}
+        [for]
+            variable=i
+            array=redeemer
+            [do]
+                {CLEAR_VARIABLE redeemer[$i].status.redeem_waiting}
+                {CLEAR_VARIABLE redeemer[$i].variables.redeem_wait}
+                [for]
+                    variable=l
+                    array=redeemer[$i].attack
+                    [do]
+                        [if]
+                            [variable]
+                                name=redeemer[$i].attack[$l].name
+                                equals=redeem
+                            [/variable]
+                            [then]
+                                {CLEAR_VARIABLE redeemer[$i].attack[$l].attack_weight}
+                            [/then]
+                        [/if]
+                    [/do]
+                [/for]
+                [unstore_unit]
+                    variable=redeemer[$i]
+                [/unstore_unit]
+            [/do]
+        [/for]
 
         {CLEAR_VARIABLE redeemer}
     [/event]

--- a/utils/redeeming.cfg
+++ b/utils/redeeming.cfg
@@ -1278,4 +1278,37 @@
 
         {CLEAR_VARIABLE redeemer}
     [/event]
+    
+    [event]
+        name=start,victory
+        first_time_only=no
+
+        [store_unit]
+            [filter]
+                status=redeem_waiting
+            [/filter]
+            variable=redeemer
+        [/store_unit]
+
+        {FOREACH redeemer i}
+            {CLEAR_VARIABLE redeemer[$i].status.redeem_waiting}
+            {CLEAR_VARIABLE redeemer[$i].variables.redeem_wait}
+            {FOREACH redeemer[$i].attack l}
+                [if]
+                    [variable]
+                        name=redeemer[$i].attack[$l].name
+                        equals=redeem
+                    [/variable]
+                    [then]
+                        {CLEAR_VARIABLE redeemer[$i].attack[$l].attack_weight}
+                    [/then]
+                [/if]
+            {NEXT l}
+            [unstore_unit]
+                variable=redeemer[$i]
+            [/unstore_unit]
+        {NEXT i}
+
+        {CLEAR_VARIABLE redeemer}
+    [/event]
 #enddef


### PR DESCRIPTION
This is the simplest fix for now, as long as the method is not changed. Both are checked, and without using the {FOREACH} macro.

The old code uses direct edits to units variables to avoid rebuilding the unit, but it is still effective in the LOTI context and does not need to be updated, in my opinion. It works fine, and with this it's already treated as any status between scenarios. I play LOTI with various other addons and they mix well, so it's still a robust system even in 1.17

Resolves #544 