### PR TITLE
fix steelhive portals

### DIFF
--- a/scenarios9/37_Catacombs_of_Prolonged_Agony.cfg
+++ b/scenarios9/37_Catacombs_of_Prolonged_Agony.cfg
@@ -376,7 +376,7 @@
 #ifdef EASY
                 {VARIABLE_OP spawn_type rand (Knight of Disaster,Knight of Disaster,Doom Knight,Knight of Pain,Knight of Disaster,Knight of Disaster,Doom Knight,Knight of Pain,Knight of Annihilation,Knight of Oblivion)}
 #endif
-                {GENERIC_UNIT {SIDE} $spawn_type {X} {Y}}
+                {GENERIC_UNIT_PASSABLE {SIDE} $spawn_type {X} {Y}}
                 [if]
                     [variable]
                         name=quests.{VARIABLE_USED}

--- a/utils/chapter9_utils.cfg
+++ b/utils/chapter9_utils.cfg
@@ -373,7 +373,7 @@
                 [/item]
                 [event]
                     name=steelhive_spawn
-                    id=steelhive_spawn
+                    id=steelhive_spawn_{SIDE}_{X}_{Y}
                     first_time_only=no
                     [if]
                         [variable]

--- a/utils/chapter9_utils.cfg
+++ b/utils/chapter9_utils.cfg
@@ -390,7 +390,7 @@
 #ifdef EASY
                             {VARIABLE_OP spawn_type rand (Machine Oculus,Machine Vector,Machine Drone,Machine Oculus,Machine Vector,Machine Drone,Machine Sparkgazer,Machine Vorpal,Machine Welder)}
 #endif
-                            {GENERIC_UNIT {SIDE} $spawn_type {X} {Y}}
+                            {GENERIC_UNIT_PASSABLE {SIDE} $spawn_type {X} {Y}}
                             {CLEAR_VARIABLE spawn_type}
                         [/else]
                     [/if]
@@ -2048,7 +2048,7 @@
                         [/variable]
                         [then]
 #ifdef HARD
-                            {GENERIC_UNIT $infernal_portals[$i].side $spawn_type $infernal_portals[$i].x $infernal_portals[$i].y}
+                            {GENERIC_UNIT_PASSABLE $infernal_portals[$i].side $spawn_type $infernal_portals[$i].x $infernal_portals[$i].y}
 #endif
 #ifdef NORMAL
                             {VARIABLE_OP did_really_spawn rand (1,1,1,1,0)}
@@ -2058,7 +2058,7 @@
                                     equals=1
                                 [/variable]
                                 [then]
-                                    {GENERIC_UNIT $infernal_portals[$i].side $spawn_type $infernal_portals[$i].x $infernal_portals[$i].y}
+                                    {GENERIC_UNIT_PASSABLE $infernal_portals[$i].side $spawn_type $infernal_portals[$i].x $infernal_portals[$i].y}
                                 [/then]
                             [/if]
 #endif
@@ -2070,7 +2070,7 @@
                                     equals=1
                                 [/variable]
                                 [then]
-                                    {GENERIC_UNIT $infernal_portals[$i].side $spawn_type $infernal_portals[$i].x $infernal_portals[$i].y}
+                                    {GENERIC_UNIT_PASSABLE $infernal_portals[$i].side $spawn_type $infernal_portals[$i].x $infernal_portals[$i].y}
                                 [/then]
                             [/if]
 #endif

--- a/utils/utils.cfg
+++ b/utils/utils.cfg
@@ -1616,3 +1616,22 @@ $item_info.description"
         [/do]
     [/for]
 #enddef
+
+#define GENERIC_UNIT_PASSABLE SIDE TYPE X Y
+    # Copied from data/core/macros/unit-utils.cfg, with passable=yes added
+    # Creates a generic unit of TYPE belonging to SIDE at X,Y, which has a
+    # random name, gender and traits (just like a recruited unit).
+    #
+    [unit]
+        side={SIDE}
+        type={TYPE}
+        x={X}
+        y={Y}
+        generate_name=yes
+        random_traits=yes
+        random_gender=yes
+        upkeep=full
+        passable=yes
+    [/unit]
+#enddef
+


### PR DESCRIPTION
In Steelhive, only one portal was active.

All of the portal events had the same id.  

I included the side in the event id, which may be redundant, but I suppose multiple sides could have a portal at the same x,y?

Also, some portal/tombstones were spawning enemies in walls, where you could not hit them.  I only updated code to use this where I could test at the moment, I suspect it might be used elsewhere as well.