### PR TITLE
Fix experience by devastating blow

### DIFF
--- a/utils/abilities_events.cfg
+++ b/utils/abilities_events.cfg
@@ -1182,6 +1182,7 @@
                                 kill=no
                                 fire_event=yes
                                 animate=no
+                                experience=no
                             [/harm_unit]
                         [/then]
                     [/if]


### PR DESCRIPTION
I thought "no" was the default option, and I have to explicitly declare it. I have edited the wiki to reflect this circumstance.
Related with #525 
https://wiki.wesnoth.org/index.php?title=DirectActionsWML&type=revision&diff=71498&oldid=71342