### PR TITLE
Respect unit's base vision

### DIFF
--- a/lua/stats.lua
+++ b/lua/stats.lua
@@ -319,7 +319,11 @@ function wesnoth.update_stats(original)
 	limit_resistance("pierce", 20);
 	limit_resistance("impact", 20);
 
-	remade.vision = remade.max_moves + vision
+	local base_vision = remade.vision
+	if base_vision < 0 then
+		base_vision = remade.max_moves
+	end
+	remade.vision = base_vision + vision
 
 	local remade_abilities = wml.get_child(remade, "abilities")
 	if not remade_abilities then


### PR DESCRIPTION
Units may have a value of vision that is different from their max_moves. If it's the same as the maximal moves, it takes a negative value (from what I see, it's almost always -1 in this case but the game's cpp code checks ``vision < 0`` so I used the same condition just in case instead of my first-thought ``base_vision == -1``)