### PR TITLE
Cover case when Harry dies before reach the town

### DIFF
--- a/scenarios2/02_Gods.cfg
+++ b/scenarios2/02_Gods.cfg
@@ -481,7 +481,7 @@
             message= _ "This must be the town of Aloh."
         [/message]
         [message]
-            speaker=Harry
+            side=2
             message= _ "The elves are coming back! To your posts, men!"
         [/message]
         [message]
@@ -489,7 +489,7 @@
             message= _ "Wait, Sir. We are not with the elven army that may have passed here some days ago."
         [/message]
         [message]
-            speaker=Harry
+            side=2
             message= _ "Why should we believe you? The other elf commander also spoke with honeyed words and then attacked our sentry patrol as soon as our guard was down. We found their walking corpses, we did. A terrible end for fighting men of honour, it was! We barely made it to a defensible position and forced their withdrawal, but their leader, Ghambar he said his name was, said they'd be back with a larger force to raze us to the ground! Ghambar sent you to trick us, did he not??!!"
         [/message]
         [message]
@@ -501,7 +501,7 @@
             message= _ "My good man, we were also attacked by elves. It seems some of my kind have gone mad under the influence of a so-called goddess and are on a campaign to destroy any who oppose their vision of a paradise."
         [/message]
         [message]
-            speaker=Harry
+            side=2
             message= _ "I have witnessed their treachery! If your words are true, prove them! Kill Ghambar, the leader of the elves who killed my men and we may talk again. I cannot trust you. Elves turned into a treacherous lot, they appear out of nowhere and strike without warning!"
         [/message]
         [message]

--- a/scenarios2/02_Gods.cfg
+++ b/scenarios2/02_Gods.cfg
@@ -476,6 +476,14 @@
             x,y=5-37,28-52
             side=1
         [/filter]
+        [if]
+            [have_unit]
+                side=2
+            [/have_unit]
+            [else]
+                {FORT_GUARD 17 40}
+            [/else]
+        [/if]
         [message]
             speaker=Lethalia
             message= _ "This must be the town of Aloh."


### PR DESCRIPTION
In discord someone has reported Harry's death off screen (in the shroud) and when they get to town they talk to someone who doesn't answer. With this change, Harry will still speak as first option (tested), but in case of his absence, any of the surviving soldiers from side 2 will do it, and the conversation still makes sense as is.

I think it's almost impossible for them all to die, so this simple change will suffice.