### PR TITLE
Ally mages with all player enemies except trolls

### DIFF
--- a/scenarios2/02_Gods.cfg
+++ b/scenarios2/02_Gods.cfg
@@ -58,7 +58,7 @@
         random_traits=yes
         side=3
         canrecruit=no
-        team_name=good
+        team_name=good,Saurians,Undead,Bandits
         user_team_name=_"Good"
         gold=0
         income=−2
@@ -96,7 +96,7 @@
             leader_value=100
             {MODIFY_AI_ADD_ASPECT 4 attacks (
                 [facet]
-                    name=testing_ai_default::aspect_attacks
+                    name=ai_default_rca::aspect_attacks
                     id=dont_attack_others
                     invalidate_on_gamestate_change=yes
                     [filter_enemy]
@@ -153,7 +153,7 @@
         [ai]
             {MODIFY_AI_ADD_ASPECT 4 attacks (
                 [facet]
-                    name=testing_ai_default::aspect_attacks
+                    name=ai_default_rca::aspect_attacks
                     id=dont_attack_others2
                     invalidate_on_gamestate_change=yes
                     [filter_enemy]
@@ -191,7 +191,7 @@
         income=−2
         {MODIFY_AI_ADD_ASPECT 6 attacks (
             [facet]
-                name=testing_ai_default::aspect_attacks
+                name=ai_default_rca::aspect_attacks
                 id=dont_attack_others3
                 invalidate_on_gamestate_change=yes
                 [filter_enemy]
@@ -266,7 +266,7 @@
         income=−2
         {MODIFY_AI_ADD_ASPECT 8 attacks (
             [facet]
-                name=testing_ai_default::aspect_attacks
+                name=ai_default_rca::aspect_attacks
                 id=dont_attack_others4
                 invalidate_on_gamestate_change=yes
                 [filter_enemy]

--- a/scenarios2/02_Gods.cfg
+++ b/scenarios2/02_Gods.cfg
@@ -58,7 +58,7 @@
         random_traits=yes
         side=3
         canrecruit=no
-        team_name=good,Saurians,Undead,Bandits
+        team_name=good,Saurians,Undead,Bandits,twisted_good
         user_team_name=_"Good"
         gold=0
         income=−2

--- a/scenarios2/02_Gods.cfg
+++ b/scenarios2/02_Gods.cfg
@@ -89,39 +89,6 @@
         type=Necromancer
         gender=female
         side=4
-        [ai]
-            aggression=1.0
-            caution=-5.0
-            grouping=no
-            leader_value=100
-            {MODIFY_AI_ADD_ASPECT 4 attacks (
-                [facet]
-                    name=ai_default_rca::aspect_attacks
-                    id=dont_attack_others
-                    invalidate_on_gamestate_change=yes
-                    [filter_enemy]
-                        [not]
-                            side=2
-                        [/not]
-                        [not]
-                            side=3
-                        [/not]
-                        [not]
-                            side=5
-                        [/not]
-                        [not]
-                            side=6
-                        [/not]
-                        [not]
-                            side=7
-                        [/not]
-                        [not]
-                            side=8
-                        [/not]
-                    [/filter_enemy]
-                [/facet]
-            )}
-        [/ai]
         id=Emragiela
         ai_special=guardian
         name="Emragiela"
@@ -150,32 +117,6 @@
         side=5
         team_name=twisted_good
         user_team_name= _ "Twisted Good"
-        [ai]
-            {MODIFY_AI_ADD_ASPECT 4 attacks (
-                [facet]
-                    name=ai_default_rca::aspect_attacks
-                    id=dont_attack_others2
-                    invalidate_on_gamestate_change=yes
-                    [filter_enemy]
-                        [not]
-                            side=2
-                        [/not]
-                        [not]
-                            side=3
-                        [/not]
-                        [not]
-                            side=6
-                        [/not]
-                        [not]
-                            side=7
-                        [/not]
-                        [not]
-                            side=8
-                        [/not]
-                    [/filter_enemy]
-                [/facet]
-            )}
-        [/ai]
     [/side]
     [side]
         type=Saurian Flanker
@@ -189,33 +130,6 @@
         user_team_name=_"Saurians"
         gold=0
         income=−2
-        {MODIFY_AI_ADD_ASPECT 6 attacks (
-            [facet]
-                name=ai_default_rca::aspect_attacks
-                id=dont_attack_others3
-                invalidate_on_gamestate_change=yes
-                [filter_enemy]
-                    [not]
-                        side=2
-                    [/not]
-                    [not]
-                        side=3
-                    [/not]
-                    [not]
-                        side=5
-                    [/not]
-                    [not]
-                        side=4
-                    [/not]
-                    [not]
-                        side=7
-                    [/not]
-                    [not]
-                        side=8
-                    [/not]
-                [/filter_enemy]
-            [/facet]
-        )}
         [modifications]
             [advancement]
                 [effect]
@@ -264,33 +178,6 @@
         user_team_name=_"Bandits"
         gold=0
         income=−2
-        {MODIFY_AI_ADD_ASPECT 8 attacks (
-            [facet]
-                name=ai_default_rca::aspect_attacks
-                id=dont_attack_others4
-                invalidate_on_gamestate_change=yes
-                [filter_enemy]
-                    [not]
-                        side=2
-                    [/not]
-                    [not]
-                        side=3
-                    [/not]
-                    [not]
-                        side=5
-                    [/not]
-                    [not]
-                        side=6
-                    [/not]
-                    [not]
-                        side=7
-                    [/not]
-                    [not]
-                        side=4
-                    [/not]
-                [/filter_enemy]
-            [/facet]
-        )}
         [modifications]
             [advancement]
                 [effect]


### PR DESCRIPTION
Resolves #584 

The alliance is hidden, not visible to the player, so it's the easiest way without making it look like the mages are ACTUALLY allied.

I have also fixed the name of the AI aspect, which is old.
What this AI does is that "Specifying scouts not attack whilst scouting" according to the wiki:
https://wiki.wesnoth.org/Formula_AI_Code_Library#Specifying_scouts_not_attack_whilst_scouting
(Keep in mind that it is more than 10 years old)
But it does not prevent them from attacking each other. That's ok. There will be a fight, since they are really enemies between them, but it will be minimized, since they will prefer to explore except to attack side 1.