### PR TITLE
Logical encampment building

### DIFF
--- a/scenarios7/05_Tundra.cfg
+++ b/scenarios7/05_Tundra.cfg
@@ -359,6 +359,22 @@ You can build a keep anywhere for 50 gold (see options in the right-click menu).
                     name=can_build_encampment
                     equals=1
                 [/variable]
+                [have_unit]
+                    side=1
+                    [filter_location]
+                        x,y=$x1,$y1
+                        radius=1
+                    [/filter_location]
+                [/have_unit]
+                [not]
+                    [have_unit]
+                        formula="side_number > 1"
+                        [filter_location]
+                            x,y=$x1,$y1
+                            radius=1
+                        [/filter_location]
+                    [/have_unit]
+                [/not]
             [/show_if]
             [command]
                 [store_gold]

--- a/scenarios7/14_Arctic_Wastelands.cfg
+++ b/scenarios7/14_Arctic_Wastelands.cfg
@@ -477,6 +477,22 @@ You can build a keep anywhere for 50 gold, or a village for 10 gold. (see option
                     name=can_build_encampment
                     equals=1
                 [/variable]
+                [have_unit]
+                    side=1
+                    [filter_location]
+                        x,y=$x1,$y1
+                        radius=1
+                    [/filter_location]
+                [/have_unit]
+                [not]
+                    [have_unit]
+                        formula="side_number > 1"
+                        [filter_location]
+                            x,y=$x1,$y1
+                            radius=1
+                        [/filter_location]
+                    [/have_unit]
+                [/not]
             [/show_if]
             [filter_location]
                 [not]


### PR DESCRIPTION
At this time, the camp can be built anywhere on the map, even in fog and darkness on the other side of the map.
This is very prone to exploits, so I came up with a simple and logical way, which requires no change in the feature description.
You can simply build the camp if there are any friendly units but NO enemies inside the camp to be built.


https://github.com/Dugy/Legend_of_the_Invincibles/assets/40789364/2148a718-e850-4572-914e-c0ae6b5e8261

