### PR TITLE
keep bzb drops on map

### DIFF
--- a/utils/utils.cfg
+++ b/utils/utils.cfg
@@ -1502,19 +1502,69 @@ $item_info.description"
                     {VARIABLE seen_beelzebub_die true}
                 [/else]
             [/if]
+            # BEGIN Set up the center for the dropped item pool, adjusting for edges of map if necessary
+            [store_map_dimensions]
+                variable=map_size
+            [/store_map_dimensions]
+            {VARIABLE drop_x $x1}
+            {VARIABLE drop_y $y1}
+            {VARIABLE radius 3}
+            {VARIABLE drop_min $radius}
+            {VARIABLE_OP drop_min add 1}
+            {VARIABLE drop_max_x $map_size.width}
+            {VARIABLE_OP drop_max_x sub 3}
+            {VARIABLE drop_max_y $map_size.height}
+            {VARIABLE_OP drop_max_y sub 3}
+            [if]
+                [variable]
+                    name=drop_x
+                    less_than=$drop_min
+                [/variable]
+                [then]
+                    {VARIABLE drop_x $drop_min}
+                [/then]
+            [/if]
+            [if]
+                [variable]
+                    name=drop_x
+                    greater_than=$drop_max_x
+                [/variable]
+                [then]
+                    {VARIABLE drop_x $drop_max_x}
+                [/then]
+            [/if]
+            [if]
+                [variable]
+                    name=drop_y
+                    less_than=$drop_min
+                [/variable]
+                [then]
+                    {VARIABLE drop_y $drop_min}
+                [/then]
+            [/if]
+            [if]
+                [variable]
+                    name=drop_y
+                    greater_than=$drop_max_y
+                [/variable]
+                [then]
+                    {VARIABLE drop_y $drop_max_y}
+                [/then]
+            [/if]
+            # END Set up the center for the dropped item pool, adjusting for edges of map if necessary
             [store_locations]
-                x,y=$x1,$y1
-                radius=3
+                x,y=$drop_x,$drop_y
+                radius=$radius
                 variable=nearby
             [/store_locations]
-            {RARE_ITEM $x1 $y1}
+            {RARE_ITEM $drop_x $drop_y}
             [foreach]
                 array=nearby
                 [do]
                     {DEFAULT_DROP_ITEM $this_item.x $this_item.y (axe,axe,staff,sword,sword,knife,bow,xbow,spear,spear,bow,dagger,mace)}
                 [/do]
             [/foreach]
-            {CLEAR_VARIABLE nearby}
+            {CLEAR_VARIABLE drop_x,drop_y,drop_min,drop_max_x,drop_max_y,radius,map_size,nearby}
             {VARIABLE_OP saved_turns sub 500}
         [/event]
     [/event]


### PR DESCRIPTION
Just moved ground zero for the drops away from the edge of the map, if necessary.

Closes  #596