### PR TITLE
Fix animations on corrupted elven scout and rider

### DIFF
--- a/units/corruption.cfg
+++ b/units/corruption.cfg
@@ -341,6 +341,7 @@
     id=Corrupted Elvish Scout
     name= _ "Corrupted Elvish Scout"
     profile="portraits/elves/scout.png"
+    image="units/elves-wood/scout/scout.png"
     ellipse="misc/ellipse"
     race=elf
     hitpoints=42
@@ -387,15 +388,13 @@
         number=2
         icon=attacks/dark-missile.png
     [/attack]
-    image="units/elves-wood/scout/scout.png"
-    #    {DEFENSE_ANIM "units/elves-wood/scout/scout-defend.png" "units/elves-wood/scout/scout.png" {SOUND_LIST:HORSE_HIT} }
-    #    [movement_anim]
-    #        [frame]
-    #            begin=0
-    #            end=150
-    #            image="units/elves-wood/scout/scout-moving.png"
-    #        [/frame]
-    #    [/movement_anim]
+    {DEFENSE_ANIM "units/elves-wood/scout/scout-defend2.png" "units/elves-wood/scout/scout-defend1.png" {SOUND_LIST:HORSE_HIT} }
+    [movement_anim]
+        start_time=0
+        [frame]
+            image="units/elves-wood/scout/scout.png:150"
+        [/frame]
+    [/movement_anim]
     [idle_anim]
         {STANDARD_IDLE_FILTER}
         start_time=0
@@ -403,51 +402,29 @@
             image="units/elves-wood/scout/scout.png:[125*9,150,175,150,175*8]"
         [/frame]
     [/idle_anim]
-    #    [attack_anim]
-    #        [filter_attack]
-    #            name=sword
-    #        [/filter_attack]
-    #        [frame]
-    #            begin=-200
-    #            end=-175
-    #            image="units/elves-wood/scout/scout.png"
-    #            sound=horse-elf-canter.wav
-    #        [/frame]
-    #        [frame]
-    #            begin=-175
-    #            end=-100
-    #            image="units/elves-wood/scout/scout-moving.png"
-    #        [/frame]
-    #        [if]
-    #            hits=no
-    #            [frame]
-    #                begin=-100
-    #                end=100
-    #                image="units/elves-wood/scout/scout-attack.png"
-    #                sound={SOUND_LIST:MISS}
-    #            [/frame]
-    #        [/if]
-    #        [else]
-    #            hits=yes
-    #            [frame]
-    #                begin=-100
-    #                end=100
-    #                image="units/elves-wood/scout/scout-attack.png"
-    #                sound={SOUND_LIST:SWORD_SWISH}
-    #            [/frame]
-    #        [/else]
-    #        [frame]
-    #            begin=100
-    #            end=200
-    #            image="units/elves-wood/scout/scout-moving.png"
-    #        [/frame]
-    #        [frame]
-    #            begin=200
-    #            end=250
-    #            image="units/elves-wood/scout/scout.png"
-    #        [/frame]
-    #    [/attack_anim]
-    #    {CORRUPTION_ATTACK_ANIM "units/elves-wood/scout/scout.png" "units/elves-wood/scout/scout-attack.png"}
+    [attack_anim]
+        [filter_attack]
+            name=sword
+        [/filter_attack]
+        start_time=-200
+        [frame]
+            image="units/elves-wood/scout/scout.png:25"
+            sound=horse-elf-canter.wav
+        [/frame]
+        [frame]
+            image="units/elves-wood/scout/scout.png:75"
+        [/frame]
+        {SOUND:HIT_AND_MISS {SOUND_LIST:SWORD_SWISH} {SOUND_LIST:MISS} -100}
+        [frame]
+            image="units/elves-wood/scout/scout.png:200"
+        [/frame]
+        [frame]
+            image="units/elves-wood/scout/scout.png:100"
+        [/frame]
+        [frame]
+            image="units/elves-wood/scout/scout.png:50"
+        [/frame]
+    [/attack_anim]
     {CORRUPTION_ATTACK_ANIM "units/elves-wood/scout/scout.png" "units/elves-wood/scout/scout.png"}
 [/unit_type]
 [unit_type]
@@ -512,60 +489,48 @@
         icon=attacks/dark-missile.png
     [/attack]
     image="units/elves-wood/rider/rider.png"
-    {DEFENSE_ANIM "units/elves-wood/rider/rider-defend.png" "units/elves-wood/rider/rider.png" {SOUND_LIST:HORSE_HIT} }
+    {DEFENSE_ANIM "units/elves-wood/rider/rider-defend2.png" "units/elves-wood/rider/rider-defend1.png" {SOUND_LIST:HORSE_HIT} }
     [movement_anim]
+        start_time=0
         [frame]
-            begin=0
-            end=150
-            image="units/elves-wood/rider/rider-moving.png"
+            image="units/elves-wood/rider/rider.png:150"
         [/frame]
     [/movement_anim]
-    {CORRUPTION_ATTACK_ANIM "units/elves-wood/rider/rider.png" "units/elves-wood/rider/rider-melee-1.png"}
+    {CORRUPTION_ATTACK_ANIM "units/elves-wood/rider/rider.png" "units/elves-wood/rider/rider.png"}
     [attack_anim]
         [filter_attack]
             name=sword
         [/filter_attack]
+        start_time=-200
         [frame]
-            begin=-200
-            end=-175
-            image="units/elves-wood/rider/rider.png"
+            image="units/elves-wood/rider/rider.png:25"
             sound=horse-elf-canter.wav
         [/frame]
         [frame]
-            begin=-175
-            end=-100
-            image="units/elves-wood/rider/rider-melee-2.png"
+            image="units/elves-wood/rider/rider.png:75"
         [/frame]
         [if]
             hits=no
             [frame]
-                begin=-100
-                end=100
-                image="units/elves-wood/rider/rider-melee-1.png"
+                image="units/elves-wood/rider/rider.png:200"
                 sound={SOUND_LIST:MISS}
             [/frame]
         [/if]
         [else]
             hits=yes
             [frame]
-                begin=-100
-                end=100
-                image="units/elves-wood/rider/rider-melee-1.png"
+                image="units/elves-wood/rider/rider.png:200"
                 sound={SOUND_LIST:SWORD_SWISH}
             [/frame]
         [/else]
         [frame]
-            begin=100
-            end=175
-            image="units/elves-wood/rider/rider-moving.png"
+            image="units/elves-wood/rider/rider.png:75"
         [/frame]
         [frame]
-            begin=175
-            end=200
-            image="units/elves-wood/rider/rider.png"
+            image="units/elves-wood/rider/rider.png:25"
         [/frame]
     [/attack_anim]
-    {CORRUPTION_ATTACK_ANIM "units/elves-wood/rider/rider.png" "units/elves-wood/rider/rider-attack.png"}
+    {CORRUPTION_ATTACK_ANIM "units/elves-wood/rider/rider.png" "units/elves-wood/rider/rider.png"}
 [/unit_type]
 [unit_type]
     id=Corrupted Elvish Hero


### PR DESCRIPTION
Move, defense, and melee attack of Corrupted Elven Scout and Elven Rider are broken. This fixes it adapting from the originals. Maybe it uses old animations and you forgot to update.

![imagen](https://github.com/Dugy/Legend_of_the_Invincibles/assets/40789364/e1e57625-67ad-49db-9aab-cfb81f7c464d)

