### PR TITLE
populate akulas place, fix manta id

### DIFF
--- a/scenarios5/23_Akulas_Place.cfg
+++ b/scenarios5/23_Akulas_Place.cfg
@@ -82,7 +82,7 @@
         side=2
         canrecruit=yes
         recruit=Javelineer_steel,Dark Sorcerer_steel,Duelist_steel,Longbowman_steel,Swordsman_steel,Lieutenant_steel
-        {GOLD 400 450 500}
+        {GOLD 200 250 300}
         {INCOME 30 40 50}
         team_name="Dreadful Evil"
         user_team_name=_"Dreadful Evil"
@@ -96,7 +96,7 @@
         side=3
         canrecruit=yes
         recruit=Spearman_steel,Dark Adept_steel,Fencer_steel,Bowman_steel
-        {GOLD 200 250 300}
+        {GOLD 100 150 200}
         {INCOME 20 30 40}
         random_traits=yes
         team_name="Dreadful Evil"
@@ -120,7 +120,7 @@
         side=4
         canrecruit=yes
         recruit=Spearman_steel,Dark Adept_steel,Fencer_steel,Bowman_steel
-        {GOLD 200 250 300}
+        {GOLD 100 150 200}
         {INCOME 20 30 40}
         random_traits=yes
         team_name="Dreadful Evil"
@@ -144,7 +144,7 @@
         side=5
         canrecruit=yes
         recruit=Spearman_steel,Dark Adept_steel,Fencer_steel,Bowman_steel
-        {GOLD 200 250 300}
+        {GOLD 100 150 200}
         {INCOME 20 30 40}
         random_traits=yes
         team_name="Dreadful Evil"
@@ -230,6 +230,54 @@
         {VARIABLE last_scenario 23}
         {VARIABLE amplificators_destroyed 0}
         {MODIFY_UNIT side=7 status.petrified yes}
+        {VARIABLE_OP demon_type rand (Javelineer_steel,Dark Sorcerer_steel,Duelist_steel,Longbowman_steel,Swordsman_steel,Lieutenant_steel)}
+        {GENERIC_UNIT 2 $demon_type 23 14}
+        {GENERIC_UNIT 2 $demon_type 24 16}
+        {GENERIC_UNIT 2 $demon_type 26 14}
+        {VARIABLE_OP demon_type rand (Javelineer_steel,Dark Sorcerer_steel,Duelist_steel,Longbowman_steel,Swordsman_steel,Lieutenant_steel)}
+        {GENERIC_UNIT 2 $demon_type 23 15}
+        {GENERIC_UNIT 2 $demon_type 24 14}
+        {GENERIC_UNIT 2 $demon_type 25 13}
+        {VARIABLE_OP demon_type rand (Javelineer_steel,Dark Sorcerer_steel,Duelist_steel,Longbowman_steel,Swordsman_steel,Lieutenant_steel)}
+        {GENERIC_UNIT 2 $demon_type 23 16}
+        {GENERIC_UNIT 2 $demon_type 25 14}
+        {GENERIC_UNIT 2 $demon_type 27 16}
+        {VARIABLE_OP demon_type rand (Javelineer_steel,Dark Sorcerer_steel,Duelist_steel,Longbowman_steel,Swordsman_steel,Lieutenant_steel)}
+        {GENERIC_UNIT 2 $demon_type 27 14}
+        {GENERIC_UNIT 2 $demon_type 25 16}
+        {GENERIC_UNIT 2 $demon_type 27 15}
+        {VARIABLE_OP demon_type rand (Javelineer_steel,Dark Sorcerer_steel,Duelist_steel,Longbowman_steel,Swordsman_steel,Lieutenant_steel)}
+        {GENERIC_UNIT 2 $demon_type 24 13}
+        {GENERIC_UNIT 2 $demon_type 26 15}
+        {GENERIC_UNIT 2 $demon_type 26 16}
+        {VARIABLE_OP demon_type rand (Javelineer_steel,Dark Sorcerer_steel,Duelist_steel,Longbowman_steel,Swordsman_steel,Lieutenant_steel)}
+        {GENERIC_UNIT 2 $demon_type 24 15}
+        {GENERIC_UNIT 2 $demon_type 25 17}
+        {GENERIC_UNIT 2 $demon_type 26 13}
+        {VARIABLE_OP demon_type rand (Spearman_steel,Dark Adept_steel,Fencer_steel,Bowman_steel)}
+        {GENERIC_UNIT 3 $demon_type 18 10}
+        {GENERIC_UNIT 3 $demon_type 19 12}
+        {GENERIC_UNIT 4 $demon_type 31 12}
+        {GENERIC_UNIT 4 $demon_type 31 11}
+        {GENERIC_UNIT 5 $demon_type 26 21}
+        {VARIABLE_OP demon_type rand (Spearman_steel,Dark Adept_steel,Fencer_steel,Bowman_steel)}
+        {GENERIC_UNIT 3 $demon_type 17 12}
+        {GENERIC_UNIT 3 $demon_type 19 11}
+        {GENERIC_UNIT 4 $demon_type 33 12}
+        {GENERIC_UNIT 5 $demon_type 26 22}
+        {GENERIC_UNIT 5 $demon_type 25 23}
+        {VARIABLE_OP demon_type rand (Spearman_steel,Dark Adept_steel,Fencer_steel,Bowman_steel)}
+        {GENERIC_UNIT 3 $demon_type 17 11}
+        {GENERIC_UNIT 4 $demon_type 32 12}
+        {GENERIC_UNIT 5 $demon_type 24 21}
+        {GENERIC_UNIT 5 $demon_type 24 22}
+        {VARIABLE_OP demon_type rand (Spearman_steel,Dark Adept_steel,Fencer_steel,Bowman_steel)}
+        {GENERIC_UNIT 3 $demon_type 18 12}
+        {GENERIC_UNIT 4 $demon_type 32 10}
+        {GENERIC_UNIT 4 $demon_type 33 11}
+        {GENERIC_UNIT 5 $demon_type 25 21}
+        {CLEAR_VARIABLE demon_type}
+
         [place_shroud]
             side=1
             x,y=57-56,5-13
@@ -382,7 +430,6 @@
                 {VARIABLE sc23 1}
             [/else]
         [/if]
-
         [if]
             [variable]
                 name=sisters_chat

--- a/scenarios5/23_Akulas_Place.cfg
+++ b/scenarios5/23_Akulas_Place.cfg
@@ -230,53 +230,57 @@
         {VARIABLE last_scenario 23}
         {VARIABLE amplificators_destroyed 0}
         {MODIFY_UNIT side=7 status.petrified yes}
-        {VARIABLE_OP demon_type rand (Javelineer_steel,Dark Sorcerer_steel,Duelist_steel,Longbowman_steel,Swordsman_steel,Lieutenant_steel)}
-        {GENERIC_UNIT 2 $demon_type 23 14}
-        {GENERIC_UNIT 2 $demon_type 24 16}
-        {GENERIC_UNIT 2 $demon_type 26 14}
-        {VARIABLE_OP demon_type rand (Javelineer_steel,Dark Sorcerer_steel,Duelist_steel,Longbowman_steel,Swordsman_steel,Lieutenant_steel)}
-        {GENERIC_UNIT 2 $demon_type 23 15}
-        {GENERIC_UNIT 2 $demon_type 24 14}
-        {GENERIC_UNIT 2 $demon_type 25 13}
-        {VARIABLE_OP demon_type rand (Javelineer_steel,Dark Sorcerer_steel,Duelist_steel,Longbowman_steel,Swordsman_steel,Lieutenant_steel)}
-        {GENERIC_UNIT 2 $demon_type 23 16}
-        {GENERIC_UNIT 2 $demon_type 25 14}
-        {GENERIC_UNIT 2 $demon_type 27 16}
-        {VARIABLE_OP demon_type rand (Javelineer_steel,Dark Sorcerer_steel,Duelist_steel,Longbowman_steel,Swordsman_steel,Lieutenant_steel)}
-        {GENERIC_UNIT 2 $demon_type 27 14}
-        {GENERIC_UNIT 2 $demon_type 25 16}
-        {GENERIC_UNIT 2 $demon_type 27 15}
-        {VARIABLE_OP demon_type rand (Javelineer_steel,Dark Sorcerer_steel,Duelist_steel,Longbowman_steel,Swordsman_steel,Lieutenant_steel)}
-        {GENERIC_UNIT 2 $demon_type 24 13}
-        {GENERIC_UNIT 2 $demon_type 26 15}
-        {GENERIC_UNIT 2 $demon_type 26 16}
-        {VARIABLE_OP demon_type rand (Javelineer_steel,Dark Sorcerer_steel,Duelist_steel,Longbowman_steel,Swordsman_steel,Lieutenant_steel)}
-        {GENERIC_UNIT 2 $demon_type 24 15}
-        {GENERIC_UNIT 2 $demon_type 25 17}
-        {GENERIC_UNIT 2 $demon_type 26 13}
-        {VARIABLE_OP demon_type rand (Spearman_steel,Dark Adept_steel,Fencer_steel,Bowman_steel)}
-        {GENERIC_UNIT 3 $demon_type 18 10}
-        {GENERIC_UNIT 3 $demon_type 19 12}
-        {GENERIC_UNIT 4 $demon_type 31 12}
-        {GENERIC_UNIT 4 $demon_type 31 11}
-        {GENERIC_UNIT 5 $demon_type 26 21}
-        {VARIABLE_OP demon_type rand (Spearman_steel,Dark Adept_steel,Fencer_steel,Bowman_steel)}
-        {GENERIC_UNIT 3 $demon_type 17 12}
-        {GENERIC_UNIT 3 $demon_type 19 11}
-        {GENERIC_UNIT 4 $demon_type 33 12}
-        {GENERIC_UNIT 5 $demon_type 26 22}
-        {GENERIC_UNIT 5 $demon_type 25 23}
-        {VARIABLE_OP demon_type rand (Spearman_steel,Dark Adept_steel,Fencer_steel,Bowman_steel)}
-        {GENERIC_UNIT 3 $demon_type 17 11}
-        {GENERIC_UNIT 4 $demon_type 32 12}
-        {GENERIC_UNIT 5 $demon_type 24 21}
-        {GENERIC_UNIT 5 $demon_type 24 22}
-        {VARIABLE_OP demon_type rand (Spearman_steel,Dark Adept_steel,Fencer_steel,Bowman_steel)}
-        {GENERIC_UNIT 3 $demon_type 18 12}
-        {GENERIC_UNIT 4 $demon_type 32 10}
-        {GENERIC_UNIT 4 $demon_type 33 11}
-        {GENERIC_UNIT 5 $demon_type 25 21}
-        {CLEAR_VARIABLE demon_type}
+
+        # BEGIN populate Akula's team's castles
+        [store_starting_location]
+            side=2
+            variable=start_loc
+        [/store_starting_location]
+        [store_locations]
+            terrain="Cud^Ii"
+            [and]
+                x=$start_loc.x
+                y=$start_loc.y
+                radius=2
+            [/and]
+            variable=side_locs
+        [/store_locations]
+        [foreach]
+            array=side_locs
+            [do]
+                {VARIABLE_OP freak_type rand (Javelineer_steel,Dark Sorcerer_steel,Duelist_steel,Longbowman_steel,Swordsman_steel,Lieutenant_steel)}
+                {GENERIC_UNIT 2 $freak_type $this_item.x $this_item.y}
+            [/do]
+        [/foreach]
+        [for]
+            variable=side
+            start=3
+            end=5
+            [do]
+                [store_starting_location]
+                    side=$side
+                    variable=start_loc
+                [/store_starting_location]
+                [store_locations]
+                    terrain="Cud"
+                    [and]
+                        x=$start_loc.x
+                        y=$start_loc.y
+                        radius=1
+                    [/and]
+                    variable=side_locs
+                [/store_locations]
+                [foreach]
+                    array=side_locs
+                    [do]
+                        {VARIABLE_OP freak_type rand (Spearman_steel,Dark Adept_steel,Fencer_steel,Bowman_steel)}
+                        {GENERIC_UNIT $side $freak_type $this_item.x $this_item.y}
+                    [/do]
+                [/foreach]
+            [/do]
+        [/for]
+        {CLEAR_VARIABLE start_loc,side_locs,freak_type}
+        # END populate Akula's team's castles
 
         [place_shroud]
             side=1

--- a/utils/autorecall.cfg
+++ b/utils/autorecall.cfg
@@ -172,7 +172,7 @@ wml.variables.list_index = string.format("%4d",wml.variables.i+1)
                                                     id=Lilith
                                                 [/not]
                                                 [not]
-                                                    id=Manta
+                                                    id=akulas_sister
                                                 [/not]
                                             [/filter]
                                             variable=unit_list

--- a/utils/chapter5_utils.cfg
+++ b/utils/chapter5_utils.cfg
@@ -1346,7 +1346,7 @@ Spells remaining: " + ${VARIABLE_NAME}
             show=no
         [/recall]
         [recall]
-            id=Manta
+            id=akulas_sister
             show=no
         [/recall]
         [recall]


### PR DESCRIPTION
Populated castles of Akula and her minions.
Docked their gold to pay for it.
Fixed a couple places where Manta.id was referred to as Manta, not akulas_sister.  She now autorecalls automatically, as I believe was intended.

I could lower the effect of destroying amps on Akula's HP from 40% to 20% while I'm in there.

Ref #601