### PR TITLE
Avoid desync problems with recall fresh troops

### DIFF
--- a/lua/utils.lua
+++ b/lua/utils.lua
@@ -45,3 +45,8 @@ loti.execute = function(code)
 		wesnoth.fire(code[i][1], code[i][2])
 	end
 end
+
+-- [deny_undo] tag to force disable undo
+function wesnoth.wml_actions.deny_undo()
+    wesnoth.allow_undo(false)
+end

--- a/utils/global_events.cfg
+++ b/utils/global_events.cfg
@@ -537,6 +537,22 @@
         first_time_only=no
         [filter]
             side=1
+            [and]
+                [not]
+                    [filter_wml]
+                        [variables]
+                            updated=yes
+                        [/variables]
+                    [/filter_wml]
+                [/not]
+                [or]
+                    [filter_wml]
+                        [variables]
+                            glob_on_starving=*
+                        [/variables]
+                    [/filter_wml]
+                [/or]
+            [/and]
         [/filter]
         [store_unit]
             [filter]

--- a/utils/global_events.cfg
+++ b/utils/global_events.cfg
@@ -529,6 +529,9 @@
                 [/not]
             [/filter]
             {UPDATE_STATS}
+            #Make the event undoable
+            {VARIABLE_OP disallow_undo rand(0..1)}
+            {CLEAR_VARIABLE disallow_undo}
         [/event]
      [/event]
      

--- a/utils/global_events.cfg
+++ b/utils/global_events.cfg
@@ -540,22 +540,11 @@
         first_time_only=no
         [filter]
             side=1
-            [and]
-                [not]
-                    [filter_wml]
-                        [variables]
-                            updated=yes
-                        [/variables]
-                    [/filter_wml]
-                [/not]
-                [or]
-                    [filter_wml]
-                        [variables]
-                            glob_on_starving=*
-                        [/variables]
-                    [/filter_wml]
-                [/or]
-            [/and]
+            [filter_wml]
+                [variables]
+                    glob_on_starving=*
+                [/variables]
+            [/filter_wml]
         [/filter]
         [store_unit]
             [filter]
@@ -564,15 +553,6 @@
             variable=advanced
             kill=no
         [/store_unit]
-        [if]
-            [variable]
-                name=advanced.variables.updated
-                equals=yes
-            [/variable]
-            [else]
-                {UPDATE_STATS}
-            [/else]
-        [/if]
         {CLEAR_VARIABLE advanced.variables.starving}
         [unstore_unit]
             variable=advanced

--- a/utils/global_events.cfg
+++ b/utils/global_events.cfg
@@ -560,8 +560,6 @@
             find_vacant=no
         [/unstore_unit]
         {CLEAR_VARIABLE advanced}
-        [allow_undo]
-        [/allow_undo]
     [/event]
 #enddef
 

--- a/utils/global_events.cfg
+++ b/utils/global_events.cfg
@@ -529,9 +529,8 @@
                 [/not]
             [/filter]
             {UPDATE_STATS}
-            #Make the event undoable
-            {VARIABLE_OP disallow_undo rand(0..1)}
-            {CLEAR_VARIABLE disallow_undo}
+            [deny_undo]
+            [/deny_undo]
         [/event]
      [/event]
      

--- a/utils/global_events.cfg
+++ b/utils/global_events.cfg
@@ -540,11 +540,22 @@
         first_time_only=no
         [filter]
             side=1
-            [filter_wml]
-                [variables]
-                    glob_on_starving=*
-                [/variables]
-            [/filter_wml]
+            [and]
+                [not]
+                    [filter_wml]
+                        [variables]
+                            updated=yes
+                        [/variables]
+                    [/filter_wml]
+                [/not]
+                [or]
+                    [filter_wml]
+                        [variables]
+                            glob_on_starving=*
+                        [/variables]
+                    [/filter_wml]
+                [/or]
+            [/and]
         [/filter]
         [store_unit]
             [filter]
@@ -553,6 +564,15 @@
             variable=advanced
             kill=no
         [/store_unit]
+        [if]
+            [variable]
+                name=advanced.variables.updated
+                equals=yes
+            [/variable]
+            [else]
+                {UPDATE_STATS}
+            [/else]
+        [/if]
         {CLEAR_VARIABLE advanced.variables.starving}
         [unstore_unit]
             variable=advanced

--- a/utils/utils.cfg
+++ b/utils/utils.cfg
@@ -747,9 +747,8 @@ $item_info.description"
             [/variables]
             upkeep=loyal
         [/modify_unit]
-        #Make the event undoable
-        {VARIABLE_OP disallow_undo rand(0..1)}
-        {CLEAR_VARIABLE disallow_undo}
+        [deny_undo]
+        [/deny_undo]
     [/event]
     [event]
         name=victory


### PR DESCRIPTION
This event is triggered when a unit transfered from another side joins you the next scenario and you recall it, undo, then redo. It affects both multi and single player.
Gives exactly the same error as #522 

To avoid disabling undo on ALL recalls I've done a extra filtering (look at the three commits separately, ignore the last one, it's reverted as it was just a test)
- The allow_undo is removed
- Only the units that have the variables to be deleted or analyzed are filtered`*` (to avoid triggering any unit on side 1)
- Added another disable undo in unit placed event

`*` In case you don't know, `glob_on_variable=*` is a special key that works only when filtering wml (not on any tag), for example [filter_wml], and means "check for existence of `variable` with any value (`*`)"