### PR TITLE
remove FOREACH in chapter 9

### DIFF
--- a/scenarios9/38_Halls_of_Miscreation.cfg
+++ b/scenarios9/38_Halls_of_Miscreation.cfg
@@ -500,17 +500,7 @@
             speaker=Efraim
             message= _ "They are stalking around, surely trying to prey on those who separated themselves from the rest and can be swarmed. Gather around me, warriors!"
         [/message]
-        [store_unit]
-            [filter]
-                side=1
-            [/filter]
-            kill=no
-            variable=movement_store
-        [/store_unit]
-        {FOREACH movement_store i}
-            {MOVE_UNIT x,y=$movement_store[$i].x,$movement_store[$i].y 21 23}
-        {NEXT i}
-        {CLEAR_VARIABLE movement_store}
+        {MOVE_SIDE_TO 1 21 23}
         [unit]
             id=Romero
             x,y=28,31

--- a/scenarios9/40_Steelhive_Depths.cfg
+++ b/scenarios9/40_Steelhive_Depths.cfg
@@ -251,7 +251,9 @@
             variable=fabricators
             kill=no
         [/store_unit]
-        {FOREACH fabricators i}
+         [foreach]
+             array=fabricators
+             [do]
 #ifdef HARD
             {VARIABLE_OP spawn_type rand (Machine Oculus,Machine Vector,Machine Drone,Machine Sparkgazer,Machine Vorpal,Machine Welder)}
 #endif
@@ -261,8 +263,9 @@
 #ifdef EASY
             {VARIABLE_OP spawn_type rand (Machine Oculus,Machine Vector,Machine Drone,Machine Oculus,Machine Vector,Machine Drone,Machine Sparkgazer,Machine Vorpal,Machine Welder)}
 #endif
-            {GENERIC_UNIT 3 $spawn_type $fabricators[$i].x $fabricators[$i].y}
-        {NEXT i}
+            {GENERIC_UNIT 3 $spawn_type $this_item.x $this_item.y}
+        [/do]
+[/foreach]
         {CLEAR_VARIABLE fabricators,spawn_type}
     [/event]
     {DROPS 5 7 (axe,axe,staff,sword,sword,knife,bow,xbow,spear,spear,bow,dagger,mace) yes 2,3,4}

--- a/scenarios9/41_Heart_of_Steelhive.cfg
+++ b/scenarios9/41_Heart_of_Steelhive.cfg
@@ -306,18 +306,21 @@
             variable=fabricators
             kill=no
         [/store_unit]
-        {FOREACH fabricators i}
+        [foreach]
+            array=fabricators
+            [do]
 #ifdef HARD
-            {VARIABLE_OP spawn_type rand (Machine Oculus,Machine Vector,Machine Drone,Machine Sparkgazer,Machine Vorpal,Machine Welder)}
+                {VARIABLE_OP spawn_type rand (Machine Oculus,Machine Vector,Machine Drone,Machine Sparkgazer,Machine Vorpal,Machine Welder)}
 #endif
 #ifdef NORMAL
-            {VARIABLE_OP spawn_type rand (Machine Oculus,Machine Vector,Machine Drone,Machine Oculus,Machine Vector,Machine Drone,Machine Oculus,Machine Vector,Machine Drone,Machine Sparkgazer,Machine Vorpal,Machine Welder,Machine Sparkgazer,Machine Vorpal,Machine Welder)}
+                {VARIABLE_OP spawn_type rand (Machine Oculus,Machine Vector,Machine Drone,Machine Oculus,Machine Vector,Machine Drone,Machine Oculus,Machine Vector,Machine Drone,Machine Sparkgazer,Machine Vorpal,Machine Welder,Machine Sparkgazer,Machine Vorpal,Machine Welder)}
 #endif
 #ifdef EASY
-            {VARIABLE_OP spawn_type rand (Machine Oculus,Machine Vector,Machine Drone,Machine Oculus,Machine Vector,Machine Drone,Machine Sparkgazer,Machine Vorpal,Machine Welder)}
+                {VARIABLE_OP spawn_type rand (Machine Oculus,Machine Vector,Machine Drone,Machine Oculus,Machine Vector,Machine Drone,Machine Sparkgazer,Machine Vorpal,Machine Welder)}
 #endif
-            {GENERIC_UNIT 3 $spawn_type $fabricators[$i].x $fabricators[$i].y}
-        {NEXT i}
+                {GENERIC_UNIT 3 $spawn_type $this_item.x $this_item.y}
+            [/do]
+        [/foreach]
         {CLEAR_VARIABLE fabricators,spawn_type}
     [/event]
     [event]

--- a/scenarios9/44_Gathering_Alcove.cfg
+++ b/scenarios9/44_Gathering_Alcove.cfg
@@ -413,17 +413,7 @@
                         speaker=Lethalia
                         message= _ "It is a trap! Uria knew our destination, and prepared an army here! Assemble here, everyone, we do not want them to hunt us one by one."
                     [/message]
-                    [store_unit]
-                        [filter]
-                            side=1
-                        [/filter]
-                        kill=no
-                        variable=movement_store
-                    [/store_unit]
-                    {FOREACH movement_store i}
-                        {MOVE_UNIT x,y=$movement_store[$i].x,$movement_store[$i].y 33 23}
-                    {NEXT i}
-                    {CLEAR_VARIABLE movement_store}
+                    {MOVE_SIDE_TO 1 33 23}
                     [unit]
                         id=Romero
                         x,y=33,16

--- a/scenarios9/46_Sepulcher_of_the_Nefarious.cfg
+++ b/scenarios9/46_Sepulcher_of_the_Nefarious.cfg
@@ -481,17 +481,7 @@
                     speaker=Efraim
                     message= _ "Hiya! Anybody in there? Some unblessed soul that needs redeeming? I do not want to lock anybody in the world of the dead against his or her will. I can offer something better... hehe."
                 [/message]
-                [store_unit]
-                    [filter]
-                        side=1
-                    [/filter]
-                    kill=no
-                    variable=movement_store
-                [/store_unit]
-                {FOREACH movement_store i}
-                    {MOVE_UNIT x,y=$movement_store[$i].x,$movement_store[$i].y 23 37}
-                {NEXT i}
-                {CLEAR_VARIABLE movement_store}
+                {MOVE_SIDE_TO 1 23 37}
                 [message]
                     speaker=Efraim
                     message= _ "Klil thet tage mundum obscuro."

--- a/scenarios9/47_Basilica_of_Imperfection.cfg
+++ b/scenarios9/47_Basilica_of_Imperfection.cfg
@@ -551,17 +551,7 @@
             speaker=Lethalia
             message= _ "Wait... this was only a bait. Somebody wants to ambush us. We must amass here to stand together and protect each other, they surely want to kill our soldiers scattered around."
         [/message]
-        [store_unit]
-            [filter]
-                side=1
-            [/filter]
-            kill=no
-            variable=movement_store
-        [/store_unit]
-        {FOREACH movement_store i}
-            {MOVE_UNIT x,y=$movement_store[$i].x,$movement_store[$i].y 32 13}
-        {NEXT i}
-        {CLEAR_VARIABLE movement_store}
+        {MOVE_SIDE_TO 1 32 13}
         [unit]
             id=Romero
             x,y=33,21

--- a/scenarios9/50_The_Last_Crusade.cfg
+++ b/scenarios9/50_The_Last_Crusade.cfg
@@ -222,42 +222,54 @@
         terrain=Ql
         variable=to_transform
     [/store_locations]
-    {FOREACH to_transform i}
-        [terrain]
-            terrain={NAME}
-            x,y=$to_transform[$i].x,$to_transform[$i].y
-        [/terrain]
-    {NEXT i}
+    [for]
+        array=to_transform
+        [do]
+            [terrain]
+                terrain={NAME}
+                x,y=$to_transform[$i].x,$to_transform[$i].y
+            [/terrain]
+        [/do]
+    [/for]
     [store_locations]
         terrain=Ql^Bs/
         variable=to_transform
     [/store_locations]
-    {FOREACH to_transform i}
-        [terrain]
-            terrain={NAME}^Bs/
-            x,y=$to_transform[$i].x,$to_transform[$i].y
-        [/terrain]
-    {NEXT i}
+    [for]
+        array=to_transform
+        [do]
+            [terrain]
+                terrain={NAME}^Bs/
+                x,y=$to_transform[$i].x,$to_transform[$i].y
+            [/terrain]
+        [/do]
+    [/for]
     [store_locations]
         terrain=Ql^Bs|
         variable=to_transform
     [/store_locations]
-    {FOREACH to_transform i}
-        [terrain]
-            terrain={NAME}^Bs|
-            x,y=$to_transform[$i].x,$to_transform[$i].y
-        [/terrain]
-    {NEXT i}
+    [for]
+        array=to_transform
+        [do]
+            [terrain]
+                terrain={NAME}^Bs|
+                x,y=$to_transform[$i].x,$to_transform[$i].y
+            [/terrain]
+        [/do]
+    [/for]
     [store_locations]
         terrain=Ql^Bs\
         variable=to_transform
     [/store_locations]
-    {FOREACH to_transform i}
-        [terrain]
-            terrain={NAME}^Bs\
-            x,y=$to_transform[$i].x,$to_transform[$i].y
-        [/terrain]
-    {NEXT i}
+    [for]
+        array=to_transform
+        [do]
+            [terrain]
+                terrain={NAME}^Bs\
+                x,y=$to_transform[$i].x,$to_transform[$i].y
+            [/terrain]
+        [/do]
+    [/for]
 #enddef
         {VARIABLE_OP path rand (1..5)}
         [if]
@@ -297,42 +309,54 @@
                     terrain=Ql
                     variable=to_transform
                 [/store_locations]
-                {FOREACH to_transform i}
-                    [terrain]
-                        terrain=Urb
-                        x,y=$to_transform[$i].x,$to_transform[$i].y
-                    [/terrain]
-                {NEXT i}
+                [for]
+                    array=to_transform
+                    [do]
+                        [terrain]
+                            terrain=Urb
+                            x,y=$to_transform[$i].x,$to_transform[$i].y
+                        [/terrain]
+                    [/do]
+                [/for]
                 [store_locations]
                     terrain=Ql^Bs/
                     variable=to_transform
                 [/store_locations]
-                {FOREACH to_transform i}
-                    [terrain]
-                        terrain=Uu
-                        x,y=$to_transform[$i].x,$to_transform[$i].y
-                    [/terrain]
-                {NEXT i}
+                [for]
+                    array=to_transform
+                    [do]
+                        [terrain]
+                            terrain=Uu
+                            x,y=$to_transform[$i].x,$to_transform[$i].y
+                        [/terrain]
+                    [/do]
+                [/for]
                 [store_locations]
                     terrain=Ql^Bs|
                     variable=to_transform
                 [/store_locations]
-                {FOREACH to_transform i}
-                    [terrain]
-                        terrain=Uh
-                        x,y=$to_transform[$i].x,$to_transform[$i].y
-                    [/terrain]
-                {NEXT i}
+                [for]
+                    array=to_transform
+                    [do]
+                        [terrain]
+                            terrain=Uh
+                            x,y=$to_transform[$i].x,$to_transform[$i].y
+                        [/terrain]
+                    [/do]
+                [/for]
                 [store_locations]
                     terrain=Ql^Bs\
                     variable=to_transform
                 [/store_locations]
-                {FOREACH to_transform i}
-                    [terrain]
-                        terrain=Uu^Uf
-                        x,y=$to_transform[$i].x,$to_transform[$i].y
-                    [/terrain]
-                {NEXT i}
+                [for]
+                    array=to_transform
+                    [do]
+                        [terrain]
+                            terrain=Uu^Uf
+                            x,y=$to_transform[$i].x,$to_transform[$i].y
+                        [/terrain]
+                    [/do]
+                [/for]
             [/then]
         [/if]
 #undef CH9SC50_UNWALKABLE_TRANSFORMATION

--- a/utils/chapter9_utils.cfg
+++ b/utils/chapter9_utils.cfg
@@ -1708,377 +1708,380 @@
         name=portal_spawn
         id=portal_spawn
         first_time_only=no
-        {FOREACH infernal_portals i}
-            {VARIABLE do_spawn $turn_number}
-            {VARIABLE_OP do_spawn modulo $infernal_portals[$i].period}
-            [if]
-                [variable]
-                    name=do_spawn
-                    equals=1
-                [/variable]
-                [then]
-                    [if]
-                        [variable]
-                            name=demons_killed
-                            less_than=50
-                        [/variable]
-                        [then]
-                            {VARIABLE_OP spawn_type rand (Demon,Demon Warrior,Demon Manowar,Succubus,Hellhound,Shadow Hound)}
-                            {VARIABLE did_spawn 1}
-                        [/then]
-                    [/if]
-                    [if]
-                        [variable]
-                            name=demons_killed
-                            greater_than_equal_to=50
-                        [/variable]
-                        [and]
+        [foreach]
+            array=infernal_portals
+            [do]
+                {VARIABLE do_spawn $turn_number}
+                {VARIABLE_OP do_spawn modulo $this_item.period}
+                [if]
+                    [variable]
+                        name=do_spawn
+                        equals=1
+                    [/variable]
+                    [then]
+                        [if]
                             [variable]
                                 name=demons_killed
-                                less_than=100
+                                less_than=50
                             [/variable]
-                        [/and]
-                        [then]
-                            {VARIABLE_OP spawn_type rand (Demon,Demon,Demon Warrior,Demon Manowar,Succubus,Hellhound,Shadow Hound)}
-                            {VARIABLE_OP did_spawn rand (1,1,1,1,1,1,1,1,1,1,1,0)}
-                        [/then]
-                    [/if]
-                    [if]
-                        [variable]
-                            name=demons_killed
-                            greater_than_equal_to=100
-                        [/variable]
-                        [and]
+                            [then]
+                                {VARIABLE_OP spawn_type rand (Demon,Demon Warrior,Demon Manowar,Succubus,Hellhound,Shadow Hound)}
+                                {VARIABLE did_spawn 1}
+                            [/then]
+                        [/if]
+                        [if]
                             [variable]
                                 name=demons_killed
-                                less_than=200
+                                greater_than_equal_to=50
                             [/variable]
-                        [/and]
-                        [then]
-                            {VARIABLE_OP spawn_type rand (Demon,Demon,Demon Warrior,Demon Warrior,Demon Manowar,Succubus,Hellhound,Shadow Hound)}
-                            {VARIABLE_OP did_spawn rand (1,1,1,1,1,1,1,1,1,0)}
-                        [/then]
-                    [/if]
-                    [if]
-                        [variable]
-                            name=demons_killed
-                            greater_than_equal_to=200
-                        [/variable]
-                        [and]
+                            [and]
+                                [variable]
+                                    name=demons_killed
+                                    less_than=100
+                                [/variable]
+                            [/and]
+                            [then]
+                                {VARIABLE_OP spawn_type rand (Demon,Demon,Demon Warrior,Demon Manowar,Succubus,Hellhound,Shadow Hound)}
+                                {VARIABLE_OP did_spawn rand (1,1,1,1,1,1,1,1,1,1,1,0)}
+                            [/then]
+                        [/if]
+                        [if]
                             [variable]
                                 name=demons_killed
-                                less_than=300
+                                greater_than_equal_to=100
                             [/variable]
-                        [/and]
-                        [then]
-                            {VARIABLE_OP spawn_type rand (Demon,Demon,Demon,Demon Warrior,Demon Warrior,Demon Manowar,Succubus,Hellhound,Shadow Hound)}
-                            {VARIABLE_OP did_spawn rand (1,1,1,1,1,1,1,1,0)}
-                        [/then]
-                    [/if]
-                    [if]
-                        [variable]
-                            name=demons_killed
-                            greater_than_equal_to=400
-                        [/variable]
-                        [and]
+                            [and]
+                                [variable]
+                                    name=demons_killed
+                                    less_than=200
+                                [/variable]
+                            [/and]
+                            [then]
+                                {VARIABLE_OP spawn_type rand (Demon,Demon,Demon Warrior,Demon Warrior,Demon Manowar,Succubus,Hellhound,Shadow Hound)}
+                                {VARIABLE_OP did_spawn rand (1,1,1,1,1,1,1,1,1,0)}
+                            [/then]
+                        [/if]
+                        [if]
                             [variable]
                                 name=demons_killed
-                                less_than=400
+                                greater_than_equal_to=200
                             [/variable]
-                        [/and]
-                        [then]
-                            {VARIABLE_OP spawn_type rand (Demon,Demon,Demon,Demon,Demon Warrior,Demon Warrior,Demon Warrior,Demon Manowar,Succubus,Hellhound,Hellhound,Shadow Hound)}
-                            {VARIABLE_OP did_spawn rand (1,1,1,1,1,1,1,0)}
-                        [/then]
-                    [/if]
-                    [if]
-                        [variable]
-                            name=demons_killed
-                            greater_than_equal_to=400
-                        [/variable]
-                        [and]
+                            [and]
+                                [variable]
+                                    name=demons_killed
+                                    less_than=300
+                                [/variable]
+                            [/and]
+                            [then]
+                                {VARIABLE_OP spawn_type rand (Demon,Demon,Demon,Demon Warrior,Demon Warrior,Demon Manowar,Succubus,Hellhound,Shadow Hound)}
+                                {VARIABLE_OP did_spawn rand (1,1,1,1,1,1,1,1,0)}
+                            [/then]
+                        [/if]
+                        [if]
                             [variable]
                                 name=demons_killed
-                                less_than=500
+                                greater_than_equal_to=400
                             [/variable]
-                        [/and]
-                        [then]
-                            {VARIABLE_OP spawn_type rand (Demon,Demon,Demon,Demon,Demon Warrior,Demon Warrior,Demon Warrior,Demon Manowar,Demon Manowar,Hellhound,Hellhound,Shadow Hound)}
-                            {VARIABLE_OP did_spawn rand (1,1,1,1,1,1,1,0)}
-                        [/then]
-                    [/if]
-                    [if]
-                        [variable]
-                            name=demons_killed
-                            greater_than_equal_to=500
-                        [/variable]
-                        [and]
+                            [and]
+                                [variable]
+                                    name=demons_killed
+                                    less_than=400
+                                [/variable]
+                            [/and]
+                            [then]
+                                {VARIABLE_OP spawn_type rand (Demon,Demon,Demon,Demon,Demon Warrior,Demon Warrior,Demon Warrior,Demon Manowar,Succubus,Hellhound,Hellhound,Shadow Hound)}
+                                {VARIABLE_OP did_spawn rand (1,1,1,1,1,1,1,0)}
+                            [/then]
+                        [/if]
+                        [if]
                             [variable]
                                 name=demons_killed
-                                less_than=600
+                                greater_than_equal_to=400
                             [/variable]
-                        [/and]
-                        [then]
-                            {VARIABLE_OP spawn_type rand (Demon,Demon,Demon,Demon,Demon,Demon Warrior,Demon Warrior,Demon Warrior,Demon Warrior,Demon Manowar,Demon Manowar,Hellhound,Hellhound,Shadow Hound)}
-                            {VARIABLE_OP did_spawn rand (1,1,1,1,1,1,0)}
-                        [/then]
-                    [/if]
-                    [if]
-                        [variable]
-                            name=demons_killed
-                            greater_than_equal_to=600
-                        [/variable]
-                        [and]
+                            [and]
+                                [variable]
+                                    name=demons_killed
+                                    less_than=500
+                                [/variable]
+                            [/and]
+                            [then]
+                                {VARIABLE_OP spawn_type rand (Demon,Demon,Demon,Demon,Demon Warrior,Demon Warrior,Demon Warrior,Demon Manowar,Demon Manowar,Hellhound,Hellhound,Shadow Hound)}
+                                {VARIABLE_OP did_spawn rand (1,1,1,1,1,1,1,0)}
+                            [/then]
+                        [/if]
+                        [if]
                             [variable]
                                 name=demons_killed
-                                less_than=700
+                                greater_than_equal_to=500
                             [/variable]
-                        [/and]
-                        [then]
-                            {VARIABLE_OP spawn_type rand (Demon,Demon,Demon,Demon,Demon,Demon Warrior,Demon Warrior,Demon Warrior,Demon Warrior,Demon Manowar,Hellhound,Hellhound)}
-                            {VARIABLE_OP did_spawn rand (1,1,1,1,1,0)}
-                        [/then]
-                    [/if]
-                    [if]
-                        [variable]
-                            name=demons_killed
-                            greater_than_equal_to=700
-                        [/variable]
-                        [and]
+                            [and]
+                                [variable]
+                                    name=demons_killed
+                                    less_than=600
+                                [/variable]
+                            [/and]
+                            [then]
+                                {VARIABLE_OP spawn_type rand (Demon,Demon,Demon,Demon,Demon,Demon Warrior,Demon Warrior,Demon Warrior,Demon Warrior,Demon Manowar,Demon Manowar,Hellhound,Hellhound,Shadow Hound)}
+                                {VARIABLE_OP did_spawn rand (1,1,1,1,1,1,0)}
+                            [/then]
+                        [/if]
+                        [if]
                             [variable]
                                 name=demons_killed
-                                less_than=800
+                                greater_than_equal_to=600
                             [/variable]
-                        [/and]
-                        [then]
-                            {VARIABLE_OP spawn_type rand (Demon,Demon,Demon,Demon,Demon,Demon,Demon Warrior,Demon Warrior,Demon Warrior,Demon Warrior,Demon Manowar,Hellhound,Hellhound)}
-                            {VARIABLE_OP did_spawn rand (1,1,1,1,0)}
-                        [/then]
-                    [/if]
-                    [if]
-                        [variable]
-                            name=demons_killed
-                            greater_than_equal_to=800
-                        [/variable]
-                        [and]
+                            [and]
+                                [variable]
+                                    name=demons_killed
+                                    less_than=700
+                                [/variable]
+                            [/and]
+                            [then]
+                                {VARIABLE_OP spawn_type rand (Demon,Demon,Demon,Demon,Demon,Demon Warrior,Demon Warrior,Demon Warrior,Demon Warrior,Demon Manowar,Hellhound,Hellhound)}
+                                {VARIABLE_OP did_spawn rand (1,1,1,1,1,0)}
+                            [/then]
+                        [/if]
+                        [if]
                             [variable]
                                 name=demons_killed
-                                less_than=900
+                                greater_than_equal_to=700
                             [/variable]
-                        [/and]
-                        [then]
-                            {VARIABLE_OP spawn_type rand (Imp,Demon,Demon,Demon,Demon,Demon,Demon,Demon Warrior,Demon Warrior,Demon Warrior,Demon Warrior,Demon Manowar,Hellhound,Hellhound)}
-                            {VARIABLE_OP did_spawn rand (1,1,1,0)}
-                        [/then]
-                    [/if]
-                    [if]
-                        [variable]
-                            name=demons_killed
-                            greater_than_equal_to=900
-                        [/variable]
-                        [and]
+                            [and]
+                                [variable]
+                                    name=demons_killed
+                                    less_than=800
+                                [/variable]
+                            [/and]
+                            [then]
+                                {VARIABLE_OP spawn_type rand (Demon,Demon,Demon,Demon,Demon,Demon,Demon Warrior,Demon Warrior,Demon Warrior,Demon Warrior,Demon Manowar,Hellhound,Hellhound)}
+                                {VARIABLE_OP did_spawn rand (1,1,1,1,0)}
+                            [/then]
+                        [/if]
+                        [if]
                             [variable]
                                 name=demons_killed
-                                less_than=1000
+                                greater_than_equal_to=800
                             [/variable]
-                        [/and]
-                        [then]
-                            {VARIABLE_OP spawn_type rand (Imp,Imp,Demon,Demon,Demon,Demon,Demon,Demon,Demon Warrior,Demon Warrior,Demon Warrior,Demon Warrior,Hellhound,Hellhound)}
-                            {VARIABLE_OP did_spawn rand (1,1,0)}
-                        [/then]
-                    [/if]
-                    [if]
-                        [variable]
-                            name=demons_killed
-                            greater_than_equal_to=1000
-                        [/variable]
-                        [and]
+                            [and]
+                                [variable]
+                                    name=demons_killed
+                                    less_than=900
+                                [/variable]
+                            [/and]
+                            [then]
+                                {VARIABLE_OP spawn_type rand (Imp,Demon,Demon,Demon,Demon,Demon,Demon,Demon Warrior,Demon Warrior,Demon Warrior,Demon Warrior,Demon Manowar,Hellhound,Hellhound)}
+                                {VARIABLE_OP did_spawn rand (1,1,1,0)}
+                            [/then]
+                        [/if]
+                        [if]
                             [variable]
                                 name=demons_killed
-                                less_than=1100
+                                greater_than_equal_to=900
                             [/variable]
-                        [/and]
-                        [then]
-                            {VARIABLE_OP spawn_type rand (Imp,Imp,Imp,Demon,Demon,Demon,Demon,Demon,Demon,Demon Warrior,Demon Warrior,Demon Warrior,Hellhound,Hellhound)}
-                            {VARIABLE_OP did_spawn rand (1,1,1,0,0)}
-                        [/then]
-                    [/if]
-                    [if]
-                        [variable]
-                            name=demons_killed
-                            greater_than_equal_to=1100
-                        [/variable]
-                        [and]
+                            [and]
+                                [variable]
+                                    name=demons_killed
+                                    less_than=1000
+                                [/variable]
+                            [/and]
+                            [then]
+                                {VARIABLE_OP spawn_type rand (Imp,Imp,Demon,Demon,Demon,Demon,Demon,Demon,Demon Warrior,Demon Warrior,Demon Warrior,Demon Warrior,Hellhound,Hellhound)}
+                                {VARIABLE_OP did_spawn rand (1,1,0)}
+                            [/then]
+                        [/if]
+                        [if]
                             [variable]
                                 name=demons_killed
-                                less_than=1200
+                                greater_than_equal_to=1000
                             [/variable]
-                        [/and]
-                        [then]
-                            {VARIABLE_OP spawn_type rand (Imp,Imp,Imp,Imp,Demon,Demon,Demon,Demon,Demon,Demon,Demon Warrior,Demon Warrior,Demon Warrior,Hellhound,Hellhound)}
-                            {VARIABLE_OP did_spawn rand (1,1,0,0,0)}
-                        [/then]
-                    [/if]
-                    [if]
-                        [variable]
-                            name=demons_killed
-                            greater_than_equal_to=1100
-                        [/variable]
-                        [and]
+                            [and]
+                                [variable]
+                                    name=demons_killed
+                                    less_than=1100
+                                [/variable]
+                            [/and]
+                            [then]
+                                {VARIABLE_OP spawn_type rand (Imp,Imp,Imp,Demon,Demon,Demon,Demon,Demon,Demon,Demon Warrior,Demon Warrior,Demon Warrior,Hellhound,Hellhound)}
+                                {VARIABLE_OP did_spawn rand (1,1,1,0,0)}
+                            [/then]
+                        [/if]
+                        [if]
                             [variable]
                                 name=demons_killed
-                                less_than=1200
+                                greater_than_equal_to=1100
                             [/variable]
-                        [/and]
-                        [then]
-                            {VARIABLE_OP spawn_type rand (Imp,Imp,Imp,Imp,Demon,Demon,Demon,Demon,Demon,Demon,Demon Warrior,Demon Warrior,Hellhound)}
-                            {VARIABLE_OP did_spawn rand (1,0,0)}
-                        [/then]
-                    [/if]
-                    [if]
-                        [variable]
-                            name=demons_killed
-                            greater_than_equal_to=1200
-                        [/variable]
-                        [and]
+                            [and]
+                                [variable]
+                                    name=demons_killed
+                                    less_than=1200
+                                [/variable]
+                            [/and]
+                            [then]
+                                {VARIABLE_OP spawn_type rand (Imp,Imp,Imp,Imp,Demon,Demon,Demon,Demon,Demon,Demon,Demon Warrior,Demon Warrior,Demon Warrior,Hellhound,Hellhound)}
+                                {VARIABLE_OP did_spawn rand (1,1,0,0,0)}
+                            [/then]
+                        [/if]
+                        [if]
                             [variable]
                                 name=demons_killed
-                                less_than=1300
+                                greater_than_equal_to=1100
                             [/variable]
-                        [/and]
-                        [then]
-                            {VARIABLE_OP spawn_type rand (Imp,Imp,Imp,Imp,Imp,Demon,Demon,Demon,Demon,Demon,Demon Warrior,Hellhound)}
-                            {VARIABLE_OP did_spawn rand (1,0,0,0)}
-                        [/then]
-                    [/if]
-                    [if]
-                        [variable]
-                            name=demons_killed
-                            greater_than_equal_to=1300
-                        [/variable]
-                        [and]
+                            [and]
+                                [variable]
+                                    name=demons_killed
+                                    less_than=1200
+                                [/variable]
+                            [/and]
+                            [then]
+                                {VARIABLE_OP spawn_type rand (Imp,Imp,Imp,Imp,Demon,Demon,Demon,Demon,Demon,Demon,Demon Warrior,Demon Warrior,Hellhound)}
+                                {VARIABLE_OP did_spawn rand (1,0,0)}
+                            [/then]
+                        [/if]
+                        [if]
                             [variable]
                                 name=demons_killed
-                                less_than=1400
+                                greater_than_equal_to=1200
                             [/variable]
-                        [/and]
-                        [then]
-                            {VARIABLE_OP spawn_type rand (Imp,Imp,Imp,Imp,Imp,Imp,Demon,Demon,Demon,Demon,Hellhound)}
-                            {VARIABLE_OP did_spawn rand (1,0,0,0,0)}
-                        [/then]
-                    [/if]
-                    [if]
-                        [variable]
-                            name=demons_killed
-                            greater_than_equal_to=1400
-                        [/variable]
-                        [and]
+                            [and]
+                                [variable]
+                                    name=demons_killed
+                                    less_than=1300
+                                [/variable]
+                            [/and]
+                            [then]
+                                {VARIABLE_OP spawn_type rand (Imp,Imp,Imp,Imp,Imp,Demon,Demon,Demon,Demon,Demon,Demon Warrior,Hellhound)}
+                                {VARIABLE_OP did_spawn rand (1,0,0,0)}
+                            [/then]
+                        [/if]
+                        [if]
                             [variable]
                                 name=demons_killed
-                                less_than=1500
+                                greater_than_equal_to=1300
                             [/variable]
-                        [/and]
-                        [then]
-                            {VARIABLE_OP spawn_type rand (Imp,Imp,Imp,Imp,Imp,Imp,Imp,Demon,Demon,Demon,Hellhound)}
-                            {VARIABLE_OP did_spawn rand (1,0,0,0,0,0)}
-                        [/then]
-                    [/if]
-                    [if]
-                        [variable]
-                            name=demons_killed
-                            greater_than_equal_to=1500
-                        [/variable]
-                        [and]
+                            [and]
+                                [variable]
+                                    name=demons_killed
+                                    less_than=1400
+                                [/variable]
+                            [/and]
+                            [then]
+                                {VARIABLE_OP spawn_type rand (Imp,Imp,Imp,Imp,Imp,Imp,Demon,Demon,Demon,Demon,Hellhound)}
+                                {VARIABLE_OP did_spawn rand (1,0,0,0,0)}
+                            [/then]
+                        [/if]
+                        [if]
                             [variable]
                                 name=demons_killed
-                                less_than=1700
+                                greater_than_equal_to=1400
                             [/variable]
-                        [/and]
-                        [then]
-                            {VARIABLE_OP spawn_type rand (Imp,Imp,Demon)}
-                            {VARIABLE_OP did_spawn rand (1,0,0,0,0,0,0)}
-                        [/then]
-                    [/if]
-                    [if]
-                        [variable]
-                            name=demons_killed
-                            greater_than_equal_to=1700
-                        [/variable]
-                        [and]
+                            [and]
+                                [variable]
+                                    name=demons_killed
+                                    less_than=1500
+                                [/variable]
+                            [/and]
+                            [then]
+                                {VARIABLE_OP spawn_type rand (Imp,Imp,Imp,Imp,Imp,Imp,Imp,Demon,Demon,Demon,Hellhound)}
+                                {VARIABLE_OP did_spawn rand (1,0,0,0,0,0)}
+                            [/then]
+                        [/if]
+                        [if]
                             [variable]
                                 name=demons_killed
-                                less_than=1850
+                                greater_than_equal_to=1500
                             [/variable]
-                        [/and]
-                        [then]
-                            {VARIABLE_OP spawn_type rand (Imp,Imp,Imp,Demon)}
-                            {VARIABLE_OP did_spawn rand (1,0,0,0,0,0,0,0)}
-                        [/then]
-                    [/if]
-                    [if]
-                        [variable]
-                            name=demons_killed
-                            greater_than_equal_to=1850
-                        [/variable]
-                        [and]
+                            [and]
+                                [variable]
+                                    name=demons_killed
+                                    less_than=1700
+                                [/variable]
+                            [/and]
+                            [then]
+                                {VARIABLE_OP spawn_type rand (Imp,Imp,Demon)}
+                                {VARIABLE_OP did_spawn rand (1,0,0,0,0,0,0)}
+                            [/then]
+                        [/if]
+                        [if]
                             [variable]
                                 name=demons_killed
-                                less_than=2000
+                                greater_than_equal_to=1700
                             [/variable]
-                        [/and]
-                        [then]
-                            {VARIABLE spawn_type Imp}
-                            {VARIABLE_OP did_spawn rand (1,0,0,0,0,0,0,0,0)}
-                        [/then]
-                    [/if]
-                    [if]
-                        [variable]
-                            name=demons_killed
-                            greater_than_equal_to=2000
-                        [/variable]
-                        [then]
-                            {VARIABLE spawn_type Imp}
-                            {VARIABLE did_spawn 0}
-                        [/then]
-                    [/if]
-                    [if]
-                        [variable]
-                            name=did_spawn
-                            equals=1
-                        [/variable]
-                        [then]
+                            [and]
+                                [variable]
+                                    name=demons_killed
+                                    less_than=1850
+                                [/variable]
+                            [/and]
+                            [then]
+                                {VARIABLE_OP spawn_type rand (Imp,Imp,Imp,Demon)}
+                                {VARIABLE_OP did_spawn rand (1,0,0,0,0,0,0,0)}
+                            [/then]
+                        [/if]
+                        [if]
+                            [variable]
+                                name=demons_killed
+                                greater_than_equal_to=1850
+                            [/variable]
+                            [and]
+                                [variable]
+                                    name=demons_killed
+                                    less_than=2000
+                                [/variable]
+                            [/and]
+                            [then]
+                                {VARIABLE spawn_type Imp}
+                                {VARIABLE_OP did_spawn rand (1,0,0,0,0,0,0,0,0)}
+                            [/then]
+                        [/if]
+                        [if]
+                            [variable]
+                                name=demons_killed
+                                greater_than_equal_to=2000
+                            [/variable]
+                            [then]
+                                {VARIABLE spawn_type Imp}
+                                {VARIABLE did_spawn 0}
+                            [/then]
+                        [/if]
+                        [if]
+                            [variable]
+                                name=did_spawn
+                                equals=1
+                            [/variable]
+                            [then]
 #ifdef HARD
-                            {GENERIC_UNIT_PASSABLE $infernal_portals[$i].side $spawn_type $infernal_portals[$i].x $infernal_portals[$i].y}
+                                {GENERIC_UNIT_PASSABLE $this_item.side $spawn_type $this_item.x $this_item.y}
 #endif
 #ifdef NORMAL
-                            {VARIABLE_OP did_really_spawn rand (1,1,1,1,0)}
-                            [if]
-                                [variable]
-                                    name=did_really_spawn
-                                    equals=1
-                                [/variable]
-                                [then]
-                                    {GENERIC_UNIT_PASSABLE $infernal_portals[$i].side $spawn_type $infernal_portals[$i].x $infernal_portals[$i].y}
-                                [/then]
-                            [/if]
+                                {VARIABLE_OP did_really_spawn rand (1,1,1,1,0)}
+                                [if]
+                                    [variable]
+                                        name=did_really_spawn
+                                        equals=1
+                                    [/variable]
+                                    [then]
+                                        {GENERIC_UNIT_PASSABLE $this_item.side $spawn_type $this_item.x $this_item.y}
+                                    [/then]
+                                [/if]
 #endif
 #ifdef EASY
-                            {VARIABLE_OP did_really_spawn rand (1,1,0)}
-                            [if]
-                                [variable]
-                                    name=did_really_spawn
-                                    equals=1
-                                [/variable]
-                                [then]
-                                    {GENERIC_UNIT_PASSABLE $infernal_portals[$i].side $spawn_type $infernal_portals[$i].x $infernal_portals[$i].y}
-                                [/then]
-                            [/if]
+                                {VARIABLE_OP did_really_spawn rand (1,1,0)}
+                                [if]
+                                    [variable]
+                                        name=did_really_spawn
+                                        equals=1
+                                    [/variable]
+                                    [then]
+                                        {GENERIC_UNIT_PASSABLE $this_item.side $spawn_type $this_item.x $this_item.y}
+                                    [/then]
+                                [/if]
 #endif
-                        [/then]
-                    [/if]
-                [/then]
-            [/if]
-        {NEXT i}
+                            [/then]
+                        [/if]
+                    [/then]
+                [/if]
+            [/do]
+        [/foreach]
         {CLEAR_VARIABLE do_spawn}
         {CLEAR_VARIABLE did_spawn}
         {CLEAR_VARIABLE did_really_spawn}
@@ -7591,23 +7594,27 @@ The map can be viewed through the right-click menu."}
                 {VARIABLE_OP rand modulo $rain_good.length}
 
                 {VARIABLE already no}
-                {FOREACH blood_rain i}
-                    [if]
-                        [variable]
-                            name=blood_rain[$i].x
-                            equals=$rain_good[$rand].x
-                        [/variable]
-                        [and]
+                [for]
+                    array=blood_rain
+                    [do]
+                        [if]
                             [variable]
-                                name=blood_rain[$i].y
-                                equals=$rain_good[$rand].y
+                                name=blood_rain[$i].x
+                                equals=$rain_good[$rand].x
                             [/variable]
-                        [/and]
-                        [then]
-                            {VARIABLE already yes}
-                        [/then]
-                    [/if]
-                {NEXT i}
+                            [and]
+                                [variable]
+                                    name=blood_rain[$i].y
+                                    equals=$rain_good[$rand].y
+                                [/variable]
+                            [/and]
+                            [then]
+                                {VARIABLE already yes}
+                                [break][/break]
+                            [/then]
+                        [/if]
+                    [/do]
+                [/for]
                 [if]
                     [variable]
                         name=already
@@ -7636,41 +7643,49 @@ The map can be viewed through the right-click menu."}
             [/do]
         [/while]
         {CLEAR_VARIABLE map_size,already,rain_good}
-        {FOREACH blood_rain i}
-            [store_unit]
-                [filter]
-                    [filter_location]
-                        x,y=$blood_rain[$i].x,$blood_rain[$i].y
-                        radius=1
-                    [/filter_location]
-                    side=1
-                [/filter]
-                variable=rained
-                kill=no
-            [/store_unit]
-            {FOREACH rained j}
-                [fire_event]
-                    name=dooming lethargy
-                    [primary_unit]
-                        find_in=rained[$j]
-                    [/primary_unit]
-                [/fire_event]
-                [harm_unit]
+        [for]
+            array=blood_rain
+            variable=i
+            [do]
+                [store_unit]
                     [filter]
-                        find_in=rained[$j]
+                        [filter_location]
+                            x,y=$blood_rain[$i].x,$blood_rain[$i].y
+                            radius=1
+                        [/filter_location]
+                        side=1
                     [/filter]
-                    amount=8
+                    variable=rained
                     kill=no
-                    animate=yes
-                [/harm_unit]
-                [fire_event]
-                    name=raining blood
-                    [primary_unit]
-                        find_in=rained[$j]
-                    [/primary_unit]
-                [/fire_event]
-            {NEXT j}
-        {NEXT i}
+                [/store_unit]
+                [for]
+                    array=rained
+                    variable=j
+                    [do]
+                        [fire_event]
+                            name=dooming lethargy
+                            [primary_unit]
+                                find_in=rained[$j]
+                            [/primary_unit]
+                        [/fire_event]
+                        [harm_unit]
+                            [filter]
+                                find_in=rained[$j]
+                            [/filter]
+                            amount=8
+                            kill=no
+                            animate=yes
+                        [/harm_unit]
+                        [fire_event]
+                            name=raining blood
+                            [primary_unit]
+                                find_in=rained[$j]
+                            [/primary_unit]
+                        [/fire_event]
+                    [/do]
+                [/for]
+            [/do]
+        [/for]
         {CLEAR_VARIABLE rained}
     [/event]
 
@@ -7690,13 +7705,16 @@ The map can be viewed through the right-click menu."}
                     variable=on_weird
                     kill=no
                 [/store_unit]
-                {FOREACH on_weird i}
-                    {VARIABLE_OP on_weird[$i].moves sub 2}
-                    [unstore_unit]
-                        variable=on_weird[$i]
-                        find_vacant=no
-                    [/unstore_unit]
-                {NEXT i}
+                [foreach]
+                    array=on_weird
+                    [do]
+                        {VARIABLE_OP this_item.moves sub 2}
+                        [unstore_unit]
+                            variable=this_item
+                            find_vacant=no
+                        [/unstore_unit]
+                    [/do]
+                [/foreach]
                 [store_unit]
                     [filter]
                         side=1
@@ -7707,18 +7725,21 @@ The map can be viewed through the right-click menu."}
                     variable=on_weird
                     kill=no
                 [/store_unit]
-                {FOREACH on_weird i}
-                    [harm_unit]
-                        [filter]
-                            id=$on_weird[$i].id
-                        [/filter]
-                        amount=4
-                        damage_type=impact
-                        fire_event=yes
-                        experience=no
-                        slowed=yes
-                    [/harm_unit]
-                {NEXT i}
+                [foreach]
+                    array=on_weird
+                    [do]
+                        [harm_unit]
+                            [filter]
+                                id=$this_item.id
+                            [/filter]
+                            amount=4
+                            damage_type=impact
+                            fire_event=yes
+                            experience=no
+                            slowed=yes
+                        [/harm_unit]
+                    [/do]
+                [/foreach]
                 [store_unit]
                     [filter]
                         side=1
@@ -7729,18 +7750,21 @@ The map can be viewed through the right-click menu."}
                     variable=on_weird
                     kill=no
                 [/store_unit]
-                {FOREACH on_weird i}
-                    [harm_unit]
-                        [filter]
-                            id=$on_weird[$i].id
-                        [/filter]
-                        amount=16
-                        damage_type=impact
-                        fire_event=yes
-                        experience=no
-                        slowed=yes
-                    [/harm_unit]
-                {NEXT i}
+                [foreach]
+                    array=on_weird
+                    [do]
+                        [harm_unit]
+                            [filter]
+                                id=$this_item.id
+                            [/filter]
+                            amount=16
+                            damage_type=impact
+                            fire_event=yes
+                            experience=no
+                            slowed=yes
+                        [/harm_unit]
+                    [/do]
+                [/foreach]
                 [store_unit]
                     [filter]
                         side=1
@@ -7751,17 +7775,20 @@ The map can be viewed through the right-click menu."}
                     variable=on_weird
                     kill=no
                 [/store_unit]
-                {FOREACH on_weird i}
-                    [harm_unit]
-                        [filter]
-                            id=$on_weird[$i].id
-                        [/filter]
-                        amount=24
-                        damage_type=impact
-                        fire_event=yes
-                        experience=no
-                    [/harm_unit]
-                {NEXT i}
+                [foreach]
+                    array=on_weird
+                    [do]
+                        [harm_unit]
+                            [filter]
+                                id=$this_item.id
+                            [/filter]
+                            amount=24
+                            damage_type=impact
+                            fire_event=yes
+                            experience=no
+                        [/harm_unit]
+                    [/do]
+                [/foreach]
                 [store_unit]
                     [filter]
                         side=1
@@ -7772,17 +7799,20 @@ The map can be viewed through the right-click menu."}
                     variable=on_weird
                     kill=no
                 [/store_unit]
-                {FOREACH on_weird i}
-                    [harm_unit]
-                        [filter]
-                            id=$on_weird[$i].id
-                        [/filter]
-                        amount=40
-                        damage_type=impact
-                        fire_event=yes
-                        experience=no
-                    [/harm_unit]
-                {NEXT i}
+                [foreach]
+                    array=on_weird
+                    [do]
+                        [harm_unit]
+                            [filter]
+                                id=$this_item.id
+                            [/filter]
+                            amount=40
+                            damage_type=impact
+                            fire_event=yes
+                            experience=no
+                        [/harm_unit]
+                    [/do]
+                [/foreach]
                 {CLEAR_VARIABLE on_weird}
             [/then]
         [/if]
@@ -7812,17 +7842,20 @@ The map can be viewed through the right-click menu."}
             terrain=*^Ziff
             variable=to_grow
         [/store_locations]
-        {FOREACH to_grow i}
-            {VARIABLE_OP spawn_type rand {TYPES}}
-            {VARIABLE_OP spawn_side rand {SIDES}}
-            [unit]
-                type=$spawn_type
-                x,y=$to_grow[$i].x,$to_grow[$i].y
-                ai_special=guardian
-                random_traits=yes
-                side=$spawn_side
-            [/unit]
-        {NEXT i}
+        [foreach]
+            array=to_grow
+            [do]
+                {VARIABLE_OP spawn_type rand {TYPES}}
+                {VARIABLE_OP spawn_side rand {SIDES}}
+                [unit]
+                    type=$spawn_type
+                    x,y=$this_item.x,$this_item.y
+                    ai_special=guardian
+                    random_traits=yes
+                    side=$spawn_side
+                [/unit]
+            [/do]
+        [/foreach]
         {CLEAR_VARIABLE to_grow,spawn_type,spawn_side}
     [/event]
 #enddef
@@ -7913,9 +7946,12 @@ The map can be viewed through the right-click menu."}
             [/not]
             variable=graves
         [/store_locations]
-        {FOREACH graves i}
-            {GENERIC_UNIT {SIDE} "Demon Soul" $graves[$i].x $graves[$i].y}
-        {NEXT i}
+        [foreach]
+            array=graves
+            [do]
+                {GENERIC_UNIT {SIDE} "Demon Soul" $this_item.x $this_item.y}
+            [/do]
+        [/foreach]
         {CLEAR_VARIABLE graves}
     [/event]
     [event]
@@ -7962,29 +7998,32 @@ The map can be viewed through the right-click menu."}
             [/filter_adjacent_location]
             variable=near_void
         [/store_locations]
-        {FOREACH near_void i}
-            {VARIABLE_OP do_expand rand (yes,no,no)}
-            [if]
-                [variable]
-                    name=do_expand
-                    equals=yes
-                [/variable]
-                [then]
-                    [terrain]
-                        x,y=$near_void[$i].x,$near_void[$i].y
-                        terrain=Xv
-                    [/terrain]
-                    [harm_unit]
-                        [filter]
-                            x,y=$near_void[$i].x,$near_void[$i].y
-                        [/filter]
-                        amount=32
-                        damage_type=arcane
-                        kill=yes
-                    [/harm_unit]
-                [/then]
-            [/if]
-        {NEXT i}
+        [foreach]
+            array=near_void
+            [do]
+                {VARIABLE_OP do_expand rand (yes,no,no)}
+                [if]
+                    [variable]
+                        name=do_expand
+                        equals=yes
+                    [/variable]
+                    [then]
+                        [terrain]
+                            x,y=$this_item.x,$this_item.y
+                            terrain=Xv
+                        [/terrain]
+                        [harm_unit]
+                            [filter]
+                                x,y=$this_item.x,$this_item.y
+                            [/filter]
+                            amount=32
+                            damage_type=arcane
+                            kill=yes
+                        [/harm_unit]
+                    [/then]
+                [/if]
+            [/do]
+        [/foreach]
         [store_locations]
             [not]
                 terrain=Xv
@@ -7995,39 +8034,42 @@ The map can be viewed through the right-click menu."}
             [/filter_adjacent_location]
             variable=near_void
         [/store_locations]
-        {FOREACH near_void i}
-            [terrain]
-                x,y=$near_void[$i].x,$near_void[$i].y
-                terrain=Xv
-            [/terrain]
-            [harm_unit]
-                [filter]
-                    x,y=$near_void[$i].x,$near_void[$i].y
-                [/filter]
-                amount=32
-                damage_type=arcane
-                kill=yes
-            [/harm_unit]
-            [if]
-                [variable]
-                    name=near_void[$i].side
-                    equals=1
-                [/variable]
-                [not]
+        [foreach]
+            array=near_void
+            [do]
+                [terrain]
+                    x,y=$this_item.x,$this_item.y
+                    terrain=Xv
+                [/terrain]
+                [harm_unit]
+                    [filter]
+                        x,y=$this_item.x,$this_item.y
+                    [/filter]
+                    amount=32
+                    damage_type=arcane
+                    kill=yes
+                [/harm_unit]
+                [if]
                     [variable]
-                        name=quests.seen_void
-                        equals=yes
+                        name=this_item.side
+                        equals=1
                     [/variable]
-                [/not]
-                [then]
-                    [message]
-                        speaker=Efraim
-                        message=_"This hungry void expands and eats everything it can reach. We most get through before it consumes the whole area."
-                    [/message]
-                    {VARIABLE quests.seen_void yes}
-                [/then]
-            [/if]
-        {NEXT i}
+                    [not]
+                        [variable]
+                            name=quests.seen_void
+                            equals=yes
+                        [/variable]
+                    [/not]
+                    [then]
+                        [message]
+                            speaker=Efraim
+                            message=_"This hungry void expands and eats everything it can reach. We most get through before it consumes the whole area."
+                        [/message]
+                        {VARIABLE quests.seen_void yes}
+                    [/then]
+                [/if]
+            [/do]
+        [/foreach]
         {CLEAR_VARIABLE near_void,do_expand}
     [/event]
 #enddef
@@ -8253,23 +8295,26 @@ The map can be viewed through the right-click menu."}
             [/not]
         [/filter]
         {VARIABLE already_carcass no}
-        {FOREACH carcasses i}
-            [if]
-                [variable]
-                    name=carcasses[$i].x
-                    equals=$x1
-                [/variable]
-                [and]
+        [foreach]
+            array=carcasses
+            [do]
+                [if]
                     [variable]
-                        name=carcasses[$i].y
-                        equals=$y1
+                        name=this_item.x
+                        equals=$x1
                     [/variable]
-                [/and]
-                [then]
-                    {VARIABLE already_carcass yes}
-                [/then]
-            [/if]
-        {NEXT i}
+                    [and]
+                        [variable]
+                            name=this_item.y
+                            equals=$y1
+                        [/variable]
+                    [/and]
+                    [then]
+                        {VARIABLE already_carcass yes}
+                    [/then]
+                [/if]
+            [/do]
+        [/foreach]
         [if]
             [variable]
                 name=already_carcass
@@ -8294,29 +8339,32 @@ The map can be viewed through the right-click menu."}
     [event]
         name=new turn
         first_time_only=no
-        {FOREACH carcasses i}
-            {VARIABLE_OP random rand (yes,no)}
-            [if]
-                [variable]
-                    name=random
-                    equals=yes
-                [/variable]
-                [then]
-                    {GENERIC_UNIT {SIDE} Flies $carcasses[$i].x $carcasses[$i].y}
-                    [+unit]
-                        [modifications]
-                            [object]
-                                [effect]
-                                    apply_to=attack
-                                    increase_damage=200%
-                                    increase_attacks=-50%
-                                [/effect]
-                            [/object]
-                        [/modifications]
-                    [/unit]
-                [/then]
-            [/if]
-        {NEXT i}
+        [foreach]
+            array=carcasses
+            [do]
+                {VARIABLE_OP random rand (yes,no)}
+                [if]
+                    [variable]
+                        name=random
+                        equals=yes
+                    [/variable]
+                    [then]
+                        {GENERIC_UNIT {SIDE} Flies $this_item.x $this_item.y}
+                        [+unit]
+                            [modifications]
+                                [object]
+                                    [effect]
+                                        apply_to=attack
+                                        increase_damage=200%
+                                        increase_attacks=-50%
+                                    [/effect]
+                                [/object]
+                            [/modifications]
+                        [/unit]
+                    [/then]
+                [/if]
+            [/do]
+        [/foreach]
         {CLEAR_VARIABLE random}
     [/event]
     [event]

--- a/utils/utils.cfg
+++ b/utils/utils.cfg
@@ -1635,3 +1635,20 @@ $item_info.description"
     [/unit]
 #enddef
 
+#define  MOVE_SIDE_TO SIDE X Y
+    # Move all units on SIDE to X,Y
+    [store_unit]
+        [filter]
+            side={SIDE}
+        [/filter]
+        kill=no
+        variable=movement_store
+    [/store_unit]
+    [for]
+        array=movement_store
+        [do]
+            {MOVE_UNIT x,y=$movement_store[$i].x,$movement_store[$i].y {X} {Y} }
+        [/do]
+    [/for]
+    {CLEAR_VARIABLE movement_store}
+#enddef


### PR DESCRIPTION
Removed FOREACH macros

Added MOVE_SIDE_TO macro for code which was used a few times, particularly when Romero shows up.

I think there might be an unrelated issue in chapter9_utils, STATUE_AMBUSH NUMBER.  One or two variables (gender_...) get set in prestart, then cleared in moveto.  What if you don't "moveto"?  No big deal, just wondered why they were hanging around in debug>inspect (also wonder if the seal guardian stores need to be kept once they are defeated).