### PR TITLE
Specify melee in ability descriptions

### DIFF
--- a/utils/abilities.cfg
+++ b/utils/abilities.cfg
@@ -1690,7 +1690,7 @@ Enemy units cannot see this unit at night, except if they have units next to it.
         id=berserk_leadership
         name= _ "radiating insanity"
         female_name= _ "female^radiating insanity"
-        description= _ "All nearby allies fight with a bloodlust equal to the dwarvish berserk."
+        description= _ "All nearby allies fight with a bloodlust equal to the dwarvish berserk on melee attacks."
         value=30
         [filter_student]
             [filter_weapon]
@@ -1709,8 +1709,8 @@ Enemy units cannot see this unit at night, except if they have units next to it.
         id=charge_leadership
         name= _ "warlord's rule"
         female_name= _ "female^warlord's rule"
-        description= _ "All nearby allies deal and take 50% more damage."
-        special_note=_" This unit can fanaticise all units adjacent to him into a frenzy, making them deal and take double damage, but only offensively."
+        description= _ "All nearby allies deal and take 50% more melee damage."
+        special_note=_" This unit can fanaticise all units adjacent to him into a frenzy, making them deal and take double melee damage, but only offensively."
         [filter_student]
             [filter_weapon]
                 range=melee


### PR DESCRIPTION
Similar to #533 , in this case forgot to specify that they only work in melee.