### PR TITLE
Scroll when Redeem is recharged

### DIFF
--- a/utils/redeeming.cfg
+++ b/utils/redeeming.cfg
@@ -1271,11 +1271,19 @@
                             [/then]
                         [/if]
                     {NEXT l}
+                    [scroll_to_unit]
+                        for_side=$redeemer[$i].side
+                        id=$redeemer[$i].id
+                    [/scroll_to_unit]
                     [unstore_unit]
                         variable=redeemer[$i]
                         {COLOR_HEAL}
                         text= _ "Redeem recharged!"
                     [/unstore_unit]
+                    [delay]
+                        time=500
+                        accelerate=yes
+                    [/delay]
                 [/then]
             [/if]
             [if]


### PR DESCRIPTION
I have realized in the second part how important it is to manage redeem. And it's hard to see the recharge message, so I added a scroll_to_unit and a delay of half a second, just enough to see the message at the same speed as the healing, for example.
I hope you find it useful, it's just a small change that makes the strategy much easier.

https://github.com/Dugy/Legend_of_the_Invincibles/assets/40789364/257bce88-8ea6-444c-bbad-0c5f2d386e22

