### PR TITLE
Only request data about advancement if it's in the bare form 

### DIFF
--- a/lua/unitdata.lua
+++ b/lua/unitdata.lua
@@ -55,6 +55,17 @@ local function wml_modification_iterator(unit, tag, filter)
 	end
 end
 
+-- Check if the advancement's table has only the id key {id = adv_id} with no extra info
+
+local function is_bare_advancement(adv)
+	for k in pairs(adv) do
+		if k ~= "id" then
+			return false
+		end
+	end
+	return true
+end
+
 -- Helper function to obtain a unit type's advancement with a given id
 
 local function get_type_advancement(unit_type, advancement_id)
@@ -201,7 +212,7 @@ local wml_based_implementation = {
 				if modif_type == "object" and contents.number then
 					-- This is an item, therefore we must add "item set" effects (if any).
 					contents = loti.unit.item_with_set_effects(contents.number, set_items, contents.sort)
-				elseif modif_type == "advancement" then
+				elseif modif_type == "advancement" and is_bare_advancement(contents) then
 					contents = get_type_advancement(unit.type, contents.id)
 				end
 
@@ -242,7 +253,7 @@ local wml_based_implementation = {
 			if modif_type == "object" and contents.number then
 				-- This is an item, therefore we must add "item set" effects (if any).
 				contents = loti.unit.item_with_set_effects(contents.number, set_items, contents.sort)
-			elseif modif_type == "advancement" then
+			elseif modif_type == "advancement" and is_bare_advancement(contents) then
 				contents = get_type_advancement(unit.type, contents.id)
 			end
 


### PR DESCRIPTION
@edwardspec  and @Dugy that is my touch on the problem that I can propose to your consideration. 

Logic is pretty simple: we check that advancement in the form ``{id = adv_id}``, if it is, we use ``get_type_advancement`` to try to get the full info. If it's not, then it must be the fully spelt advancement, so we just use ``contents`` without touching it. 

I also want to show you the mod (merely a draft but still) that I'm implementing that I mentioned in #560 and which stumbled upon this bug. https://github.com/Discontinuum/LotI_Legacies_and_Books

The mod adds advancements to units that don't have LotI version. It's planned to add all needed legacies and books, for now only fire and ice dragon legacies are implements. 

``events.cfg`` sets up variables containing WML code of advancements (initially I used events to add amlas, so the name is a bit outdated, will rename to amlas.cfg or something like that). As I said in the comments under #560, I gave up on the casting unit's animations and just deleted all the code that mentions it when copypasted it from LotI.

The lua code that runs during ``pre advance`` is pretty straight-forward: we create a set of the unit's present advancements and check if it has a legacy. If it has a legacy, we add advancements of that legacy from the corresponding variable. The same logic will be applied to books: it will check which books the unit read and will add corresponding advancements in the same way.