### PR TITLE
typo in Apologies, update blizzard info in redeem

### DIFF
--- a/lua/redeem.lua
+++ b/lua/redeem.lua
@@ -36,7 +36,7 @@ known_ability_trees.redeem = {
 	},
 	blizzard = {
 		image = "attacks/blizzard.png",
-		label =_ "Blizzard (only for attacking, slows a lot of units, moves them over the place)",
+		label =_ "Blizzard (only for attacking, slows a lot of units)",
 		requires = { "arcticblast" },
 		short_name =_ "Blizzard"
 	},

--- a/scenarios6/15_Apologies.cfg
+++ b/scenarios6/15_Apologies.cfg
@@ -65,7 +65,7 @@
                 [/store_unit]
                 {CLEAR_VARIABLE Efrstore.variables.achieved_amla}
                 {CLEAR_VARIABLE Efrstore.modifications.trait}
-                {CLEAR_VARIABLE Efrstore.modifications.advancement,Eftstore.variables.devour_count,Eftstore.variables.max_devour_count}
+                {CLEAR_VARIABLE Efrstore.modifications.advancement,Efrstore.variables.devour_count,Efrstore.variables.max_devour_count}
                 {VARIABLE Efrstore.modifications.advancement[$Efrstore.modifications.advancement.length].id leadership}
                 {VARIABLE Efrstore.modifications.advancement[$Efrstore.modifications.advancement.length].id leadership1}
                 {VARIABLE Efrstore.modifications.advancement[$Efrstore.modifications.advancement.length].id leadership2}
@@ -589,7 +589,7 @@
                         id=Efraim
                     [/filter]
                 [/store_unit]
-                {CLEAR_VARIABLE Efrstore.modifications.advancement,Eftstore.variables.devour_count,Eftstore.variables.max_devour_count}
+                {CLEAR_VARIABLE Efrstore.modifications.advancement,Efrstore.variables.devour_count,Efrstore.variables.max_devour_count}
                 {CLEAR_VARIABLE Efrstore.variables.achieved_amla}
                 {CLEAR_VARIABLE Efrstore.modifications.trait}
                 {VARIABLE Efrstore.modifications.advancement[$Efrstore.modifications.advancement.length].id leadership}


### PR DESCRIPTION
I swear blizzard used to scatter enemies, kind of like shockwave.  But it doesn't now, and I see no indication it's trying to.
