### PR TITLE
fix United/Transporting redeem upgrade

### DIFF
--- a/lua/redeem.lua
+++ b/lua/redeem.lua
@@ -36,7 +36,7 @@ known_ability_trees.redeem = {
 	},
 	blizzard = {
 		image = "attacks/blizzard.png",
-		label =_ "Blizzard (only for attacking, slows a lot of units, moves them over the place)",
+		label =_ "Blizzard (only for attacking, slows a lot of units)",
 		requires = { "arcticblast" },
 		short_name =_ "Blizzard"
 	},

--- a/lua/redeem.lua
+++ b/lua/redeem.lua
@@ -532,8 +532,6 @@ end
 -- Unit is identified by cfg.find_in parameter (e.g. find_in=secondary_unit).
 -- NOTE: this is TEMPORARY (won't be needed in the future),
 -- because the WML code that needs this variable might be replaced by Lua.
---
--- NOTE: this is now used by ch8 United and ch9 Transporting Facility.
 function wesnoth.wml_actions.count_redeem_upgrades(cfg)
 	local to_variable = cfg.to_variable or "upgrade_count"
 

--- a/scenarios6/15_Apologies.cfg
+++ b/scenarios6/15_Apologies.cfg
@@ -65,7 +65,7 @@
                 [/store_unit]
                 {CLEAR_VARIABLE Efrstore.variables.achieved_amla}
                 {CLEAR_VARIABLE Efrstore.modifications.trait}
-                {CLEAR_VARIABLE Efrstore.modifications.advancement,Eftstore.variables.devour_count,Eftstore.variables.max_devour_count}
+                {CLEAR_VARIABLE Efrstore.modifications.advancement,Efrstore.variables.devour_count,Efrstore.variables.max_devour_count}
                 {VARIABLE Efrstore.modifications.advancement[$Efrstore.modifications.advancement.length].id leadership}
                 {VARIABLE Efrstore.modifications.advancement[$Efrstore.modifications.advancement.length].id leadership1}
                 {VARIABLE Efrstore.modifications.advancement[$Efrstore.modifications.advancement.length].id leadership2}
@@ -589,7 +589,7 @@
                         id=Efraim
                     [/filter]
                 [/store_unit]
-                {CLEAR_VARIABLE Efrstore.modifications.advancement,Eftstore.variables.devour_count,Eftstore.variables.max_devour_count}
+                {CLEAR_VARIABLE Efrstore.modifications.advancement,Efrstore.variables.devour_count,Efrstore.variables.max_devour_count}
                 {CLEAR_VARIABLE Efrstore.variables.achieved_amla}
                 {CLEAR_VARIABLE Efrstore.modifications.trait}
                 {VARIABLE Efrstore.modifications.advancement[$Efrstore.modifications.advancement.length].id leadership}

--- a/scenarios8/03_United.cfg
+++ b/scenarios8/03_United.cfg
@@ -662,11 +662,6 @@
                 equals=1
             [/variable]
             [then]
-                # TEST
-                {VARIABLE Efrstore.variables.redeem_level 3}
-                {VARIABLE Lethstore.variables.redeem_level 3}
-                # TEST
-
                 [lua]
                     code =  <<
                 -- max_redeem_count(n+1)=max_redeem_count(n)+floor(n*4/3), where n is redeem level 

--- a/scenarios8/03_United.cfg
+++ b/scenarios8/03_United.cfg
@@ -523,24 +523,25 @@
             variable=Efrstore
             kill=no
         [/store_unit]
-        {VARIABLE efraim_upgrade_count 0}
-        {VARIABLE lethalia_upgrade_count 0}
-        [count_redeem_upgrades]
-            to_variable=efraim_upgrade_count
-            find_in="Efrstore"
-        [/count_redeem_upgrades]
-        [count_redeem_upgrades]
-            to_variable=lethalia_upgrade_count
-            find_in="Lethstore"
-        [/count_redeem_upgrades]
+        {VARIABLE efraim_new_max 0}
+        {VARIABLE lethalia_new_max 0}
+        {VARIABLE efraim_redeem_level $Efrstore.variables.redeem_level}
+        {VARIABLE lethalia_redeem_level $Lethstore.variables.redeem_level}
+        # Begin These will be unnecessary once nothing depends on counting upgrades
+        {VARIABLE efraim_upgrade_count $efraim_redeem_level}
+        {VARIABLE_OP efraim_upgrade_count sub 1}
+        {VARIABLE lethalia_upgrade_count $lethalia_upgrade_count}
+        {VARIABLE_OP lethalia_upgrade_count sub 1}
+        # End These will be unnecessary once nothing depends on counting upgrades
+
         [if]
             [variable]
-                name=efraim_upgrade_count
+                name=efraim_redeem_level
                 less_than=5
             [/variable]
             [and]
                 [variable]
-                    name=lethalia_upgrade_count
+                    name=lethalia_redeem_level
                     less_than=5
                 [/variable]
             [/and]
@@ -553,12 +554,12 @@
         [/if]
         [if]
             [variable]
-                name=efraim_upgrade_count
+                name=efraim_redeem_level
                 less_than=5
             [/variable]
             [and]
                 [variable]
-                    name=lethalia_upgrade_count
+                    name=lethalia_redeem_level
                     greater_than=4
                 [/variable]
             [/and]
@@ -571,12 +572,12 @@
         [/if]
         [if]
             [variable]
-                name=lethalia_upgrade_count
+                name=lethalia_redeem_level
                 less_than=5
             [/variable]
             [and]
                 [variable]
-                    name=efraim_upgrade_count
+                    name=efraim_redeem_level
                     greater_than=4
                 [/variable]
             [/and]
@@ -591,12 +592,12 @@
         {VARIABLE lethalia_will_upgrade 0}
         [if]
             [variable]
-                name=efraim_upgrade_count
+                name=efraim_redeem_level
                 less_than=5
             [/variable]
             [or]
                 [variable]
-                    name=lethalia_upgrade_count
+                    name=lethalia_redeem_level
                     less_than=5
                 [/variable]
             [/or]
@@ -608,12 +609,12 @@
                         label= _ "Yes, for both."
                         [show_if]
                             [variable]
-                                name=efraim_upgrade_count
+                                name=efraim_redeem_level
                                 less_than=5
                             [/variable]
                             [and]
                                 [variable]
-                                    name=lethalia_upgrade_count
+                                    name=lethalia_redeem_level
                                     less_than=5
                                 [/variable]
                             [/and]
@@ -627,7 +628,7 @@
                         label= _ "Yes, for Efraim."
                         [show_if]
                             [variable]
-                                name=efraim_upgrade_count
+                                name=efraim_redeem_level
                                 less_than=5
                             [/variable]
                         [/show_if]
@@ -639,7 +640,7 @@
                         label= _ "Yes, for Lethalia."
                         [show_if]
                             [variable]
-                                name=lethalia_upgrade_count
+                                name=lethalia_redeem_level
                                 less_than=5
                             [/variable]
                         [/show_if]
@@ -661,35 +662,87 @@
                 equals=1
             [/variable]
             [then]
+                # TEST
+                {VARIABLE Efrstore.variables.redeem_level 3}
+                {VARIABLE Lethstore.variables.redeem_level 3}
+                # TEST
+
+                [lua]
+                    code =  <<
+                -- max_redeem_count(n+1)=max_redeem_count(n)+floor(n*4/3), where n is redeem level 
+                --   and max_redeem_count(1) = 6.
+                -- Instead of repeatedly calculating these values, they are presented here (with plenty of extras for future use)
+                local max_redeem_count_list = {6, 8, 10, 13, 17, 22, 29, 38, 50, 66, 88, 117, 156, 208, 277, 369, 492, 656, 874, 1165, 1553, 2070, 2760, 3680, 4906, 6541, 8721, 11628, 15504, 20672, 27562, 36749, 48998, 65330, 87106, 116141, 154854, 206472, 275296, 367061}
+                local efraim_new_max = 0
+                local efraim_redeem_level = wml.variables["Efrstore.variables.redeem_level"]
+                if(efraim_redeem_level < 5) then
+                    for i=efraim_redeem_level,5,1 do
+                        efraim_new_max = efraim_new_max + max_redeem_count_list[i]
+                    end
+                end
+                wml.variables["efraim_new_max"] = efraim_new_max
+            >>
+                [/lua]
+                {VARIABLE Efrstore.variables.max_redeem_count $efraim_new_max}
+                {VARIABLE Efrstore.variables.redeem_level 5}
+                {VARIABLE found_in_advancements 0}
+                # Efraim gets leadership if he didn't have it already
+                [foreach]
+                    array=Efrstore.modifications.advancement
+                    [do]
+                        [if]
+                            [variable]
+                                name=Efrstore.modifications.advancement[i]
+                                equals="heal"
+                            [/variable]
+                            [then]
+                                {VARIABLE found_in_advancements 1}
+                                [break][/break]
+                            [/then]
+                        [/if]
+                    [/do]
+                [/foreach]
+                [if]
+                    [variable]
+                        name=found_in_advancements
+                        equals=0
+                    [/variable]
+                    [then]
+                        {VARIABLE Efrstore.modifications.advancement[$Efrstore.modifications.advancement.length].id leadership}
+                    [/then]
+                [/if]
+                {CLEAR_VARIABLE found_in_advancements}
+                # Begin These will be unnecessary once nothing depends on counting upgrades
                 [while]
                     [variable]
                         name=efraim_upgrade_count
-                        less_than=5
+                        less_than=4
                     [/variable]
                     [do]
                         {VARIABLE Efrstore.modifications.advancement[$Efrstore.modifications.advancement.length].id leadership}
                         {VARIABLE_OP efraim_upgrade_count add 1}
-                        [unstore_unit]
-                            variable=Efrstore
-                            find_vacant=no
-                        [/unstore_unit]
-                        [object]
-                            silent=yes
-                            [filter]
-                                id=Efraim
-                            [/filter]
-                            [effect]
-                                apply_to=attack
-                                name="redeem"
-                                [set_specials]
-                                    mode=replace
-                                    {WEAPON_SPECIAL_REDEEM_5}
-                                    {WEAPON_SPECIAL_FOCUSED}
-                                [/set_specials]
-                            [/effect]
-                        [/object]
                     [/do]
                 [/while]
+                # End These will be unnecessary once nothing depends on counting upgrades
+                [unstore_unit]
+                    variable=Efrstore
+                    find_vacant=no
+                [/unstore_unit]
+                [object]
+                    silent=yes
+                    [filter]
+                        id=Efraim
+                    [/filter]
+                    [effect]
+                        apply_to=attack
+                        name="redeem"
+                        [set_specials]
+                            mode=replace
+                            {WEAPON_SPECIAL_REDEEM_5}
+                            {WEAPON_SPECIAL_FOCUSED}
+                        [/set_specials]
+                    [/effect]
+                [/object]
             [/then]
         [/if]
         [if]
@@ -698,45 +751,93 @@
                 equals=1
             [/variable]
             [then]
+                [lua]
+                    code =  <<
+                -- max_redeem_count(n+1)=max_redeem_count(n)+floor(n*4/3), where n is redeem level 
+                --   and max_redeem_count(1) = 6.
+                -- Instead of repeatedly calculating these values, they are presented here (with plenty of extras for future use)
+                local max_redeem_count_list = {6, 8, 10, 13, 17, 22, 29, 38, 50, 66, 88, 117, 156, 208, 277, 369, 492, 656, 874, 1165, 1553, 2070, 2760, 3680, 4906, 6541, 8721, 11628, 15504, 20672, 27562, 36749, 48998, 65330, 87106, 116141, 154854, 206472, 275296, 367061}
+
+                local lethalia_new_max = 0
+                local lethalia_redeem_level = wml.variables["Lethstore.variables.redeem_level"]
+                if(lethalia_redeem_level < 5) then
+                    for i=lethalia_redeem_level,5,1 do
+                        lethalia_new_max = lethalia_new_max + max_redeem_count_list[i]
+                    end
+                end
+                wml.variables["lethalia_new_max"] = lethalia_new_max
+            >>
+                [/lua]
+                {VARIABLE Lethstore.variables.max_redeem_count $lethalia_new_max}
+                {VARIABLE Lethstore.variables.redeem_level 5}
+                {VARIABLE found_in_advancements 0}
+                # Lethalia gets heal if she didn't have it already
+                [foreach]
+                    array=Lethstore.modifications.advancement
+                    [do]
+                        [if]
+                            [variable]
+                                name=Lethstore.modifications.advancement[i]
+                                equals="heal"
+                            [/variable]
+                            [then]
+                                {VARIABLE found_in_advancements 1}
+                                [break][/break]
+                            [/then]
+                        [/if]
+                    [/do]
+                [/foreach]
+                [if]
+                    [variable]
+                        name=found_in_advancements
+                        equals=0
+                    [/variable]
+                    [then]
+                        {VARIABLE Lethstore.modifications.advancement[$Lethstore.modifications.advancement.length].id heal}
+                    [/then]
+                [/if]
+                {CLEAR_VARIABLE found_in_advancements}
+                # Begin These will be unnecessary once nothing depends on counting upgrades
                 [while]
                     [variable]
                         name=lethalia_upgrade_count
-                        less_than=5
+                        less_than=4
                     [/variable]
                     [do]
                         {VARIABLE Lethstore.modifications.advancement[$Lethstore.modifications.advancement.length].id heal}
                         {VARIABLE_OP lethalia_upgrade_count add 1}
-                        [unstore_unit]
-                            variable=Lethstore
-                            find_vacant=no
-                        [/unstore_unit]
-                        [object]
-                            silent=yes
-                            [filter]
-                                id=Lethalia
-                            [/filter]
-                            [effect]
-                                apply_to=attack
-                                name="redeem"
-                                [set_specials]
-                                    mode=replace
-                                    {WEAPON_SPECIAL_REDEEM_5}
-                                    {WEAPON_SPECIAL_FOCUSED}
-                                [/set_specials]
-                            [/effect]
-                        [/object]
                     [/do]
                 [/while]
+                # End These will be unnecessary once nothing depends on counting upgrades
+                [unstore_unit]
+                    variable=Lethstore
+                    find_vacant=no
+                [/unstore_unit]
+                [object]
+                    silent=yes
+                    [filter]
+                        id=Lethalia
+                    [/filter]
+                    [effect]
+                        apply_to=attack
+                        name="redeem"
+                        [set_specials]
+                            mode=replace
+                            {WEAPON_SPECIAL_REDEEM_5}
+                            {WEAPON_SPECIAL_FOCUSED}
+                        [/set_specials]
+                    [/effect]
+                [/object]
             [/then]
         [/if]
         [if]
             [variable]
-                name=efraim_upgrade_count
+                name=efraim_redeem_level
                 less_than=5
             [/variable]
             [or]
                 [variable]
-                    name=lethalia_upgrade_count
+                    name=lethalia_redeem_level
                     less_than=5
                 [/variable]
             [/or]
@@ -748,6 +849,7 @@
             [/then]
         [/if]
         {CLEAR_VARIABLE efraim_upgrade_count,Efrstore,efraim_will_upgrade,lethalia_upgrade_count,Lethstore,lethalia_will_upgrade}
+        {CLEAR_VARIABLE efraim_redeem_level,efraim_new_max,lethalia_redeem_level,lethalia_new_max}
         [message]
             speaker=duke
             message= _ "So, what do we do now?"

--- a/scenarios9/01_Transporting_Facility.cfg
+++ b/scenarios9/01_Transporting_Facility.cfg
@@ -310,21 +310,25 @@
                     variable=Efrstore
                     kill=no
                 [/store_unit]
-                {VARIABLE efraim_upgrade_count 0}
-                [lua]
-                    code = <<
-            wesnoth.wml_actions.count_redeem_upgrades({id="Lethalia", to_variable="lethalia_upgrade_count"})
-            wesnoth.wml_actions.count_redeem_upgrades({id="Efraim", to_variable="efraim_upgrade_count"})
-        >>	
-                [/lua]
+                {VARIABLE efraim_new_max 0}
+                {VARIABLE lethalia_new_max 0}
+                {VARIABLE efraim_redeem_level $Efrstore.variables.redeem_level}
+                {VARIABLE lethalia_redeem_level $Lethstore.variables.redeem_level}
+                # Begin These will be unnecessary once nothing depends on counting upgrades
+                {VARIABLE efraim_upgrade_count $efraim_redeem_level}
+                {VARIABLE_OP efraim_upgrade_count sub 1}
+                {VARIABLE lethalia_upgrade_count $lethalia_upgrade_count}
+                {VARIABLE_OP lethalia_upgrade_count sub 1}
+                # End These will be unnecessary once nothing depends on counting upgrades
+
                 [if]
                     [variable]
-                        name=efraim_upgrade_count
+                        name=efraim_redeem_level
                         less_than=8
                     [/variable]
                     [and]
                         [variable]
-                            name=lethalia_upgrade_count
+                            name=lethalia_redeem_level
                             less_than=8
                         [/variable]
                     [/and]
@@ -337,12 +341,12 @@
                 [/if]
                 [if]
                     [variable]
-                        name=efraim_upgrade_count
+                        name=efraim_redeem_level
                         less_than=8
                     [/variable]
                     [and]
                         [variable]
-                            name=lethalia_upgrade_count
+                            name=lethalia_redeem_level
                             greater_than=7
                         [/variable]
                     [/and]
@@ -355,12 +359,12 @@
                 [/if]
                 [if]
                     [variable]
-                        name=lethalia_upgrade_count
+                        name=lethalia_redeem_level
                         less_than=8
                     [/variable]
                     [and]
                         [variable]
-                            name=efraim_upgrade_count
+                            name=efraim_redeem_level
                             greater_than=7
                         [/variable]
                     [/and]
@@ -375,13 +379,13 @@
                 {VARIABLE lethalia_will_upgrade 0}
                 [if]
                     [variable]
-                        name=efraim_upgrade_count
-                        less_than=7
+                        name=efraim_redeem_level
+                        less_than=8
                     [/variable]
                     [or]
                         [variable]
-                            name=lethalia_upgrade_count
-                            less_than=7
+                            name=lethalia_redeem_level
+                            less_than=8
                         [/variable]
                     [/or]
                     [then]
@@ -392,13 +396,13 @@
                                 label= _ "Yes, for both."
                                 [show_if]
                                     [variable]
-                                        name=efraim_upgrade_count
-                                        less_than=7
+                                        name=efraim_redeem_level
+                                        less_than=8
                                     [/variable]
                                     [and]
                                         [variable]
-                                            name=lethalia_upgrade_count
-                                            less_than=7
+                                            name=lethalia_redeem_level
+                                            less_than=8
                                         [/variable]
                                     [/and]
                                 [/show_if]
@@ -411,8 +415,8 @@
                                 label= _ "Yes, for Efraim."
                                 [show_if]
                                     [variable]
-                                        name=efraim_upgrade_count
-                                        less_than=7
+                                        name=efraim_redeem_level
+                                        less_than=8
                                     [/variable]
                                 [/show_if]
                                 [command]
@@ -423,8 +427,8 @@
                                 label= _ "Yes, for Lethalia."
                                 [show_if]
                                     [variable]
-                                        name=lethalia_upgrade_count
-                                        less_than=7
+                                        name=lethalia_redeem_level
+                                        less_than=8
                                     [/variable]
                                 [/show_if]
                                 [command]
@@ -445,35 +449,83 @@
                         equals=1
                     [/variable]
                     [then]
+                        [lua]
+                            code =  <<
+                -- max_redeem_count(n+1)=max_redeem_count(n)+floor(n*4/3), where n is redeem level 
+                --   and max_redeem_count(1) = 6.
+                -- Instead of repeatedly calculating these values, they are presented here (with plenty of extras for future use)
+                local max_redeem_count_list = {6, 8, 10, 13, 17, 22, 29, 38, 50, 66, 88, 117, 156, 208, 277, 369, 492, 656, 874, 1165, 1553, 2070, 2760, 3680, 4906, 6541, 8721, 11628, 15504, 20672, 27562, 36749, 48998, 65330, 87106, 116141, 154854, 206472, 275296, 367061}
+                local efraim_new_max = 0
+                local efraim_redeem_level = wml.variables["Efrstore.variables.redeem_level"]
+                if(efraim_redeem_level < 8) then
+                    for i=efraim_redeem_level,8,1 do
+                        efraim_new_max = efraim_new_max + max_redeem_count_list[i]
+                    end
+                end
+                wml.variables["efraim_new_max"] = efraim_new_max
+            >>
+                        [/lua]
+                        {VARIABLE Efrstore.variables.max_redeem_count $efraim_new_max}
+                        {VARIABLE Efrstore.variables.redeem_level 8}
+                        {VARIABLE found_in_advancements 0}
+                        # Efraim gets leadership if he didn't have it already
+                        [foreach]
+                            array=Efrstore.modifications.advancement
+                            [do]
+                                [if]
+                                    [variable]
+                                        name=Efrstore.modifications.advancement[i]
+                                        equals="heal"
+                                    [/variable]
+                                    [then]
+                                        {VARIABLE found_in_advancements 1}
+                                        [break][/break]
+                                    [/then]
+                                [/if]
+                            [/do]
+                        [/foreach]
+                        [if]
+                            [variable]
+                                name=found_in_advancements
+                                equals=0
+                            [/variable]
+                            [then]
+                                {VARIABLE Efrstore.modifications.advancement[$Efrstore.modifications.advancement.length].id leadership}
+                            [/then]
+                        [/if]
+                        {CLEAR_VARIABLE found_in_advancements}
+                        # Begin These will be unnecessary once nothing depends on counting upgrades
+                        {VARIABLE Efrstore.variables.max_redeem_count $efraim_new_max}
                         [while]
                             [variable]
                                 name=efraim_upgrade_count
-                                less_than=8
+                                less_than=7
                             [/variable]
                             [do]
                                 {VARIABLE Efrstore.modifications.advancement[$Efrstore.modifications.advancement.length].id leadership}
                                 {VARIABLE_OP efraim_upgrade_count add 1}
-                                [unstore_unit]
-                                    variable=Efrstore
-                                    find_vacant=no
-                                [/unstore_unit]
-                                [object]
-                                    silent=yes
-                                    [filter]
-                                        id=Efraim
-                                    [/filter]
-                                    [effect]
-                                        apply_to=attack
-                                        name="redeem"
-                                        [set_specials]
-                                            mode=replace
-                                            {WEAPON_SPECIAL_REDEEM_8}
-                                            {WEAPON_SPECIAL_FOCUSED}
-                                        [/set_specials]
-                                    [/effect]
-                                [/object]
                             [/do]
                         [/while]
+                        # End These will be unnecessary once nothing depends on counting upgrades
+                        [unstore_unit]
+                            variable=Efrstore
+                            find_vacant=no
+                        [/unstore_unit]
+                        [object]
+                            silent=yes
+                            [filter]
+                                id=Efraim
+                            [/filter]
+                            [effect]
+                                apply_to=attack
+                                name="redeem"
+                                [set_specials]
+                                    mode=replace
+                                    {WEAPON_SPECIAL_REDEEM_8}
+                                    {WEAPON_SPECIAL_FOCUSED}
+                                [/set_specials]
+                            [/effect]
+                        [/object]
                     [/then]
                 [/if]
                 [if]
@@ -482,40 +534,88 @@
                         equals=1
                     [/variable]
                     [then]
+                        [lua]
+                            code =  <<
+                -- max_redeem_count(n+1)=max_redeem_count(n)+floor(n*4/3), where n is redeem level 
+                --   and max_redeem_count(1) = 6.
+                -- Instead of repeatedly calculating these values, they are presented here (with plenty of extras for future use)
+                local max_redeem_count_list = {6, 8, 10, 13, 17, 22, 29, 38, 50, 66, 88, 117, 156, 208, 277, 369, 492, 656, 874, 1165, 1553, 2070, 2760, 3680, 4906, 6541, 8721, 11628, 15504, 20672, 27562, 36749, 48998, 65330, 87106, 116141, 154854, 206472, 275296, 367061}
+
+                local lethalia_new_max = 0
+                local lethalia_redeem_level = wml.variables["Lethstore.variables.redeem_level"]
+                if(lethalia_redeem_level < 8) then
+                    for i=lethalia_redeem_level,8,1 do
+                        lethalia_new_max = lethalia_new_max + max_redeem_count_list[i]
+                    end
+                end
+                wml.variables["lethalia_new_max"] = lethalia_new_max
+            >>
+                        [/lua]
+                        {VARIABLE Lethstore.variables.max_redeem_count $lethalia_new_max}
+                        {VARIABLE Lethstore.variables.redeem_level 8}
+                        {VARIABLE found_in_advancements 0}
+                        # Lethalia gets heal if she didn't have it already
+                        [foreach]
+                            array=Lethstore.modifications.advancement
+                            [do]
+                                [if]
+                                    [variable]
+                                        name=Lethstore.modifications.advancement[i]
+                                        equals="heal"
+                                    [/variable]
+                                    [then]
+                                        {VARIABLE found_in_advancements 1}
+                                        [break][/break]
+                                    [/then]
+                                [/if]
+                            [/do]
+                        [/foreach]
+                        [if]
+                            [variable]
+                                name=found_in_advancements
+                                equals=0
+                            [/variable]
+                            [then]
+                                {VARIABLE Lethstore.modifications.advancement[$Lethstore.modifications.advancement.length].id heal}
+                            [/then]
+                        [/if]
+                        {CLEAR_VARIABLE found_in_advancements}
+                        # Begin These will be unnecessary once nothing depends on counting upgrades
                         [while]
                             [variable]
                                 name=lethalia_upgrade_count
-                                less_than=8
+                                less_than=7
                             [/variable]
                             [do]
                                 {VARIABLE Lethstore.modifications.advancement[$Lethstore.modifications.advancement.length].id heal}
                                 {VARIABLE_OP lethalia_upgrade_count add 1}
-                                [unstore_unit]
-                                    variable=Lethstore
-                                    find_vacant=no
-                                [/unstore_unit]
-                                [object]
-                                    silent=yes
-                                    [filter]
-                                        id=Lethalia
-                                    [/filter]
-                                    [effect]
-                                        apply_to=attack
-                                        name="redeem"
-                                        [set_specials]
-                                            mode=replace
-                                            {WEAPON_SPECIAL_REDEEM_8}
-                                            {WEAPON_SPECIAL_FOCUSED}
-                                        [/set_specials]
-                                    [/effect]
-                                [/object]
                             [/do]
                         [/while]
+                        # End These will be unnecessary once nothing depends on counting upgrades
+                        [unstore_unit]
+                            variable=Lethstore
+                            find_vacant=no
+                        [/unstore_unit]
+                        [object]
+                            silent=yes
+                            [filter]
+                                id=Lethalia
+                            [/filter]
+                            [effect]
+                                apply_to=attack
+                                name="redeem"
+                                [set_specials]
+                                    mode=replace
+                                    {WEAPON_SPECIAL_REDEEM_8}
+                                    {WEAPON_SPECIAL_FOCUSED}
+                                [/set_specials]
+                            [/effect]
+                        [/object]
                     [/then]
                 [/if]
                 [if]
                     [variable]
-                        name=efraim_upgrade_count
+                        name=efraim_redeem_level
                         less_than=7
                     [/variable]
                     [or]
@@ -532,6 +632,7 @@
                     [/then]
                 [/if]
                 {CLEAR_VARIABLE efraim_upgrade_count,Efrstore,efraim_will_upgrade,lethalia_upgrade_count,Lethstore,lethalia_will_upgrade}
+                {CLEAR_VARIABLE efraim_redeem_level,efraim_new_max,lethalia_redeem_level,lethalia_new_max}
             [/else]
         [/if]
         {INFERNO_RECALL_ALL}

--- a/utils/redeeming.cfg
+++ b/utils/redeeming.cfg
@@ -1219,7 +1219,15 @@
             [/then]
             [else]
                 {VARIABLE redeemer.variables.redeem_count 1}
-                {VARIABLE redeemer.variables.redeem_level 1}
+                [if]
+                    [variable]
+                        name=redeemer.variables.redeem_level
+                        greater_than=0
+                    [/variable]
+                    [else]
+                        {VARIABLE redeemer.variables.redeem_level 1}
+                    [/else]
+                [/if]
                 [unstore_unit]
                     variable=redeemer
                     {COLOR_HEAL}

--- a/utils/redeeming.cfg
+++ b/utils/redeeming.cfg
@@ -770,7 +770,7 @@
                 -- Instead of repeatedly calculating these values, they are presented here (with plenty of extras for future use)
                 local max_redeem_count_list = {6, 8, 10, 13, 17, 22, 29, 38, 50, 66, 88, 117, 156, 208, 277, 369, 492, 656, 874, 1165, 1553, 2070, 2760, 3680, 4906, 6541, 8721, 11628, 15504, 20672, 27562, 36749, 48998, 65330, 87106, 116141, 154854, 206472, 275296, 367061}
                 local redeem_level = wml.variables["redeemer.variables.redeem_level"]
-                wml.variables["redeemer.variables.redeem_count"] = max_redeem_count_list[redeem_level]
+                wml.variables["redeemer.variables.max_redeem_count"] = max_redeem_count_list[redeem_level]
             >>
                                         [/lua]
 

--- a/utils/redeeming.cfg
+++ b/utils/redeeming.cfg
@@ -206,6 +206,8 @@
         [filter_attack]
             name=redeem
         [/filter_attack]
+        # Begin This looks like it can be replaced with unit.variables.redeem_level
+        #  But be sure to search for "so we should correct it back" if you do
         {FOREACH weapon.specials.damage i}
             [if]
                 [variable]
@@ -227,6 +229,7 @@
                 [/then]
             [/if]
         {NEXT i}
+        # End This looks like it can be replaced with unit.variables.redeem_level
         {VARIABLE redeemed_in_total 0}
         [if]
             [variable]
@@ -735,12 +738,7 @@
                                     ability_tree=redeem
                                 [/show_redeem_menu]
 
-                                [count_redeem_upgrades]
-                                    find_in=redeemer
-                                    to_variable=upgrade_count
-                                [/count_redeem_upgrades]
-
-                                {VARIABLE_OP upgrade_count add 1}
+                                {VARIABLE_OP redeemer.variables.redeem_level add 1}
 
                                 [if]
                                     [variable]
@@ -761,27 +759,36 @@
                                                 {VARIABLE redeemer.variables.redeem_count 0}
                                             [/then]
                                         [/if]
-                                        {VARIABLE_OP redeemer.variables.max_redeem_count multiply 4}
-                                        [set_variable]
-                                            name=redeemer.variables.max_redeem_count
-                                            divide=3
-                                            round=floor
-                                        [/set_variable]
+                                        # We can't just calculate the new max_redeem_count from the existing one, we have to look it up.
+                                        # If player took an upgrade to jump redeem levels (e.g. c08s03 United), the current max_redeem_count won't
+                                        # be "correct" for the first advancement.
+                                        # Or we could iterate our way up from level 1.  Not.
+                                        [lua]
+                                            code =  <<
+                -- max_redeem_count(n+1)=max_redeem_count(n)+floor(n*4/3), where n is redeem level 
+                --   and max_redeem_count(1) = 6.
+                -- Instead of repeatedly calculating these values, they are presented here (with plenty of extras for future use)
+                local max_redeem_count_list = {6, 8, 10, 13, 17, 22, 29, 38, 50, 66, 88, 117, 156, 208, 277, 369, 492, 656, 874, 1165, 1553, 2070, 2760, 3680, 4906, 6541, 8721, 11628, 15504, 20672, 27562, 36749, 48998, 65330, 87106, 116141, 154854, 206472, 275296, 367061}
+                local redeem_level = wml.variables["redeemer.variables.redeem_level"]
+                wml.variables["redeemer.variables.redeem_count"] = max_redeem_count_list[redeem_level]
+            >>
+                                        [/lua]
+
                                         {VARIABLE question_asked "$redeemer.variables.redeem_count|/$redeemer.variables.max_redeem_count"}
-                                        {CLEAR_VARIABLE redeemer.variables.max_redeem_count}	#Will be reviewed later, for possible errors
                                         [if]
                                             [variable]
-                                                name=upgrade_count
+                                                name=redeemer.variables.redeem_level
                                                 greater_than=20
                                             [/variable]
                                             [then]
-                                                {VARIABLE upgrade_count 20}
+                                                {VARIABLE redeemer.variables.redeem_level 20}
                                             [/then]
                                         [/if]
                                         [switch]
-                                            variable=upgrade_count
+                                            variable=redeemer.variables.redeem_level
                                             [case]
                                                 value=1		#Clone of the following one for the case if something went wrong
+                                                {VARIABLE redeemer.variables.redeem_level 2}
                                                 [set_variables]
                                                     name=redeemer.modifications.advancement[$redeemer.modifications.advancement.length]
                                                     mode=replace
@@ -1165,7 +1172,7 @@
                                         [/switch]
                                         [if]
                                             [variable]
-                                                name=upgrade_count
+                                                name=redeemer.variables.redeem_level
                                                 greater_than=20
                                             [/variable]
                                             [then]
@@ -1212,6 +1219,7 @@
             [/then]
             [else]
                 {VARIABLE redeemer.variables.redeem_count 1}
+                {VARIABLE redeemer.variables.redeem_level 1}
                 [unstore_unit]
                     variable=redeemer
                     {COLOR_HEAL}
@@ -1220,7 +1228,7 @@
                 [/unstore_unit]
             [/else]
         [/if]
-        {CLEAR_VARIABLE redeemer,question_asked,upgrade_count,chose}
+        {CLEAR_VARIABLE redeemer,question_asked,chose}
     [/event]
 
     [event]
@@ -1278,5 +1286,4 @@
 
         {CLEAR_VARIABLE redeemer}
     [/event]
-
 #enddef


### PR DESCRIPTION
This will break backward compatibility with saves that don't have unit.variables.redeem_level.  I could put in a workaround, if it's not available when needed (redeem advancement), derive it from the attack special.

I don't know why that other commit is getting included here.  Maybe I'm not keeping local branch up to date with remote?

Ref: #534 