### PR TITLE
new tag [make_units_wander]

### DIFF
--- a/lua/utils.lua
+++ b/lua/utils.lua
@@ -51,21 +51,31 @@ function wesnoth.wml_actions.deny_undo()
     wesnoth.allow_undo(false)
 end
 
--- [is_in_list] tag checks to see if required string= is a member of a comma separated list=
--- Returns true/false (yes/no in wml) in required to_variable.
--- Does not handle empty entries ("" is NOT considered in "cat,,dog")
-function wesnoth.wml_actions.is_in_list(cfg)
-	local list=cfg.list or wml.error("[is_in_list]: missing required list=")
-	local string=tostring(cfg.string) or wml.error("[is_in_list]: missing required string=")
-	local to_variable=cfg.to_variable or wml.error("[is_in_list]: missing required to_variable=")
+-- is_in_list checks to see if required cfg.string is a member of a comma separated l cfg.list
+-- Does not handle empty entries ("" is NOT considered to be in "cat,,dog")
+local function is_in_list(cfg)
+	local list=cfg.list or wml.error("is_in_list: missing required cfg.list")
+	local string=tostring(cfg.string) or wml.error("is_in_list: missing required cfg.string")
 
-	local ret=false
-	for w in string.gmatch(list, "[%w%s]+") do
+	for w in string.gmatch(list, "[%w%s%^]+") do
+		print(string.format("Comparing <%s> to <%s>",w,string))
 		if (w == string) then
-			ret=true
-			break
+			return true
 		end
 	end
+	return false
+end
+
+
+-- [is_in_list] tag checks to see if required string= is a member of a comma separated list=
+-- Returns true/false (yes/no in wml) in required to_variable.
+-- Does not handle empty entries ("" is NOT considered to be in "cat,,dog")
+function wesnoth.wml_actions.is_in_list(cfg)
+	local to_variable=cfg.to_variable or wml.error("[is_in_list]: missing required to_variable=")
+	if (cfg.list == nil) then wml.error("[is_in_list]: missing required list=") end
+	if (cfg.string == nil) then wml.error("[is_in_list]: missing required string=") end
+
+	local ret=is_in_list(cfg)
 	wml.variables[to_variable]=ret
 end
 
@@ -94,4 +104,45 @@ function wesnoth.wml_actions.sort_unit_list(cfg)
 	end )
 
 	wml.array_access.set(to_variable, ul)
+end
+
+-- [make_units_wander] Moves units randomly around the map
+function wesnoth.wml_actions.make_units_wander(cfg)
+	local min_x=0
+	if (cfg.min_x ~= nil) then min_x=cfg.min_x end
+	local max_x=cfg.max_x  -- should get default from map size
+	local min_y=0
+	if (cfg.min_y ~= nil) then min_y=cfg.min_y end
+	local max_y=cfg.max_y  -- should get default from map size
+	local avoid_terrain_list=cfg.avoid_terrain_list
+	local radius=3
+	if (cfg.radius ~= nil) then radius=cfg.radius end
+	local filter=wml.get_child(cfg, "filter")
+
+	local units=wesnoth.units.find_on_map(filter)
+	        if #units < 1 then
+                wml.error("[make_units_wander]: no units found, check [filter]")
+        end
+
+	for _, unit in pairs(units) do
+
+		--print(string.format("Considering unit %s, x,y=%d,%d",unit.id,unit.x,unit.y))
+		local moveto_x=unit.__cfg.x + math.random(0-radius,radius)
+		local moveto_y=unit.__cfg.y + math.random(0-radius,radius)
+
+		local target_terrain=wesnoth.current.map[{moveto_x,moveto_y}]
+
+		local doit=false
+		if ((moveto_x>min_x) and (moveto_x<=max_x) and (moveto_y>min_y) and (moveto_y<=max_y)) then doit=true end
+
+		if (avoid_terrain_list ~= nil) and (doit == true) then
+			if is_in_list({list=avoid_terrain_list,string=target_terrain}) then doit=false end
+		end
+
+		--if not doit then print(string.format("    not moving %s from %d,%d to %d,%d",unit.id,unit.x,unit.y,moveto_x,moveto_y)) end
+		if doit then
+			--print(string.format("    moving %s from %d,%d to %d,%d",unit.id,unit.x,unit.y,moveto_x,moveto_y))
+			wml.fire("move_unit",{id=unit.id, to_x=moveto_x, to_y=moveto_y})
+		end
+	end
 end

--- a/scenarios10/01_Despair.cfg
+++ b/scenarios10/01_Despair.cfg
@@ -505,64 +505,14 @@
                 ) side 2}
             [/then]
         [/if]
-        [store_unit]
+        [make_units_wander]
             [filter]
                 side=3
             [/filter]
-            kill=no
-            variable=movement_store
-        [/store_unit]
-        [foreach]
-            array=movement_store
-            [do]
-                [if]
-                    [variable]
-                        name=this_item.attacks_left
-                        greater_than=0
-                    [/variable]
-                    [then]
-                        {VARIABLE_OP move_x rand (-3,-2,-1,0,1,2,3)}
-                        {VARIABLE_OP move_y rand (-3,-2,-1,0,1,2,3)}
-                        {VARIABLE moveto_x $this_item.x}
-                        {VARIABLE moveto_y $this_item.y}
-                        {VARIABLE_OP moveto_x add $move_x}
-                        {VARIABLE_OP moveto_y add $move_y}
-                        [if]
-                            [variable]
-                                name=moveto_x
-                                less_than=38
-                            [/variable]
-                            [and]
-                                [variable]
-                                    name=moveto_x
-                                    greater_than=0
-                                [/variable]
-                            [/and]
-                            [and]
-                                [variable]
-                                    name=moveto_y
-                                    greater_than=0
-                                [/variable]
-                            [/and]
-                            [and]
-                                [variable]
-                                    name=moveto_y
-                                    less_than=26
-                                [/variable]
-                            [/and]
-                            [then]
-                                {MOVE_UNIT x,y=$this_item.x,$this_item.y $moveto_x $moveto_y}
-                            [/then]
-                        [/if]
-                    [/then]
-                [/if]
-            [/do]
-        [/foreach]
-        {CLEAR_VARIABLE move_x}
-        {CLEAR_VARIABLE move_y}
-        {CLEAR_VARIABLE moveto_x}
-        {CLEAR_VARIABLE moveto_y}
-        {CLEAR_VARIABLE movement_store}
+            radius=3
+            max_x=37
+            max_y=25
+        [/make_units_wander]
         [if]
             [have_unit]
                 side=1

--- a/scenarios10/03_Fimbulwinter.cfg
+++ b/scenarios10/03_Fimbulwinter.cfg
@@ -260,276 +260,226 @@
                         [/filter]
 
                         {QUANTITY radius 6 7 8}
-                    [/filter_location]
-                ) side 4}
-            [/then]
-        [/if]
-        [store_unit]
-            [filter]
-                side=5
-            [/filter]
-            kill=no
-            variable=movement_store
-        [/store_unit]
-        [foreach]
-            array=movement_store
-            [do]
-                [if]
-                    [variable]
-                        name=this_item.attacks_left
-                        greater_than=0
-                    [/variable]
-                    [then]
-                        {VARIABLE_OP move_x rand (-3,-2,-1,0,1,2,3)}
-                        {VARIABLE_OP move_y rand (-3,-2,-1,0,1,2,3)}
-                        {VARIABLE moveto_x $this_item.x}
-                        {VARIABLE moveto_y $this_item.y}
-                        {VARIABLE_OP moveto_x add $move_x}
-                        {VARIABLE_OP moveto_y add $move_y}
-                        [if]
-                            [variable]
-                                name=moveto_x
-                                less_than=68
-                            [/variable]
-                            [and]
-                                [variable]
-                                    name=moveto_x
-                                    greater_than=37
-                                [/variable]
-                            [/and]
-                            [and]
-                                [variable]
-                                    name=moveto_y
-                                    greater_than=0
-                                [/variable]
-                            [/and]
-                            [and]
-                                [variable]
-                                    name=moveto_y
-                                    less_than=26
-                                [/variable]
-                            [/and]
-                            [then]
-                                {MOVE_UNIT x,y=$this_item.x,$this_item.y $moveto_x $moveto_y}
-                            [/then]
-                        [/if]
-                    [/then]
-                [/if]
-            [/do]
-        [/foreach]
-        {CLEAR_VARIABLE move_x}
-        {CLEAR_VARIABLE move_y}
-        {CLEAR_VARIABLE moveto_x}
-        {CLEAR_VARIABLE moveto_y}
-        {CLEAR_VARIABLE movement_store}
-        [if]
-            [have_unit]
-                side=1
-                [filter_vision]
-                    visible=yes
+                    [/filter_location] ) side 4}
+                [/then]
+            [/if]
+            [make_units_wander]
+                [filter]
                     side=5
-                [/filter_vision]
-                [or]
+                [/filter]
+                radius=3
+                min_x=38
+                max_x=67
+                min_y=0
+                max_y=25
+            [/make_units_wander]
+            [if]
+                [have_unit]
                     side=1
                     [filter_vision]
                         visible=yes
-                        side=4
+                        side=5
                     [/filter_vision]
-                [/or]
-            [/have_unit]
-            [then]
-                {MODIFY_UNIT (
-                    side=5
-                    [filter_location]
-                        [filter]
-                            side=1
-                        [/filter]
+                    [or]
+                        side=1
+                        [filter_vision]
+                            visible=yes
+                            side=4
+                        [/filter_vision]
+                    [/or]
+                [/have_unit]
+                [then]
+                    {MODIFY_UNIT (
+                        side=5
+                        [filter_location]
+                            [filter]
+                                side=1
+                            [/filter]
 
-                        {QUANTITY radius 6 7 8}
-                    [/filter_location]
-                ) side 4}
-            [/then]
-        [/if]
-    [/event]
-    [event]
-        name=moveto
-        [filter]
-            x=1-24
-            side=1
-        [/filter]
-        [remove_shroud]
-            side=1
-            x=17-21
-            y=3-7
-        [/remove_shroud]
-        [unit]
-            id=necro
-            name= _ "Ardogar the Defiler"
-            type=Necromancer
-            random_traits=yes
-            canrecruit=yes
-            unrenamable=yes
-            side=2
-            x,y=19,6
-            {IS_LOYAL}
-            [modifications]
-                {TRAIT_LOYAL}
-            [/modifications]
-        [/unit]
-        [unit]
-            type=Demon Overlord
-            id=enemy
-            generate_name=yes
-            side=3
-            x,y=4,16
-            to_variable=leader_store
-        [/unit]
-        {VARIABLE leader_store.canrecruit yes}
-        [unstore_unit]
-            variable=leader_store
-        [/unstore_unit]
-        {CLEAR_VARIABLE leader_store}
-        {GENERIC_UNIT 3 Imp 17 7}
-        {GENERIC_UNIT 3 Imp 20 7}
-        [modify_side]
-            side=2
-            income=10
-        [/modify_side]
-        [modify_side]
-            side=3
-            income=25
-        [/modify_side]
-        [message]
-            speaker=necro
-            message= _ "A little help is needed here."
-        [/message]
-        [message]
-            speaker=Gumbrul
-            message= _ "How can a necromancer fear a few puny imps? Just send your undead and they will slay them with ease."
-        [/message]
-        [message]
-            speaker=necro
-            message= _ "Not exactly. Raising undead is no longer possible, although other spells still work. Some necromancers believe that it signifies the end of the world, when not only the life in the world is dying but also its magic. But ones like me study this malfunction phenomenon. It appears that whenever a spirit is summoned – either to create a ghost or to reanimate a corpse – something sucks it away... But not back into the world of the dead, as spells preventing necromancy usually work."
-        [/message]
-        [message]
-            speaker=Vritra
-            message= _ "My parents are former necromancers, so I know a bit about this kind of things. I was told that demons suck souls into Inferno to use them for hard labour or to torture them just for amusement. By trying to use necromancy, these souls are now being moved into Inferno... a really terrible destiny, far worse than undeath."
-        [/message]
-        [message]
-            speaker=necro
-            message= _ "Not exactly. They are not sucked into Inferno either, we have assembled enough evidence to reject that hypothesis."
-        [/message]
-        [message]
-            speaker=Vritra
-            message= _ "Mum was casting a spell that was supposed to prevent the demons from sucking the souls into Inferno, but it probably spread a bit too much, so that no necromancy is possible."
-        [/message]
-        [message]
-            speaker=necro
-            message= _ "Not exactly. Only summoning does not work, unless cast via previously enchanted items. But still, the enemies are coming, and we need your help!"
-        [/message]
-        [message]
-            speaker=Gumbrul
-            message= _ "We should help them, undead are our fiends now."
-        [/message]
-    [/event]
-    [event]
-        name=attack
-        [filter]
-            id=Vritra
-        [/filter]
-        [message]
-            speaker=Gumbrul
-            message= _ "I see that there is anger within you, Vritra. Why are you trying to avoid using it? Anger is one of the main powers of orcs, you should learn to use it."
-        [/message]
-        [message]
-            speaker=Vritra
-            message= _ "This is not the same anger you orcs know. This is a dark fury that might be able to take control of me and make me kill anything, allies and enemies alike. If I was not careful enough, I started radiating an aura that harmed anything around me, and every moment spent without killing was a pain, while killing made me feel really strong. This is different from your anger, and I want to avoid this."
-        [/message]
-        [message]
-            speaker=Gumbrul
-            message= _ "How does that anger feel?"
-        [/message]
-        [message]
-            speaker=Vritra
-            message= _ "It feels like if I wanted to tear souls from bodies, eat them and cause eternal torment to them in a spiritual jail that is hidden within me. You would not like it either."
-        [/message]
-        [message]
-            speaker=Krux
-            message= _ "That is strange, when I feel anger, I just want to punish the enemies for all the evil they have done. And I am driven by anger in most fights with demons, believe me."
-        [/message]
-        [message]
-            speaker=Gumbrul
-            message= _ "When I feel anger, it comes from the hatred for destroying everything this world was about. This anger will not turn you into a monster."
-        [/message]
-        [message]
-            speaker=Vritra
-            message= _ "Nothing can turn me into a monster. I <i>am</i> a monster. I am just trying to be like you. I need to avoid using a lot of my powers in order to avoid ending up as a deadly monster, preying on humans, eating their souls and becoming more and more powerful."
-        [/message]
-        [message]
-            speaker=Krux
-            message= _ "But you said you <i>learned</i> to control your anger."
-        [/message]
-        [message]
-            speaker=Vritra
-            message= _ "Yes, but only to some extent. The powers my anger brings are great, but I want to avoid using it as it is too dangerous."
-        [/message]
-        [message]
-            speaker=Gumbrul
-            message= _ "We might not survive without your powers of darkness. This is the Twilight of the Gods, the time when Light and Darkness must unite to fight the new peril. Use the anger, Vritra..."
-        [/message]
-        [message]
-            speaker=Vritra
-            message= _ "Let me think about it. But I will need to imitate your style of anger."
-        [/message]
-        [store_unit]
-            [filter]
-                id=Vritra
-            [/filter]
-            variable=Vritra_store
-        [/store_unit]
-        [set_variables]
-            name=Vritra_store.modifications.advancement[$Vritra_store.modifications.advancement.length]
-            [value]
-                id=berserk1
-                description= _ "able to attack twice in a row"
-                image=attacks/frenzy.png
-                [effect]
-                    apply_to=bonus_attack
+                            {QUANTITY radius 6 7 8}
+                        [/filter_location]) side 4}
+                    [/then]
+                [/if]
+            [/event]
+            [event]
+                name=moveto
+                [filter]
+                    x=1-24
+                    side=1
+                [/filter]
+                [remove_shroud]
+                    side=1
+                    x=17-21
+                    y=3-7
+                [/remove_shroud]
+                [unit]
+                    id=necro
+                    name= _ "Ardogar the Defiler"
+                    type=Necromancer
+                    random_traits=yes
+                    canrecruit=yes
+                    unrenamable=yes
+                    side=2
+                    x,y=19,6
+                    {IS_LOYAL}
+                    [modifications]
+                        {TRAIT_LOYAL}
+                    [/modifications]
+                [/unit]
+                [unit]
+                    type=Demon Overlord
+                    id=enemy
+                    generate_name=yes
+                    side=3
+                    x,y=4,16
+                    to_variable=leader_store
+                [/unit]
+                {VARIABLE leader_store.canrecruit yes}
+                [unstore_unit]
+                    variable=leader_store
+                [/unstore_unit]
+                {CLEAR_VARIABLE leader_store}
+                {GENERIC_UNIT 3 Imp 17 7}
+                {GENERIC_UNIT 3 Imp 20 7}
+                [modify_side]
+                    side=2
+                    income=10
+                [/modify_side]
+                [modify_side]
+                    side=3
+                    income=25
+                [/modify_side]
+                [message]
+                    speaker=necro
+                    message= _ "A little help is needed here."
+                [/message]
+                [message]
+                    speaker=Gumbrul
+                    message= _ "How can a necromancer fear a few puny imps? Just send your undead and they will slay them with ease."
+                [/message]
+                [message]
+                    speaker=necro
+                    message= _ "Not exactly. Raising undead is no longer possible, although other spells still work. Some necromancers believe that it signifies the end of the world, when not only the life in the world is dying but also its magic. But ones like me study this malfunction phenomenon. It appears that whenever a spirit is summoned – either to create a ghost or to reanimate a corpse – something sucks it away... But not back into the world of the dead, as spells preventing necromancy usually work."
+                [/message]
+                [message]
+                    speaker=Vritra
+                    message= _ "My parents are former necromancers, so I know a bit about this kind of things. I was told that demons suck souls into Inferno to use them for hard labour or to torture them just for amusement. By trying to use necromancy, these souls are now being moved into Inferno... a really terrible destiny, far worse than undeath."
+                [/message]
+                [message]
+                    speaker=necro
+                    message= _ "Not exactly. They are not sucked into Inferno either, we have assembled enough evidence to reject that hypothesis."
+                [/message]
+                [message]
+                    speaker=Vritra
+                    message= _ "Mum was casting a spell that was supposed to prevent the demons from sucking the souls into Inferno, but it probably spread a bit too much, so that no necromancy is possible."
+                [/message]
+                [message]
+                    speaker=necro
+                    message= _ "Not exactly. Only summoning does not work, unless cast via previously enchanted items. But still, the enemies are coming, and we need your help!"
+                [/message]
+                [message]
+                    speaker=Gumbrul
+                    message= _ "We should help them, undead are our fiends now."
+                [/message]
+            [/event]
+            [event]
+                name=attack
+                [filter]
+                    id=Vritra
+                [/filter]
+                [message]
+                    speaker=Gumbrul
+                    message= _ "I see that there is anger within you, Vritra. Why are you trying to avoid using it? Anger is one of the main powers of orcs, you should learn to use it."
+                [/message]
+                [message]
+                    speaker=Vritra
+                    message= _ "This is not the same anger you orcs know. This is a dark fury that might be able to take control of me and make me kill anything, allies and enemies alike. If I was not careful enough, I started radiating an aura that harmed anything around me, and every moment spent without killing was a pain, while killing made me feel really strong. This is different from your anger, and I want to avoid this."
+                [/message]
+                [message]
+                    speaker=Gumbrul
+                    message= _ "How does that anger feel?"
+                [/message]
+                [message]
+                    speaker=Vritra
+                    message= _ "It feels like if I wanted to tear souls from bodies, eat them and cause eternal torment to them in a spiritual jail that is hidden within me. You would not like it either."
+                [/message]
+                [message]
+                    speaker=Krux
+                    message= _ "That is strange, when I feel anger, I just want to punish the enemies for all the evil they have done. And I am driven by anger in most fights with demons, believe me."
+                [/message]
+                [message]
+                    speaker=Gumbrul
+                    message= _ "When I feel anger, it comes from the hatred for destroying everything this world was about. This anger will not turn you into a monster."
+                [/message]
+                [message]
+                    speaker=Vritra
+                    message= _ "Nothing can turn me into a monster. I <i>am</i> a monster. I am just trying to be like you. I need to avoid using a lot of my powers in order to avoid ending up as a deadly monster, preying on humans, eating their souls and becoming more and more powerful."
+                [/message]
+                [message]
+                    speaker=Krux
+                    message= _ "But you said you <i>learned</i> to control your anger."
+                [/message]
+                [message]
+                    speaker=Vritra
+                    message= _ "Yes, but only to some extent. The powers my anger brings are great, but I want to avoid using it as it is too dangerous."
+                [/message]
+                [message]
+                    speaker=Gumbrul
+                    message= _ "We might not survive without your powers of darkness. This is the Twilight of the Gods, the time when Light and Darkness must unite to fight the new peril. Use the anger, Vritra..."
+                [/message]
+                [message]
+                    speaker=Vritra
+                    message= _ "Let me think about it. But I will need to imitate your style of anger."
+                [/message]
+                [store_unit]
+                    [filter]
+                        id=Vritra
+                    [/filter]
+                    variable=Vritra_store
+                [/store_unit]
+                [set_variables]
+                    name=Vritra_store.modifications.advancement[$Vritra_store.modifications.advancement.length]
+                    [value]
+                        id=berserk1
+                        description= _ "able to attack twice in a row"
+                        image=attacks/frenzy.png
+                        [effect]
+                            apply_to=bonus_attack
+                            name=mberserk2
+                            description= _ "fury (2)"
+                            clone_anim=yes
+                            icon=attacks/frenzy.png
+                            type=blade
+                            range=melee
+                            defense_weight=0
+                            damage=-20
+                            [specials]
+                                {WEAPON_SPECIAL_LESSER_BERSERK 2}
+                            [/specials]
+                        [/effect]
+                    [/value]
+                    mode=replace
+                [/set_variables]
+                [unstore_unit]
+                    variable=Vritra_store
+                    find_vacant=no
+                [/unstore_unit]
+                {CLEAR_VARIABLE Vritra_store}
+                {UPDATE_STATS}
+            [/event]
+            [event]
+                name=attack
+                [filter]
+                    id=Vritra
+                [/filter]
+                [filter_attack]
                     name=mberserk2
-                    description= _ "fury (2)"
-                    clone_anim=yes
-                    icon=attacks/frenzy.png
-                    type=blade
-                    range=melee
-                    defense_weight=0
-                    damage=-20
-                    [specials]
-                        {WEAPON_SPECIAL_LESSER_BERSERK 2}
-                    [/specials]
-                [/effect]
-            [/value]
-            mode=replace
-        [/set_variables]
-        [unstore_unit]
-            variable=Vritra_store
-            find_vacant=no
-        [/unstore_unit]
-        {CLEAR_VARIABLE Vritra_store}
-        {UPDATE_STATS}
-    [/event]
-    [event]
-        name=attack
-        [filter]
-            id=Vritra
-        [/filter]
-        [filter_attack]
-            name=mberserk2
-        [/filter_attack]
-        [message]
-            speaker=Gumbrul
-            message= _ "Good, let the anger flow through you."
-        [/message]	#A little bit parodying Star Wars.
-    [/event]
+                [/filter_attack]
+                [message]
+                    speaker=Gumbrul
+                    message= _ "Good, let the anger flow through you."
+                [/message]	#A little bit parodying Star Wars.
+            [/event]
 #define RUNE_TRAP X Y IMAGE EFFECT
     [item]
         x={X}
@@ -557,28 +507,28 @@
         [/item]
     [/event]
 #enddef
-    {RUNE_TRAP 58 8 1 ([heal_unit]
+            {RUNE_TRAP 58 8 1 ([heal_unit]
+            [filter]
+                find_in=unit
+            [/filter]
+            amount=30
+            animate=yes
+        [/heal_unit])}
+        {RUNE_TRAP 55 17 2 ([harm_unit]
+        [filter]
+            find_in=unit
+        [/filter]
+        amount=30
+        damage_type=cold
+        animate=yes
+    [/harm_unit])}
+    {RUNE_TRAP 43 4 3 ([heal_unit]
     [filter]
         find_in=unit
     [/filter]
-    amount=30
+    amount=50
+    restore_statuses=no
     animate=yes
-[/heal_unit])}
-{RUNE_TRAP 55 17 2 ([harm_unit]
-[filter]
-    find_in=unit
-[/filter]
-amount=30
-damage_type=cold
-animate=yes
-[/harm_unit])}
-{RUNE_TRAP 43 4 3 ([heal_unit]
-[filter]
-    find_in=unit
-[/filter]
-amount=50
-restore_statuses=no
-animate=yes
 [/heal_unit])}
 {RUNE_TRAP 36 24 4 ([harm_unit]
 [filter]

--- a/scenarios4/13_The_Way_of_Assassins.cfg
+++ b/scenarios4/13_The_Way_of_Assassins.cfg
@@ -468,66 +468,16 @@ A good plan. Let us go."
     [/event]
     [event]
         #Makes the guards wander around the map, when not in combat mode.
-        name=side turn
+        name=side 2 turn
         first_time_only=no
-        [if]
-            [variable]
-                name=side_number
-                equals=2
-            [/variable]
-            [then]
-                [store_unit]
-                    [filter]
-                        side=2
-                    [/filter]
-                    kill=no
-                    variable=movement_store
-                [/store_unit]
-                [foreach]
-                    array=movement_store
-                    [do]
-                        {VARIABLE_OP move_x rand (-3,-2,-1,0,1,2,3)}
-                        {VARIABLE_OP move_y rand (-3,-2,-1,0,1,2,3)}
-                        {VARIABLE moveto_x $this_item.x}
-                        {VARIABLE moveto_y $this_item.y}
-                        {VARIABLE_OP moveto_x add $move_x}
-                        {VARIABLE_OP moveto_y add $move_y}
-                        [if]
-                            [variable]
-                                name=moveto_x
-                                less_than=45
-                            [/variable]
-                            [and]
-                                [variable]
-                                    name=moveto_x
-                                    greater_than=0
-                                [/variable]
-                            [/and]
-                            [and]
-                                [variable]
-                                    name=moveto_y
-                                    greater_than=0
-                                [/variable]
-                            [/and]
-                            [and]
-                                [variable]
-                                    name=moveto_y
-                                    less_than=34
-                                [/variable]
-                            [/and]
-                            [then]
-                                {MOVE_UNIT x,y=$this_item.x,$this_item.y $moveto_x $moveto_y}
-                            [/then]
-                        [/if]
-                    [/do]
-                [/foreach]
-                {CLEAR_VARIABLE move_x}
-                {CLEAR_VARIABLE move_y}
-                {CLEAR_VARIABLE moveto_x}
-                {CLEAR_VARIABLE moveto_y}
-                {CLEAR_VARIABLE movement_store}
-            [/then]
-        [/if]
+        [make_units_wander]
+            [filter]
+                side=2
+            [/filter]
+            radius=3
+            max_x=44
+            max_y=33
+        [/make_units_wander]
     [/event]
     [event]
         name=die

--- a/scenarios5/05_We_Walk_in_the_Shadows.cfg
+++ b/scenarios5/05_We_Walk_in_the_Shadows.cfg
@@ -146,686 +146,637 @@
                             [/filter_location]
                         [/not]
                     [/filter_enemy]
-                [/facet]
-            )}
-        [/ai]
-    [/side]
-    [side]
-        no_leader=yes
-        side=4
-        {AI_OVERHAUL_PLACE 4}
-        {AI_OVERHAUL_PLACE_2 4}
-        team_name=evil
-        user_team_name=_"Evil"
-    [/side]
-    [event]
-        name=start
-        {ANTIASSASSIN_UNIT 3 "Royal Guard" 16 26}
-        {ANTIASSASSIN_UNIT 3 "Iron Mauler" 24 31}
-        {ANTIASSASSIN_UNIT 3 "Master Bowman" 35 21}
-        {ANTIASSASSIN_UNIT 3 "Swordsman" 28 25}
-        {ANTIASSASSIN_UNIT 3 "Halberdier" 35 19}
-        {ANTIASSASSIN_UNIT 3 "Shock Trooper" 25 22}
-        {ANTIASSASSIN_UNIT 3 "Silver Mage" 39 15}
-        {ANTIASSASSIN_UNIT 3 "Master at Arms" 43 13}
-        {ANTIASSASSIN_UNIT 3 "Iron Mauler" 38 3}
-        {ANTIASSASSIN_UNIT 3 "Master Bowman" 31 3}
-        {ANTIASSASSIN_UNIT 3 "Halberdier" 23 5}
-        {ANTIASSASSIN_UNIT 3 "Javelineer" 14 8}
-        {ANTIASSASSIN_UNIT 2 "Red Mage" 12 4}
-        {ANTIASSASSIN_UNIT 2 "Red Mage" 16 2}
-        {ANTIASSASSIN_UNIT 3 "Royal Guard" 15 18}
-        {ANTIASSASSIN_UNIT 3 "Swordsman" 24 11}
-        {ANTIASSASSIN_UNIT 3 "Royal Guard" 5 17}
-        {ANTIASSASSIN_UNIT 3 "Shock Trooper" 4 6}
-        {ANTIASSASSIN_UNIT 3 "Shock Trooper" 9 19}
-        {ANTIASSASSIN_UNIT 3 "Halberdier" 7 11}
-        [message]
-            speaker=Efraim
-            message= _ "There is much more street illumination than I expected. We will have to hide in bushes and dark alleys to get to him. The problem is that if they find us, they will immediately evacuate the mages and call for so many guards that they would overwhelm us."
-        [/message]
-        [message]
-            speaker=Lethalia
-            message= _ "But thieves can be hiding in the dark alleys. And the fight might attire the guards."
-        [/message]
-        [object]
-            id=Sneak
-            silent=yes
+                [/facet]                    )}
+            [/ai]
+        [/side]
+        [side]
+            no_leader=yes
+            side=4
+            {AI_OVERHAUL_PLACE 4}
+            {AI_OVERHAUL_PLACE_2 4}
+            team_name=evil
+            user_team_name=_"Evil"
+        [/side]
+        [event]
+            name=start
+            {ANTIASSASSIN_UNIT 3 "Royal Guard" 16 26}
+            {ANTIASSASSIN_UNIT 3 "Iron Mauler" 24 31}
+            {ANTIASSASSIN_UNIT 3 "Master Bowman" 35 21}
+            {ANTIASSASSIN_UNIT 3 "Swordsman" 28 25}
+            {ANTIASSASSIN_UNIT 3 "Halberdier" 35 19}
+            {ANTIASSASSIN_UNIT 3 "Shock Trooper" 25 22}
+            {ANTIASSASSIN_UNIT 3 "Silver Mage" 39 15}
+            {ANTIASSASSIN_UNIT 3 "Master at Arms" 43 13}
+            {ANTIASSASSIN_UNIT 3 "Iron Mauler" 38 3}
+            {ANTIASSASSIN_UNIT 3 "Master Bowman" 31 3}
+            {ANTIASSASSIN_UNIT 3 "Halberdier" 23 5}
+            {ANTIASSASSIN_UNIT 3 "Javelineer" 14 8}
+            {ANTIASSASSIN_UNIT 2 "Red Mage" 12 4}
+            {ANTIASSASSIN_UNIT 2 "Red Mage" 16 2}
+            {ANTIASSASSIN_UNIT 3 "Royal Guard" 15 18}
+            {ANTIASSASSIN_UNIT 3 "Swordsman" 24 11}
+            {ANTIASSASSIN_UNIT 3 "Royal Guard" 5 17}
+            {ANTIASSASSIN_UNIT 3 "Shock Trooper" 4 6}
+            {ANTIASSASSIN_UNIT 3 "Shock Trooper" 9 19}
+            {ANTIASSASSIN_UNIT 3 "Halberdier" 7 11}
+            [message]
+                speaker=Efraim
+                message= _ "There is much more street illumination than I expected. We will have to hide in bushes and dark alleys to get to him. The problem is that if they find us, they will immediately evacuate the mages and call for so many guards that they would overwhelm us."
+            [/message]
+            [message]
+                speaker=Lethalia
+                message= _ "But thieves can be hiding in the dark alleys. And the fight might attire the guards."
+            [/message]
+            [object]
+                id=Sneak
+                silent=yes
+                [filter]
+                    id=Efraim
+                [/filter]
+                [effect]
+                    apply_to=attack
+                    remove_specials=plague
+                [/effect]
+                [effect]
+                    apply_to=new_ability
+                    [abilities]
+                        [hides]
+                            id=nightstalk
+                            name= _ "nightstalk"
+                            female_name= _ "nightstalk"
+                            description= _ "The unit becomes invisible during night.
+
+Enemy units cannot see this unit at night, except if they have units next to it. Any enemy unit that first discovers this unit immediately loses all its remaining movement."
+                            name_inactive= _ "nightstalk"
+                            female_name_inactive= _ "female^nightstalk"
+                            description_inactive= _ "The unit becomes invisible during night.
+
+Enemy units cannot see this unit at night, except if they have units next to it. Any enemy unit that first discovers this unit immediately loses all its remaining movement."
+                            affect_self=yes
+                            alert="Detected!"
+                            [filter_self]
+                                [filter_location]
+                                    time_of_day=chaotic
+                                [/filter_location]
+                            [/filter_self]
+                        [/hides]
+                    [/abilities]
+                [/effect]
+                [effect]
+                    apply_to=remove_abilities
+                    [abilities]
+                        [illuminates]	#Make sure that nobody creates his own shadow/light.
+                            id=illumination
+                        [/illuminates]
+                        [illuminates]
+                            id=improved illumination
+                        [/illuminates]
+                        [illuminates]
+                            id=great illumination
+                        [/illuminates]
+                        [illuminates]
+                            id=darkens
+                        [/illuminates]
+                        [illuminates]
+                            id=darkens badly
+                        [/illuminates]
+                        [illuminates]
+                            id=darkens severely
+                        [/illuminates]
+                    [/abilities]
+                [/effect]
+            [/object]
+            [object]
+                id=Sneak_Lethalia
+                silent=yes
+                [filter]
+                    id=Lethalia
+                [/filter]
+                [effect]
+                    apply_to=attack
+                    remove_specials=plague,plague(Soulless),plague(Faerie Fire Unit)
+                [/effect]
+                [effect]
+                    apply_to=new_ability
+                    [abilities]
+                        [hides]
+                            id=nightstalk
+                            name= _ "nightstalk"
+                            female_name= _ "nightstalk"
+                            description= _ "The unit becomes invisible during night.
+
+Enemy units cannot see this unit at night, except if they have units next to it. Any enemy unit that first discovers this unit immediately loses all its remaining movement."
+                            name_inactive= _ "nightstalk"
+                            female_name_inactive= _ "female^nightstalk"
+                            description_inactive= _ "The unit becomes invisible during night.
+
+Enemy units cannot see this unit at night, except if they have units next to it. Any enemy unit that first discovers this unit immediately loses all its remaining movement."
+                            affect_self=yes
+                            alert="Detected!"
+                            [filter_self]
+                                [filter_location]
+                                    time_of_day=chaotic
+                                [/filter_location]
+                            [/filter_self]
+                        [/hides]
+                    [/abilities]
+                [/effect]
+                [effect]
+                    apply_to=remove_abilities
+                    [abilities]
+                        [illuminates]
+                            id=illumination
+                        [/illuminates]
+                        [illuminates]
+                            id=improved illumination
+                        [/illuminates]
+                        [illuminates]
+                            id=great illumination
+                        [/illuminates]
+                        [illuminates]
+                            id=darkens
+                        [/illuminates]
+                        [illuminates]
+                            id=darkens badly
+                        [/illuminates]
+                        [illuminates]
+                            id=darkens severely
+                        [/illuminates]
+                    [/abilities]
+                [/effect]
+            [/object]
+        [/event]
+        [event]
+            #Makes the guards wander around the map.
+            name=side turn
+            first_time_only=no
+            [if]
+                [variable]
+                    name=side_number
+                    equals=4   # Why do side 3's units wander around on side 4's turn?
+                [/variable]
+                [then]
+                    [make_units_wander]
+                        [filter]
+                            side=3
+                        [/filter]
+                        radius=3
+                        max_x=44
+                        max_y=33
+                    [/make_units_wander]
+                [/then]
+            [/if]
+        [/event]
+        [event]
+            name=attack
             [filter]
-                id=Efraim
+                side=3
             [/filter]
-            [effect]
-                apply_to=attack
-                remove_specials=plague
-            [/effect]
-            [effect]
-                apply_to=new_ability
-                [abilities]
-                    [hides]
-                        id=nightstalk
-                        name= _ "nightstalk"
-                        female_name= _ "nightstalk"
-                        description= _ "The unit becomes invisible during night.
-
-Enemy units cannot see this unit at night, except if they have units next to it. Any enemy unit that first discovers this unit immediately loses all its remaining movement."
-                        name_inactive= _ "nightstalk"
-                        female_name_inactive= _ "female^nightstalk"
-                        description_inactive= _ "The unit becomes invisible during night.
-
-Enemy units cannot see this unit at night, except if they have units next to it. Any enemy unit that first discovers this unit immediately loses all its remaining movement."
-                        affect_self=yes
-                        alert="Detected!"
-                        [filter_self]
-                            [filter_location]
-                                time_of_day=chaotic
-                            [/filter_location]
-                        [/filter_self]
-                    [/hides]
-                [/abilities]
-            [/effect]
-            [effect]
-                apply_to=remove_abilities
-                [abilities]
-                    [illuminates]	#Make sure that nobody creates his own shadow/light.
-                        id=illumination
-                    [/illuminates]
-                    [illuminates]
-                        id=improved illumination
-                    [/illuminates]
-                    [illuminates]
-                        id=great illumination
-                    [/illuminates]
-                    [illuminates]
-                        id=darkens
-                    [/illuminates]
-                    [illuminates]
-                        id=darkens badly
-                    [/illuminates]
-                    [illuminates]
-                        id=darkens severely
-                    [/illuminates]
-                [/abilities]
-            [/effect]
-        [/object]
-        [object]
-            id=Sneak_Lethalia
-            silent=yes
+            [filter_second]
+                side=1
+            [/filter_second]
+            [message]
+                speaker=unit
+                message=_ "Mugger! You are under arrest! No... you are... ALARM! REINFORCEMENTS! I have found the necromancers!"
+            [/message]
+            [endlevel]
+                result=defeat
+            [/endlevel]
+        [/event]
+        [event]
+            name=moveto
+            [filter]
+                x,y=2-3,23-27
+                side=1
+            [/filter]
+            {ANTIASSASSIN_UNIT 4 Assassin 2 22}
+            {ANTIASSASSIN_UNIT 4 Rogue 2 26}
+            {ANTIASSASSIN_UNIT 4 Rogue 3 27}
+            {ANTIASSASSIN_UNIT 4 Thief 3 23}
+            [message]
+                speaker=unit
+                message= _ "Damn, I was mugged. Well, boys, you will get to paradise very quickly."
+            [/message]
+        [/event]
+        [event]
+            name=moveto
+            [filter]
+                x,y=11-15,12-15
+                side=1
+            [/filter]
+            {ANTIASSASSIN_UNIT 4 Assassin 13 13}
+            {ANTIASSASSIN_UNIT 4 Rogue 12 14}
+            {ANTIASSASSIN_UNIT 4 Rogue 15 14}
+            {ANTIASSASSIN_UNIT 4 Assassin 13 16}
+            [message]
+                speaker=unit
+                message= _ "Haha, you want to fight?"
+            [/message]
+        [/event]
+        [event]
+            name=moveto
+            [filter]
+                x,y=27-30,9-13
+                side=1
+            [/filter]
+            {ANTIASSASSIN_UNIT 4 Assassin 28 10}
+            {ANTIASSASSIN_UNIT 4 Rogue 30 11}
+            {ANTIASSASSIN_UNIT 4 Highwayman 29 12}
+            {ANTIASSASSIN_UNIT 4 Assassin 31 10}
+            [message]
+                speaker=unit
+                message= _ "Run if you do not want your tongues cut away."
+            [/message]
+        [/event]
+        [event]
+            name=moveto
+            [filter]
+                x,y=39-42,27-32
+                side=1
+            [/filter]
+            {ANTIASSASSIN_UNIT 4 Assassin 44 26}
+            {ANTIASSASSIN_UNIT 4 Rogue 39 28}
+            {ANTIASSASSIN_UNIT 4 Rogue 41 32}
+            {ANTIASSASSIN_UNIT 4 Assassin 44 31}
+            [message]
+                speaker=unit
+                message= _ "Damn, I was mugged. Hearken ye, leave or I can assure you that you will get to paradise very quickly."
+            [/message]
+        [/event]
+        [event]
+            name=moveto
+            [filter]
+                x,y=11-17,1-4
+                side=1
+            [/filter]
+            [message]
+                speaker=unit
+                message= _ "We have found you."
+            [/message]
+            {MOVE_UNIT id=Efraim 13 2}
+            {MOVE_UNIT id=Lethalia 12 2}
+            [message]
+                speaker=Efraim
+                message= _ "How did you get to the information how to create the second sun?"
+            [/message]
+            [message]
+                speaker=Taruk
+                message= _ "I was just lucky, I just looked somewhere and it was there?"
+            [/message]
+            [message]
+                speaker=Lethalia
+                message= _ "Where?"
+            [/message]
+            [message]
+                speaker=Taruk
+                message= _ "Ehm, hm... Well, it was in... inside... a hole... inside a hole..."
+            [/message]
+            [message]
+                speaker=Lethalia
+                message= _ "You are lying. You have not found it. Who gave it to you?"
+            [/message]
+            [message]
+                speaker=Taruk
+                message= _ "One of King's counsellors, Akula."
+            [/message]
+            [message]
+                speaker=Lethalia
+                message= _ "Akula?!"
+            [/message]
+            [message]
+                speaker=Efraim
+                message= _ "Now everything looks more reasonable. She is an undead. That explains her huge resistance to damage. She might be a person who can get to that information. And she wants to destroy the Empire and create a huge chaos, and possibly to come to control it after. She poisoned the old king, gave the information to Taruk, who came up with an idea to create the third sun, and the king needed it to stop the doubts about his rule, so he decided so. And she joined us to destabilise the Empire to make sure it will not survive the cataclysm. If he decided not to create the third sun, she would have used her political power to steal the throne like the king suspected. A brilliant plan."
+            [/message]
+            [message]
+                speaker=Lethalia
+                message= _ "She is not able to decrypt the information. And I cannot imagine how can she build a kingdom from the ashes of the old Empire after the cataclysm. And by the way, I saw Akula bleed after that she was cut, she is definitely a different of undead than we are. If she even is an undead."
+            [/message]
+            [message]
+                speaker=Efraim
+                message= _ "Do you have a better explanation?"
+            [/message]
+            [message]
+                speaker=Lethalia
+                message= _ "No. Yours have flaws, but fits quite well."
+            [/message]
+            [message]
+                speaker=Efraim
+                message= _ "I will create a projection of King Dantair."
+            [/message]
+            [unit]
+                id=Dantair
+                profile="portraits/humans/marshal-2.png"
+                name= _ "King Dantair"
+                type=Royal Warrior
+                side=1
+                x,y=14,2
+                canrecruit=yes
+                recruit=
+                random_traits=yes
+            [/unit]
+            [message]
+                speaker=Dantair
+                message= _ "What do you want from me?"
+            [/message]
+            [message]
+                speaker=Efraim
+                message= _ "We have found out that it was Akula who was behind all of this. She killed the king, gave the information how to raise new suns to that wizard, all in order to make you create it. Then she joined us in order to weaken the Empire to make it fall easier after the cataclysm. This mage said to us that it was Akula who gave him the information."
+            [/message]
+            [message]
+                speaker=Dantair
+                message= _ "Akula... Akula the betrayer is behind all of this... But how may I trust you? Because one unimportant wizard said so?"
+            [/message]
+            {CLEAR_VARIABLE progress}
+            [recall]
+                id=Akula
+                x,y=13,5
+            [/recall]
+            [message]
+                speaker=Akula
+                message= _ "I have decided that you are no longer helpful to me. So you will be killed."
+            [/message]
+            [message]
+                speaker=Efraim
+                message= _ "You think you can kill us?"
+            [/message]
+            [message]
+                speaker=Akula
+                message= _ "You think I am just a mere undead? I am not. When I was still breathing, I have found an interesting place during an excavation. Remains of an ancient underground colony. With unimaginable inventions. I tried to use one of them, but it stabbed me. It replaced a part of my organs, and it caused me to die. But I knew the secrets of necromancy. I kept myself in this world binding my soul to a massive metallic instrument that seemed to be commanding the mechanical part of my body. I regained the full control of my body, with superhuman strength and resilience. It keeps a part of my body alive, because it needs something to digest food. And also it makes me look alive."
+            [/message]
+            [message]
+                speaker=Efraim
+                message= _ "Impressive."
+            [/message]
+            [message]
+                speaker=Akula
+                message= _ "But I no longer need to look human so much. Look what I really am!"
+            [/message]
+            {ADVANCE_UNIT id=Akula Akula_steel}
+            [message]
+                speaker=Akula
+                message= _ "And prepare to die now!"
+            [/message]
+            {VARIABLE recall_count 50}
+            [while]
+                [variable]
+                    name=recall_count
+                    greater_than=1
+                [/variable]
+                [do]
+                    {VARIABLE_OP recall_count add -1}
+                    [recall]
+                        x,y=13,5
+                    [/recall]
+                [/do]
+            [/while]
+            {CLEAR_VARIABLE recall_count}
+            {MODIFY_UNIT (side=1
+            [not]
+                id=Efraim
+            [/not]
+            [not]
+                id=Lethalia
+            [/not]
+            [not]
+                id=Dantair
+            [/not]      ) side 4}
+            [message]
+                speaker=Dantair
+                message= _ "What the hell is that thing? I will not create that sun, I promise, just stop that beast of steel!"
+            [/message]
+            [kill]
+                id=Dantair
+                animate=no
+            [/kill]
+            [message]
+                speaker=Efraim
+                message= _ "I wonder how many of them walks this world..."
+            [/message]
+            [objectives]
+                summary= _ "New Objectives:"
+                show=yes
+                side=1
+                [objective]
+                    description= _ "Defeat Akula"
+                    condition=win
+                [/objective]
+                [objective]
+                    description= _ "Destruction of Efraim or Lethalia"
+                    condition=lose
+                [/objective]
+            [/objectives]
+            [modify_turns]
+                value=-1
+            [/modify_turns]
+            [replace_schedule]
+                {DOUBLE_SUN}
+            [/replace_schedule]
+            [modify_side]
+                side=3
+                team_name=Good
+                user_team_name=_"Good"
+            [/modify_side]
+            [modify_side]
+                side=2
+                team_name=Good
+                user_team_name=_"Good"
+            [/modify_side]
+        [/event]
+        [event]
+            name=time over
+            {COLOR_ADJUST 30 30 30}
+            [message]
+                speaker=Lethalia
+                message= _ "The dawn breaks."
+            [/message]
+        [/event]
+        [event]
+            name=last breath
             [filter]
                 id=Lethalia
             [/filter]
-            [effect]
-                apply_to=attack
-                remove_specials=plague,plague(Soulless),plague(Faerie Fire Unit)
-            [/effect]
-            [effect]
-                apply_to=new_ability
-                [abilities]
-                    [hides]
-                        id=nightstalk
-                        name= _ "nightstalk"
-                        female_name= _ "nightstalk"
-                        description= _ "The unit becomes invisible during night.
-
-Enemy units cannot see this unit at night, except if they have units next to it. Any enemy unit that first discovers this unit immediately loses all its remaining movement."
-                        name_inactive= _ "nightstalk"
-                        female_name_inactive= _ "female^nightstalk"
-                        description_inactive= _ "The unit becomes invisible during night.
-
-Enemy units cannot see this unit at night, except if they have units next to it. Any enemy unit that first discovers this unit immediately loses all its remaining movement."
-                        affect_self=yes
-                        alert="Detected!"
-                        [filter_self]
-                            [filter_location]
-                                time_of_day=chaotic
-                            [/filter_location]
-                        [/filter_self]
-                    [/hides]
-                [/abilities]
-            [/effect]
-            [effect]
-                apply_to=remove_abilities
-                [abilities]
-                    [illuminates]
-                        id=illumination
-                    [/illuminates]
-                    [illuminates]
-                        id=improved illumination
-                    [/illuminates]
-                    [illuminates]
-                        id=great illumination
-                    [/illuminates]
-                    [illuminates]
-                        id=darkens
-                    [/illuminates]
-                    [illuminates]
-                        id=darkens badly
-                    [/illuminates]
-                    [illuminates]
-                        id=darkens severely
-                    [/illuminates]
-                [/abilities]
-            [/effect]
-        [/object]
-    [/event]
-    [event]
-        #Makes the guards wander around the map.
-        name=side turn
-        first_time_only=no
-        [if]
-            [variable]
-                name=side_number
-                equals=4
-            [/variable]
-            [then]
-                [store_unit]
-                    [filter]
-                        side=3
-                    [/filter]
-                    kill=no
-                    variable=movement_store
-                [/store_unit]
-                {FOREACH movement_store i}
-                    [if]
-                        [variable]
-                            name=movement_store[$i].attacks_left
-                            greater_than=0
-                        [/variable]
-                        [then]
-                            {VARIABLE_OP move_x rand (-3,-2,-1,0,1,2,3)}
-                            {VARIABLE_OP move_y rand (-3,-2,-1,0,1,2,3)}
-                            {VARIABLE moveto_x $movement_store[$i].x}
-                            {VARIABLE moveto_y $movement_store[$i].y}
-                            {VARIABLE_OP moveto_x add $move_x}
-                            {VARIABLE_OP moveto_y add $move_y}
-                            [if]
-                                [variable]
-                                    name=moveto_x
-                                    less_than=45
-                                [/variable]
-                                [and]
-                                    [variable]
-                                        name=moveto_x
-                                        greater_than=0
-                                    [/variable]
-                                [/and]
-                                [and]
-                                    [variable]
-                                        name=moveto_y
-                                        greater_than=0
-                                    [/variable]
-                                [/and]
-                                [and]
-                                    [variable]
-                                        name=moveto_y
-                                        less_than=34
-                                    [/variable]
-                                [/and]
-                                [then]
-                                    {MOVE_UNIT x,y=$movement_store[$i].x,$movement_store[$i].y $moveto_x $moveto_y}
-                                [/then]
-                            [/if]
-                        [/then]
-                    [/if]
-                {NEXT i}
-                {CLEAR_VARIABLE move_x}
-                {CLEAR_VARIABLE move_y}
-                {CLEAR_VARIABLE moveto_x}
-                {CLEAR_VARIABLE moveto_y}
-                {CLEAR_VARIABLE movement_store}
-            [/then]
-        [/if]
-    [/event]
-    [event]
-        name=attack
-        [filter]
-            side=3
-        [/filter]
-        [filter_second]
-            side=1
-        [/filter_second]
+            [message]
+                speaker=unit
+                message= _ "How could this happen?"
+            [/message]
+            [endlevel]
+                result=defeat
+            [/endlevel]
+        [/event]
+        [event]
+            name=last breath
+            [filter]
+                id=Efraim
+            [/filter]
+            [message]
+                speaker=unit
+                message= _ "How could this happen to me?"
+            [/message]
+            [endlevel]
+                result=defeat
+            [/endlevel]
+        [/event]
+        [event]
+            name=last breath
+            [filter]
+                id=Akula
+            [/filter]
+            [message]
+                speaker=Akula
+                message= _ "This is not over yet... I can teleport away, I have prepared the spell... And you will see my semi-undead, semi-mechanical army!"
+            [/message]
+            {MODIFY_UNIT (side=4
+            [not]
+                race=human
+            [/not]
+            [not]
+                id=Akula
+            [/not]
+        ) side 1}
         [message]
-            speaker=unit
-            message=_ "Mugger! You are under arrest! No... you are... ALARM! REINFORCEMENTS! I have found the necromancers!"
+            speaker=Efraim
+            message= _ "What a fool she was. It was so obvious she had a teleportation spell prepared. I have secretly enchanted her to know where she moves. Not a powerful spell, it was hard to get past her defences, but it lasted for a short while - so now I perfectly know where she went. Into the northern mountains."
         [/message]
+        [store_unit]
+            [filter]
+                id=Efraim
+            [/filter]
+            variable=gifted
+            kill=yes
+        [/store_unit]
+        {VARIABLE i 0}
+        [while]
+            [variable]
+                name=i
+                less_than=$gifted.modifications.object.length
+            [/variable]
+            [do]
+                [if]
+                    [variable]
+                        name=gifted.modifications.object[$i].id
+                        equals=Sneak
+                    [/variable]
+                    [then]
+                        {CLEAR_VARIABLE gifted.modifications.object[$i]}
+                    [/then]
+                    [else]
+                        [set_variable]
+                            name=i
+                            add=1
+                        [/set_variable]
+                    [/else]
+                [/if]
+            [/do]
+        [/while]
+        {CLEAR_VARIABLE i}
+        [unit]
+            side=1
+            x=$gifted.x
+            y=$gifted.y
+            experience=$gifted.experience
+            canrecruit=yes
+            type=Efraim_lich
+            id=Efraim
+            gender=male
+            name=Efraim
+            underlying_id=$gifted.underlying_id
+            unrenamable=yes
+            animate=no
+            [insert_tag]
+                name=modifications
+                variable=gifted.modifications
+            [/insert_tag]
+            [insert_tag]
+                name=variables
+                variable=gifted.variables
+            [/insert_tag]
+        [/unit]
+        [store_unit]
+            [filter]
+                id=Lethalia
+            [/filter]
+            variable=gifted
+            kill=yes
+        [/store_unit]
+        {VARIABLE i 0}
+        [while]
+            [variable]
+                name=i
+                less_than=$gifted.modifications.object.length
+            [/variable]
+            [do]
+                [if]
+                    [variable]
+                        name=gifted.modifications.object[$i].id
+                        equals=Sneak_Lethalia
+                    [/variable]
+                    [then]
+                        {CLEAR_VARIABLE gifted.modifications.object[$i]}
+                    [/then]
+                    [else]
+                        [set_variable]
+                            name=i
+                            add=1
+                        [/set_variable]
+                    [/else]
+                [/if]
+            [/do]
+        [/while]
+        {CLEAR_VARIABLE i}
+        [unit]
+            side=1
+            x=$gifted.x
+            y=$gifted.y
+            experience=$gifted.experience
+            canrecruit=yes
+            type=Lethalia_lich
+            id=Lethalia
+            gender=male
+            name=Lethalia
+            underlying_id=$gifted.underlying_id
+            unrenamable=yes
+            animate=no
+            [insert_tag]
+                name=modifications
+                variable=gifted.modifications
+            [/insert_tag]
+            [insert_tag]
+                name=variables
+                variable=gifted.variables
+            [/insert_tag]
+        [/unit]
+        [fire_event]
+            name=Efraim_update
+            [primary_unit]
+                id=Efraim
+            [/primary_unit]
+        [/fire_event]
         [endlevel]
-            result=defeat
+            result=victory
+            bonus=no
         [/endlevel]
     [/event]
     [event]
-        name=moveto
-        [filter]
-            x,y=2-3,23-27
-            side=1
-        [/filter]
-        {ANTIASSASSIN_UNIT 4 Assassin 2 22}
-        {ANTIASSASSIN_UNIT 4 Rogue 2 26}
-        {ANTIASSASSIN_UNIT 4 Rogue 3 27}
-        {ANTIASSASSIN_UNIT 4 Thief 3 23}
-        [message]
-            speaker=unit
-            message= _ "Damn, I was mugged. Well, boys, you will get to paradise very quickly."
-        [/message]
+        name=Efraim_update
+        {UPDATE_STATS}
+        [fire_event]
+            name=Lethalia_update
+            [primary_unit]
+                id=Lethalia
+            [/primary_unit]
+        [/fire_event]
     [/event]
     [event]
-        name=moveto
-        [filter]
-            x,y=11-15,12-15
-            side=1
-        [/filter]
-        {ANTIASSASSIN_UNIT 4 Assassin 13 13}
-        {ANTIASSASSIN_UNIT 4 Rogue 12 14}
-        {ANTIASSASSIN_UNIT 4 Rogue 15 14}
-        {ANTIASSASSIN_UNIT 4 Assassin 13 16}
-        [message]
-            speaker=unit
-            message= _ "Haha, you want to fight?"
-        [/message]
-    [/event]
-    [event]
-        name=moveto
-        [filter]
-            x,y=27-30,9-13
-            side=1
-        [/filter]
-        {ANTIASSASSIN_UNIT 4 Assassin 28 10}
-        {ANTIASSASSIN_UNIT 4 Rogue 30 11}
-        {ANTIASSASSIN_UNIT 4 Highwayman 29 12}
-        {ANTIASSASSIN_UNIT 4 Assassin 31 10}
-        [message]
-            speaker=unit
-            message= _ "Run if you do not want your tongues cut away."
-        [/message]
-    [/event]
-    [event]
-        name=moveto
-        [filter]
-            x,y=39-42,27-32
-            side=1
-        [/filter]
-        {ANTIASSASSIN_UNIT 4 Assassin 44 26}
-        {ANTIASSASSIN_UNIT 4 Rogue 39 28}
-        {ANTIASSASSIN_UNIT 4 Rogue 41 32}
-        {ANTIASSASSIN_UNIT 4 Assassin 44 31}
-        [message]
-            speaker=unit
-            message= _ "Damn, I was mugged. Hearken ye, leave or I can assure you that you will get to paradise very quickly."
-        [/message]
-    [/event]
-    [event]
-        name=moveto
-        [filter]
-            x,y=11-17,1-4
-            side=1
-        [/filter]
-        [message]
-            speaker=unit
-            message= _ "We have found you."
-        [/message]
-        {MOVE_UNIT id=Efraim 13 2}
-        {MOVE_UNIT id=Lethalia 12 2}
-        [message]
-            speaker=Efraim
-            message= _ "How did you get to the information how to create the second sun?"
-        [/message]
-        [message]
-            speaker=Taruk
-            message= _ "I was just lucky, I just looked somewhere and it was there?"
-        [/message]
-        [message]
-            speaker=Lethalia
-            message= _ "Where?"
-        [/message]
-        [message]
-            speaker=Taruk
-            message= _ "Ehm, hm... Well, it was in... inside... a hole... inside a hole..."
-        [/message]
-        [message]
-            speaker=Lethalia
-            message= _ "You are lying. You have not found it. Who gave it to you?"
-        [/message]
-        [message]
-            speaker=Taruk
-            message= _ "One of King's counsellors, Akula."
-        [/message]
-        [message]
-            speaker=Lethalia
-            message= _ "Akula?!"
-        [/message]
-        [message]
-            speaker=Efraim
-            message= _ "Now everything looks more reasonable. She is an undead. That explains her huge resistance to damage. She might be a person who can get to that information. And she wants to destroy the Empire and create a huge chaos, and possibly to come to control it after. She poisoned the old king, gave the information to Taruk, who came up with an idea to create the third sun, and the king needed it to stop the doubts about his rule, so he decided so. And she joined us to destabilise the Empire to make sure it will not survive the cataclysm. If he decided not to create the third sun, she would have used her political power to steal the throne like the king suspected. A brilliant plan."
-        [/message]
-        [message]
-            speaker=Lethalia
-            message= _ "She is not able to decrypt the information. And I cannot imagine how can she build a kingdom from the ashes of the old Empire after the cataclysm. And by the way, I saw Akula bleed after that she was cut, she is definitely a different of undead than we are. If she even is an undead."
-        [/message]
-        [message]
-            speaker=Efraim
-            message= _ "Do you have a better explanation?"
-        [/message]
-        [message]
-            speaker=Lethalia
-            message= _ "No. Yours have flaws, but fits quite well."
-        [/message]
-        [message]
-            speaker=Efraim
-            message= _ "I will create a projection of King Dantair."
-        [/message]
-        [unit]
-            id=Dantair
-            profile="portraits/humans/marshal-2.png"
-            name= _ "King Dantair"
-            type=Royal Warrior
-            side=1
-            x,y=14,2
-            canrecruit=yes
-            recruit=
-            random_traits=yes
-        [/unit]
-        [message]
-            speaker=Dantair
-            message= _ "What do you want from me?"
-        [/message]
-        [message]
-            speaker=Efraim
-            message= _ "We have found out that it was Akula who was behind all of this. She killed the king, gave the information how to raise new suns to that wizard, all in order to make you create it. Then she joined us in order to weaken the Empire to make it fall easier after the cataclysm. This mage said to us that it was Akula who gave him the information."
-        [/message]
-        [message]
-            speaker=Dantair
-            message= _ "Akula... Akula the betrayer is behind all of this... But how may I trust you? Because one unimportant wizard said so?"
-        [/message]
-        {CLEAR_VARIABLE progress}
-        [recall]
-            id=Akula
-            x,y=13,5
-        [/recall]
-        [message]
-            speaker=Akula
-            message= _ "I have decided that you are no longer helpful to me. So you will be killed."
-        [/message]
-        [message]
-            speaker=Efraim
-            message= _ "You think you can kill us?"
-        [/message]
-        [message]
-            speaker=Akula
-            message= _ "You think I am just a mere undead? I am not. When I was still breathing, I have found an interesting place during an excavation. Remains of an ancient underground colony. With unimaginable inventions. I tried to use one of them, but it stabbed me. It replaced a part of my organs, and it caused me to die. But I knew the secrets of necromancy. I kept myself in this world binding my soul to a massive metallic instrument that seemed to be commanding the mechanical part of my body. I regained the full control of my body, with superhuman strength and resilience. It keeps a part of my body alive, because it needs something to digest food. And also it makes me look alive."
-        [/message]
-        [message]
-            speaker=Efraim
-            message= _ "Impressive."
-        [/message]
-        [message]
-            speaker=Akula
-            message= _ "But I no longer need to look human so much. Look what I really am!"
-        [/message]
-        {ADVANCE_UNIT id=Akula Akula_steel}
-        [message]
-            speaker=Akula
-            message= _ "And prepare to die now!"
-        [/message]
-        {VARIABLE recall_count 50}
-        [while]
-            [variable]
-                name=recall_count
-                greater_than=1
-            [/variable]
-            [do]
-                {VARIABLE_OP recall_count add -1}
-                [recall]
-                    x,y=13,5
-                [/recall]
-            [/do]
-        [/while]
-        {CLEAR_VARIABLE recall_count}
-        {MODIFY_UNIT (side=1
-        [not]
-            id=Efraim
-        [/not]
-        [not]
-            id=Lethalia
-        [/not]
-        [not]
-            id=Dantair
-        [/not]
-    ) side 4}
-    [message]
-        speaker=Dantair
-        message= _ "What the hell is that thing? I will not create that sun, I promise, just stop that beast of steel!"
-    [/message]
-    [kill]
-        id=Dantair
-        animate=no
-    [/kill]
-    [message]
-        speaker=Efraim
-        message= _ "I wonder how many of them walks this world..."
-    [/message]
-    [objectives]
-        summary= _ "New Objectives:"
-        show=yes
-        side=1
-        [objective]
-            description= _ "Defeat Akula"
-            condition=win
-        [/objective]
-        [objective]
-            description= _ "Destruction of Efraim or Lethalia"
-            condition=lose
-        [/objective]
-    [/objectives]
-    [modify_turns]
-        value=-1
-    [/modify_turns]
-    [replace_schedule]
-        {DOUBLE_SUN}
-    [/replace_schedule]
-    [modify_side]
-        side=3
-        team_name=Good
-        user_team_name=_"Good"
-    [/modify_side]
-    [modify_side]
-        side=2
-        team_name=Good
-        user_team_name=_"Good"
-    [/modify_side]
-[/event]
-[event]
-    name=time over
-    {COLOR_ADJUST 30 30 30}
-    [message]
-        speaker=Lethalia
-        message= _ "The dawn breaks."
-    [/message]
-[/event]
-[event]
-    name=last breath
-    [filter]
-        id=Lethalia
-    [/filter]
-    [message]
-        speaker=unit
-        message= _ "How could this happen?"
-    [/message]
-    [endlevel]
-        result=defeat
-    [/endlevel]
-[/event]
-[event]
-    name=last breath
-    [filter]
-        id=Efraim
-    [/filter]
-    [message]
-        speaker=unit
-        message= _ "How could this happen to me?"
-    [/message]
-    [endlevel]
-        result=defeat
-    [/endlevel]
-[/event]
-[event]
-    name=last breath
-    [filter]
-        id=Akula
-    [/filter]
-    [message]
-        speaker=Akula
-        message= _ "This is not over yet... I can teleport away, I have prepared the spell... And you will see my semi-undead, semi-mechanical army!"
-    [/message]
-    {MODIFY_UNIT (side=4
-    [not]
-        race=human
-    [/not]
-    [not]
-        id=Akula
-    [/not]
-) side 1}
-[message]
-    speaker=Efraim
-    message= _ "What a fool she was. It was so obvious she had a teleportation spell prepared. I have secretly enchanted her to know where she moves. Not a powerful spell, it was hard to get past her defences, but it lasted for a short while - so now I perfectly know where she went. Into the northern mountains."
-[/message]
-[store_unit]
-    [filter]
-        id=Efraim
-    [/filter]
-    variable=gifted
-    kill=yes
-[/store_unit]
-{VARIABLE i 0}
-[while]
-    [variable]
-        name=i
-        less_than=$gifted.modifications.object.length
-    [/variable]
-    [do]
-        [if]
-            [variable]
-                name=gifted.modifications.object[$i].id
-                equals=Sneak
-            [/variable]
-            [then]
-                {CLEAR_VARIABLE gifted.modifications.object[$i]}
-            [/then]
-            [else]
-                [set_variable]
-                    name=i
-                    add=1
-                [/set_variable]
-            [/else]
-        [/if]
-    [/do]
-[/while]
-{CLEAR_VARIABLE i}
-[unit]
-    side=1
-    x=$gifted.x
-    y=$gifted.y
-    experience=$gifted.experience
-    canrecruit=yes
-    type=Efraim_lich
-    id=Efraim
-    gender=male
-    name=Efraim
-    underlying_id=$gifted.underlying_id
-    unrenamable=yes
-    animate=no
-    [insert_tag]
-        name=modifications
-        variable=gifted.modifications
-    [/insert_tag]
-    [insert_tag]
-        name=variables
-        variable=gifted.variables
-    [/insert_tag]
-[/unit]
-[store_unit]
-    [filter]
-        id=Lethalia
-    [/filter]
-    variable=gifted
-    kill=yes
-[/store_unit]
-{VARIABLE i 0}
-[while]
-    [variable]
-        name=i
-        less_than=$gifted.modifications.object.length
-    [/variable]
-    [do]
-        [if]
-            [variable]
-                name=gifted.modifications.object[$i].id
-                equals=Sneak_Lethalia
-            [/variable]
-            [then]
-                {CLEAR_VARIABLE gifted.modifications.object[$i]}
-            [/then]
-            [else]
-                [set_variable]
-                    name=i
-                    add=1
-                [/set_variable]
-            [/else]
-        [/if]
-    [/do]
-[/while]
-{CLEAR_VARIABLE i}
-[unit]
-    side=1
-    x=$gifted.x
-    y=$gifted.y
-    experience=$gifted.experience
-    canrecruit=yes
-    type=Lethalia_lich
-    id=Lethalia
-    gender=male
-    name=Lethalia
-    underlying_id=$gifted.underlying_id
-    unrenamable=yes
-    animate=no
-    [insert_tag]
-        name=modifications
-        variable=gifted.modifications
-    [/insert_tag]
-    [insert_tag]
-        name=variables
-        variable=gifted.variables
-    [/insert_tag]
-[/unit]
-[fire_event]
-    name=Efraim_update
-    [primary_unit]
-        id=Efraim
-    [/primary_unit]
-[/fire_event]
-[endlevel]
-    result=victory
-    bonus=no
-[/endlevel]
-[/event]
-[event]
-    name=Efraim_update
-    {UPDATE_STATS}
-    [fire_event]
         name=Lethalia_update
-        [primary_unit]
-            id=Lethalia
-        [/primary_unit]
-    [/fire_event]
-[/event]
-[event]
-    name=Lethalia_update
-    {UPDATE_STATS}
-[/event]
+        {UPDATE_STATS}
+    [/event]
 
-{NO_FAST_AI}
+    {NO_FAST_AI}
 
-{FORCE_CHANCE_TO_HIT side=1 id=Taruk 0 ()}
-{DROPS 2 3 (sword,knife,dagger,staff) no 3,4}
+    {FORCE_CHANCE_TO_HIT side=1 id=Taruk 0 ()}
+    {DROPS 2 3 (sword,knife,dagger,staff) no 3,4}
 
-experience_modifier=125
+    experience_modifier=125
 [/scenario]
 
 #undef ANTIASSASSIN_UNIT

--- a/scenarios8/05_Investigations.cfg
+++ b/scenarios8/05_Investigations.cfg
@@ -741,7 +741,7 @@
             radius=3
             max_x=56
             max_y=41
-            avoid_terrain_list="Hh^Fds,Hh^Fms,Ww,Gs^Fms,Gs^Fds,Mm"
+            avoid_terrain_list="Hh^Fds,Hh^Fms,Ww,Gs^Fms,Gs^Fds,Hh^Mm,Mm"
         [/make_units_wander]
     [/event]
     {NO_FAST_AI}

--- a/scenarios8/05_Investigations.cfg
+++ b/scenarios8/05_Investigations.cfg
@@ -734,102 +734,15 @@
         #Makes the guards wander around the map.
         name=side 2 turn
         first_time_only=no
-        [store_unit]
+        [make_units_wander]
             [filter]
                 side=2
             [/filter]
-            kill=no
-            variable=movement_store
-        [/store_unit]
-        [foreach]
-            array=movement_store
-            [do]
-                {VARIABLE_OP move_x rand (-3,-2,-1,0,1,2,3)}
-                {VARIABLE_OP move_y rand (-3,-2,-1,0,1,2,3)}
-                {VARIABLE moveto_x $movement_store[$i].x}
-                {VARIABLE moveto_y $movement_store[$i].y}
-                {VARIABLE_OP moveto_x add $move_x}
-                {VARIABLE_OP moveto_y add $move_y}
-                [store_locations]
-                    x,y=$moveto_x,$moveto_y
-                    variable=target_hex
-                [/store_locations]
-                [if]
-                    [variable]
-                        name=moveto_x
-                        less_than=57
-                    [/variable]
-                    [and]
-                        [variable]
-                            name=moveto_x
-                            greater_than=0
-                        [/variable]
-                    [/and]
-                    [and]
-                        [variable]
-                            name=moveto_y
-                            greater_than=0
-                        [/variable]
-                    [/and]
-                    [and]
-                        [variable]
-                            name=moveto_y
-                            less_than=42
-                        [/variable]
-                    [/and]
-                    [and]
-                        [variable]
-                            name=target_hex.terrain
-                            not_equals=Hh^Fds
-                        [/variable]
-                    [/and]
-                    [and]
-                        [variable]
-                            name=target_hex.terrain
-                            not_equals=Hh^Fms
-                        [/variable]
-                    [/and]
-                    [and]
-                        [variable]
-                            name=target_hex.terrain
-                            not_equals=Hh^Mm
-                        [/variable]
-                    [/and]
-                    [and]
-                        [variable]
-                            name=target_hex.terrain
-                            not_equals=Ww
-                        [/variable]
-                    [/and]
-                    [and]
-                        [variable]
-                            name=target_hex.terrain
-                            not_equals=Gs^Fms
-                        [/variable]
-                    [/and]
-                    [and]
-                        [variable]
-                            name=target_hex.terrain
-                            not_equals=Gs^Fds
-                        [/variable]
-                    [/and]
-                    [and]
-                        [variable]
-                            name=target_hex.terrain
-                            not_equals=Mm
-                        [/variable]
-                    [/and]
-                    [then]
-                        {MOVE_UNIT x,y=$this_item.x,$this_item.y $moveto_x $moveto_y}
-                    [/then]
-                [/if]
-            [/do]
-        [/foreach]
-        {CLEAR_VARIABLE move_x}
-        {CLEAR_VARIABLE move_y}
-        {CLEAR_VARIABLE moveto_x}
-        {CLEAR_VARIABLE moveto_y}
-        {CLEAR_VARIABLE movement_store,target_hex}
+            radius=3
+            max_x=56
+            max_y=41
+            avoid_terrain_list="Hh^Fds,Hh^Fms,Ww,Gs^Fms,Gs^Fds,Mm"
+        [/make_units_wander]
     [/event]
     {NO_FAST_AI}
 


### PR DESCRIPTION
While working on FOREACH, I found several scenarios that "Make guards/demons wander", so I made a function to handle that.

Broke out is_in_list so it could be used for lua as well as wml
Added support for ^ in is_in_list to handle terrain types

Around these blocks there is usually code which looks like it is supposed to make only units that can't see our team wander, mostly by changing the units' side.  But it's done differently just about each time, or at least it looks that way to me, so I didn't want to tackle that without really understanding what was going on.  It might be worth a look, though I played all of these and they play okay.

BTW, while I was testing 10/01_Despair, I saw these dropped at the beginning:
        - 4 scythe, all Exerminators
        - 2 armor, both the same
        - 2 mace, both fighting bull
        - no other item sort had >1 drop

Almost as if the item.sort is picked randomly, and then the item type within that group is always (the first???).  Pretty sure this is new.  I don't think I've touched drops (yet), except adding the fake turn number for Nightmare Cellar.  Could be dumb luck, if I believed in that sort of thing.