### PR TITLE
Use built-in wesnoth [effect] for alignment and max_attacks

### DIFF
--- a/lua/items.lua
+++ b/lua/items.lua
@@ -835,10 +835,10 @@ loti.item.describe_item = function(number, sort, set_items)
 				describe("unwalkable", _"above unwalkable places")
 				describe("impassable", _"through impassable walls")
 			elseif effect.apply_to == "alignment" then
-				if effect.alignment == "chaotic" then line = "<span color='yellow'>" .. _"Sets alignment to chaotic" .. "</span>"
-				elseif effect.alignment == "liminal" then line = "<span color='yellow'>" .. _"Sets alignment to liminal" .. "</span>"
-				elseif effect.alignment == "lawful" then line = "<span color='yellow'>" .. _"Sets alignment to lawful" .. "</span>"
-				elseif effect.alignment == "neutral" then line = "<span color='yellow'>" .. _"Sets alignment to neutral" .. "</span>" end
+				if effect.set == "chaotic" then line = "<span color='yellow'>" .. _"Sets alignment to chaotic" .. "</span>"
+				elseif effect.set == "liminal" then line = "<span color='yellow'>" .. _"Sets alignment to liminal" .. "</span>"
+				elseif effect.set == "lawful" then line = "<span color='yellow'>" .. _"Sets alignment to lawful" .. "</span>"
+				elseif effect.set == "neutral" then line = "<span color='yellow'>" .. _"Sets alignment to neutral" .. "</span>" end
 			elseif effect.apply_to == "bonus_attack" then
 				line = "<span color='green'>" .. _"Bonus attack: " .. effect.description .. "</span>"
 			elseif effect.apply_to == "status" and effect.add == "not_living" then

--- a/lua/stats.lua
+++ b/lua/stats.lua
@@ -324,6 +324,9 @@ function wesnoth.update_stats(original)
 		base_vision = remade.max_moves
 	end
 	remade.vision = base_vision + vision
+	if remade.vision < 0 then
+		remade.vision = 0
+	end
 
 	local remade_abilities = wml.get_child(remade, "abilities")
 	if not remade_abilities then
@@ -362,8 +365,8 @@ function wesnoth.update_stats(original)
 	local is_loyal
 
 	for index, eff in loti.unit.effects(remade) do -- luacheck: ignore 213/index
-		-- TODO: Add alignment, max_attacks and new_advancement using wesnoth.effects
-		if eff.apply_to == "alignment" then
+		-- LEGACY
+		if eff.apply_to == "alignment" and eff.alignment then
 			remade.alignment = eff.alignment
 		end
 		if eff.apply_to == "loyal" then
@@ -392,7 +395,8 @@ function wesnoth.update_stats(original)
 				set_if_same("type")
 			end
 		end
-		if eff.apply_to == "max_attacks" then
+		--LEGACY
+		if eff.apply_to == "max_attacks" and eff.add then
 			remade.max_attacks = remade.max_attacks + eff.add
 		end
 		if eff.apply_to == "new_advancement" then

--- a/utils/item_list.cfg
+++ b/utils/item_list.cfg
@@ -354,7 +354,7 @@ Stand up and see the sky turn bright"
         [/effect]
         [effect]
             apply_to=alignment
-            alignment=chaotic
+            set=chaotic
         [/effect]
         arcane_resist=-10
         flavour=_"You merely adopted darkness, I was molded by it."
@@ -458,7 +458,7 @@ Stand up and see the sky turn bright"
         [/effect]
         [effect]
             apply_to=alignment
-            alignment=lawful
+            set=lawful
         [/effect]
         arcane_penetrate=10
         vision=1
@@ -563,7 +563,7 @@ Stand up and see the sky turn bright"
         [/effect]
         [effect]
             apply_to=alignment
-            alignment=chaotic
+            set=chaotic
         [/effect]
         flavour=_"You, comrade with that Unholy Axe, position yourself as far from me as possible!"
     [/object]
@@ -864,7 +864,7 @@ Stand up and see the sky turn bright"
         gladiators_drop=1
         [effect]
             apply_to=max_attacks
-            add=1
+            increase=1
         [/effect]
         flavour=_"Are you sane? You cannot fight so much, we will run out of enemies too soon!"
     [/object]
@@ -1558,7 +1558,7 @@ Adjacent own units will do 20% more damage and will have 10% better resistances.
         damage=40
         [effect]
             apply_to=alignment
-            alignment=liminal
+            set=liminal
         [/effect]
         magic=30
         fire_resist=10
@@ -1618,7 +1618,7 @@ Adjacent own units will do 20% more damage and will have 10% better resistances.
         merge=yes
         [effect]
             apply_to=alignment
-            alignment=neutral
+            set=neutral
         [/effect]
         cold_resist=5
         flavour=_"A good executioner kills with a single blow."
@@ -2551,7 +2551,7 @@ defeat your foes mace to face."
         defence=10
         [effect]
             apply_to=alignment
-            alignment=chaotic
+            set=chaotic
         [/effect]
         arcane_resist=-10
         flavour=_"You call my new shirt filth?! For the thirty dirty pins in the sleeves?"
@@ -3343,7 +3343,7 @@ defeat your foes mace to face."
         damage=20
         [effect]
             apply_to=alignment
-            alignment=neutral
+            set=neutral
         [/effect]
         [effect]
             apply_to=movement
@@ -3831,7 +3831,7 @@ and saved the righteous."
         attacks_plus=1
         [effect]
             apply_to=alignment
-            alignment=chaotic
+            set=chaotic
         [/effect]
         vision=1
         flavour=_"Abandon the order, attack them randomly when unprepared."
@@ -4282,7 +4282,7 @@ New ability: despair (20)</span>"
         [/effect]
         [effect]
             apply_to=alignment
-            alignment=chaotic
+            set=chaotic
         [/effect]
         flavour=_"Your descendants, ancestors and friends are demonic kin that is behind all our suffering."
     [/object]
@@ -6252,7 +6252,7 @@ traditions were brought to them."
         number=304
         [effect]
             apply_to=alignment
-            alignment=neutral
+            set=neutral
         [/effect]
         flavour=_"Fidel is dead. Hail the Infidel."
     [/object]
@@ -7926,7 +7926,7 @@ Showshaunshog proved him wrong by collecting condensed water from smoke."
         [/effect]
         [effect]
             apply_to=alignment
-            alignment=chaotic
+            set=chaotic
         [/effect]
         [effect]
             apply_to=movement_costs
@@ -7970,7 +7970,7 @@ Showshaunshog proved him wrong by collecting condensed water from smoke."
         [/effect]
         [effect]
             apply_to=alignment
-            alignment=lawful
+            set=lawful
         [/effect]
         [specials]
             {WEAPON_SPECIAL_UNHOLYBANE}
@@ -8484,7 +8484,7 @@ Showshaunshog proved him wrong by collecting condensed water from smoke."
         dodge=10
         [effect]
             apply_to=alignment
-            alignment=chaotic
+            set=chaotic
         [/effect]
         flavour=_"Drive all light away and enjoy the darkness."
     [/object]
@@ -8586,7 +8586,7 @@ Showshaunshog proved him wrong by collecting condensed water from smoke."
         arcane_resist=15
         [effect]
             apply_to=alignment
-            alignment=lawful
+            set=lawful
         [/effect]
         flavour=_"Glory of the pure led the nocturnal creatures away."
     [/object]


### PR DESCRIPTION
This is the first patch about #577 making alignment and max_attacks using built-in wesnoth.effect implementation. Vision stays the old way for now, I need to test more how it will work in older replays