### PR TITLE
fix traders allowing credit

### DIFF
--- a/utils/utils.cfg
+++ b/utils/utils.cfg
@@ -195,6 +195,7 @@
             side=$unit.side
             amount=-{COST}
         [/gold]
+        {VARIABLE_OP gold sub {COST}}
     [/command]
 #enddef
 #define SELL_GEMS
@@ -281,6 +282,7 @@ $item_info.description"
                                     side=$side_number
                                     amount=-{PRICE}
                                 [/gold]
+                                {VARIABLE_OP gold sub {PRICE}}
                                 {VARIABLE_OP items_dropped add 1}
                                 {VARIABLE {VARIABLE_NAME} 1}
                                 [fire_event]


### PR DESCRIPTION
Buying items from trader was only decrementing the global gold value, not the local gold variable which controlled what you were allowed to buy.

There are too many different trader implementations, IMO.   A project for another day.