### PR TITLE
use macro for teleport_to_leader

### DIFF
--- a/scenarios6/09_Across_the_Barren_Land.cfg
+++ b/scenarios6/09_Across_the_Barren_Land.cfg
@@ -213,7 +213,6 @@ You can teleport all units to your leader once per ten turns (see option in the 
         {RARE_ITEM 9 28}
         {RARE_ITEM 4 4}
         {RARE_ITEM 54 3}
-        {VARIABLE teleport_wait 10}
     [/event]
 
     [side]
@@ -583,47 +582,7 @@ You can teleport all units to your leader once per ten turns (see option in the 
     [/event]
     [event]
         name=start
-        [set_menu_item]
-            id=zz_ch6s9_teleport
-            description= _ "Teleport units to leader"
-            [show_if]
-                [have_unit]
-                    x,y=$x1,$y1
-                    id=$leader_chosen
-                [/have_unit]
-                [and]
-                    [variable]
-                        name=teleport_wait
-                        greater_than_equal_to=10
-                    [/variable]
-                [/and]
-            [/show_if]
-            [command]
-                {VARIABLE teleport_wait 0}
-                [store_unit]
-                    [filter]
-                        side=1
-                        canrecruit=no
-                    [/filter]
-                    kill=no
-                    variable=teleport_store
-                [/store_unit]
-                [foreach]
-                    array=teleport_store
-                    [do]
-                        [teleport]
-                            [filter]
-                                id=$teleport_store[$i].id
-                            [/filter]
-                            x,y=$x1,$y1
-                            clear_shroud=yes
-                            animate=no
-                        [/teleport]
-                    [/do]
-                [/foreach]
-                {CLEAR_VARIABLE teleport_store}
-            [/command]
-        [/set_menu_item]
+        {TELEPORT_TO_LEADER_MENU Efraim 10 10 10}
         [message]
             speaker=$leader_chosen
             message= _ "Behind this desert, there should be a mountain range. Behind the mountain range, there should be another desert, or a steppe. Behind that desert or steppe, there should be another mountain range. The Heart Mountains. Behind them, there should be the end of these barren lands."
@@ -680,7 +639,6 @@ You can teleport all units to your leader once per ten turns (see option in the 
                 {VARIABLE_OP spawn_x rand (5,55)}
                 {VARIABLE_OP spawn_y rand (145,65,10)}
                 {GENERIC_UNIT 5 $spawn_type $spawn_x $spawn_y}
-                {VARIABLE_OP teleport_wait add 1}
                 {CLEAR_VARIABLE spawn_type,spawn_x,spawn_y}
             [/then]
         [/if]
@@ -714,7 +672,6 @@ You can teleport all units to your leader once per ten turns (see option in the 
         {CLEAR_VARIABLE i2}
         {CLEAR_VARIABLE i3}
         {CLEAR_VARIABLE i4}
-        {CLEAR_VARIABLE teleport_wait}
         [endlevel]
             result=victory
             bonus=no

--- a/scenarios7/05_Tundra.cfg
+++ b/scenarios7/05_Tundra.cfg
@@ -199,7 +199,6 @@
     [event]
         name=prestart
         {VARIABLE can_build_encampment 1}
-        {VARIABLE teleport_wait 10}
         {CAPTURE_VILLAGES 1 54 87 12}
 #ifdef HARD
         {VARIABLE spawn_count 60}
@@ -308,49 +307,7 @@ You can build a keep anywhere for 50 gold (see options in the right-click menu).
 
     [event]
         name=start
-        [set_menu_item]
-            id=zz_ch6s9_teleport
-            description= _ "Teleport units to leader"
-            [show_if]
-                [have_unit]
-                    x,y=$x1,$y1
-                    id=Efraim
-                [/have_unit]
-                [and]
-                    [variable]
-                        name=teleport_wait
-                        greater_than_equal_to=10
-                    [/variable]
-                [/and]
-            [/show_if]
-            [command]
-                {VARIABLE teleport_wait 0}
-                [store_unit]
-                    [filter]
-                        side=1
-                        [not]
-                            id=Efraim
-                        [/not]
-                    [/filter]
-                    kill=no
-                    variable=teleport_store
-                [/store_unit]
-                [foreach]
-                    array=teleport_store
-                    [do]
-                        [teleport]
-                            [filter]
-                                id=$this_item.id
-                            [/filter]
-                            x,y=$x1,$y1
-                            clear_shroud=yes
-                            animate=no
-                        [/teleport]
-                    [/do]
-                [/foreach]
-                {CLEAR_VARIABLE teleport_store}
-            [/command]
-        [/set_menu_item]
+        {TELEPORT_TO_LEADER_MENU Efraim 10 10 10}
         [set_menu_item]
             id=zz_ch7s5_camp
             description= _ "Build an encampment"
@@ -505,7 +462,7 @@ You can build a keep anywhere for 50 gold (see options in the right-click menu).
             speaker=Efraim
             message= _ "Excellent! Let us enter it."
         [/message]
-        {CLEAR_VARIABLE teleport_wait,can_build_encampment}
+        {CLEAR_VARIABLE can_build_encampment}
         [endlevel]
             result=victory
             bonus=no
@@ -537,7 +494,6 @@ You can build a keep anywhere for 50 gold (see options in the right-click menu).
                 equals=1
             [/variable]
             [then]
-                {VARIABLE_OP teleport_wait add 1}
                 {VARIABLE_OP random rand (0,0,1)}
                 [if]
                     [variable]

--- a/scenarios7/14_Arctic_Wastelands.cfg
+++ b/scenarios7/14_Arctic_Wastelands.cfg
@@ -375,7 +375,6 @@
         name=prestart
         {VARIABLE can_build_encampment 1}
         {VARIABLE can_build_igloo 1}
-        {VARIABLE teleport_wait 10}
         {CAPTURE_VILLAGES 1 94 85 10}
 #ifdef HARD
         {VARIABLE spawn_count 60}
@@ -426,49 +425,7 @@ You can build a keep anywhere for 50 gold, or a village for 10 gold. (see option
         {RARE_ITEM 64 4}
         {RARE_ITEM 96 5}
         {RARE_ITEM 75 57}
-        [set_menu_item]
-            id=zz_ch6s9_teleport
-            description= _ "Teleport units to leader"
-            [show_if]
-                [have_unit]
-                    x,y=$x1,$y1
-                    id=Efraim
-                [/have_unit]
-                [and]
-                    [variable]
-                        name=teleport_wait
-                        greater_than_equal_to=10
-                    [/variable]
-                [/and]
-            [/show_if]
-            [command]
-                {VARIABLE teleport_wait 0}
-                [store_unit]
-                    [filter]
-                        side=1
-                        [not]
-                            id=Efraim
-                        [/not]
-                    [/filter]
-                    kill=no
-                    variable=teleport_store
-                [/store_unit]
-                [foreach]
-                    array=teleport_store
-                    [do]
-                        [teleport]
-                            [filter]
-                                id=$this_item.id
-                            [/filter]
-                            x,y=$x1,$y1
-                            clear_shroud=yes
-                            animate=no
-                        [/teleport]
-                    [/do]
-                [/foreach]
-                {CLEAR_VARIABLE teleport_store}
-            [/command]
-        [/set_menu_item]
+        {TELEPORT_TO_LEADER_MENU Efraim 10 10 10}
         [set_menu_item]
             id=zz_ch7s5_camp
             description= _ "Build an encampment"
@@ -747,7 +704,7 @@ You can build a keep anywhere for 50 gold, or a village for 10 gold. (see option
             speaker=Efraim
             message= _ "Perfect. I hope that this battle will actually be the final one."
         [/message]
-        {CLEAR_VARIABLE teleport_wait,can_build_encampment,can_build_igloo}
+        {CLEAR_VARIABLE can_build_encampment,can_build_igloo}
         [endlevel]
             result=victory
             bonus=no
@@ -757,7 +714,6 @@ You can build a keep anywhere for 50 gold, or a village for 10 gold. (see option
     [event]
         name=new turn
         first_time_only=no
-        {VARIABLE_OP teleport_wait add 1}
 #ifdef EASY
         {VARIABLE_OP spawn_type rand (Skeleton,Skeleton Archer,Ghost,Wraith,Revenant,Deathblade,Monstrosity)}
 #endif

--- a/scenarios8/08_The_Desert.cfg
+++ b/scenarios8/08_The_Desert.cfg
@@ -299,7 +299,6 @@
 
     [event]
         name=prestart
-        {VARIABLE teleport_wait 10}
         {CAPTURE_VILLAGES 1 5 4 10}
 #ifdef HARD
         {VARIABLE spawn_count 60}
@@ -350,49 +349,7 @@ You can teleport all units to Efraim once per ten turns. (see options in the rig
         {RARE_ITEM 20 71}
         {RARE_ITEM 32 40}
         {RARE_ITEM 1 69}
-        [set_menu_item]
-            id=zz_ch6s9_teleport
-            description= _ "Teleport units to leader"
-            [show_if]
-                [have_unit]
-                    x,y=$x1,$y1
-                    id=Efraim
-                [/have_unit]
-                [and]
-                    [variable]
-                        name=teleport_wait
-                        greater_than_equal_to=10
-                    [/variable]
-                [/and]
-            [/show_if]
-            [command]
-                {VARIABLE teleport_wait 0}
-                [store_unit]
-                    [filter]
-                        side=1
-                        [not]
-                            id=Efraim
-                        [/not]
-                    [/filter]
-                    kill=no
-                    variable=teleport_store
-                [/store_unit]
-                [foreach]
-            array=teleport_store
-            [do]
-                    [teleport]
-                        [filter]
-                            id=$this_item.id
-                        [/filter]
-                        x,y=$x1,$y1
-                        clear_shroud=yes
-                        animate=no
-                    [/teleport]
-            [/do]
-                [/foreach]
-                {CLEAR_VARIABLE teleport_store}
-            [/command]
-        [/set_menu_item]
+        {TELEPORT_TO_LEADER_MENU Efraim 10 10 10}
         [recall]
             id=Lethalia
         [/recall]
@@ -478,7 +435,7 @@ You can teleport all units to Efraim once per ten turns. (see options in the rig
             speaker=unit
             message= _ "The desert ends here!"
         [/message]
-        {CLEAR_VARIABLE teleport_wait,i1,i2,i3,i4,i5,i6,turn_number_nightday}
+        {CLEAR_VARIABLE i1,i2,i3,i4,i5,i6,turn_number_nightday}
         [endlevel]
             result=victory
             bonus=no
@@ -697,7 +654,6 @@ You can teleport all units to Efraim once per ten turns. (see options in the rig
     [event]
         name=new turn
         first_time_only=no
-        {VARIABLE_OP teleport_wait add 1}
 #ifdef EASY
         {VARIABLE_OP spawn_type rand (Skeleton,Skeleton Archer,Ghost,Wraith,Revenant,Deathblade,Soulless,Ghoul)}
 #endif

--- a/scenarios8/15_Jungle_Hell.cfg
+++ b/scenarios8/15_Jungle_Hell.cfg
@@ -193,7 +193,6 @@
 
     [event]
         name=prestart
-        {VARIABLE teleport_wait 10}
 #ifdef HARD
         {VARIABLE spawn_count 80}
 #endif
@@ -300,49 +299,7 @@ Items left behind WILL BE put into the inventory."
         {GOLD_CHEST 99 87}
         {GOLD_CHEST 96 38}
         {GOLD_CHEST 77 72}
-        [set_menu_item]
-            id=zz_ch6s9_teleport
-            description= _ "Teleport units to leader"
-            [show_if]
-                [have_unit]
-                    x,y=$x1,$y1
-                    id=Efraim
-                [/have_unit]
-                [and]
-                    [variable]
-                        name=teleport_wait
-                        greater_than_equal_to=10
-                    [/variable]
-                [/and]
-            [/show_if]
-            [command]
-                {VARIABLE teleport_wait 0}
-                [store_unit]
-                    [filter]
-                        side=1
-                        [not]
-                            id=Efraim
-                        [/not]
-                    [/filter]
-                    kill=no
-                    variable=teleport_store
-                [/store_unit]
-                [foreach]
-                    array=teleport_store
-                    [do]
-                        [teleport]
-                            [filter]
-                                id=$this_item.id
-                            [/filter]
-                            x,y=$x1,$y1
-                            clear_shroud=yes
-                            animate=no
-                        [/teleport]
-                    [/do]
-                [/foreach]
-                {CLEAR_VARIABLE teleport_store}
-            [/command]
-        [/set_menu_item]
+        {TELEPORT_TO_LEADER_MENU Efraim 10 10 10}
         [recall]
             id=Lethalia
             x,y=58,2
@@ -377,7 +334,6 @@ Items left behind WILL BE put into the inventory."
     [event]
         name=new turn
         first_time_only=no
-        {VARIABLE_OP teleport_wait add 1}
         {CH8S15_SPAWN_POINT 1 24}
         {CH8S15_SPAWN_POINT 1 36}
         {CH8S15_SPAWN_POINT 1 69}
@@ -434,7 +390,6 @@ Items left behind WILL BE put into the inventory."
             speaker=Lethalia
             message= _ "Smile, my friends, after this green hell comes heaven: No trees! ... But sand. And−"
         [/message]
-        {VARIABLE teleport_wait 0}
         [for]   # Pick up all items from the map so they will be added to the inventory
             array=items
             variable=i

--- a/utils/utils.cfg
+++ b/utils/utils.cfg
@@ -195,6 +195,7 @@
             side=$unit.side
             amount=-{COST}
         [/gold]
+        {VARIABLE_OP gold sub {COST}}
     [/command]
 #enddef
 #define SELL_GEMS
@@ -281,6 +282,7 @@ $item_info.description"
                                     side=$side_number
                                     amount=-{PRICE}
                                 [/gold]
+                                {VARIABLE_OP gold sub {PRICE}}
                                 {VARIABLE_OP items_dropped add 1}
                                 {VARIABLE {VARIABLE_NAME} 1}
                                 [fire_event]
@@ -1719,4 +1721,119 @@ $item_info.description"
         [/do]
     [/for]
     {CLEAR_VARIABLE movement_store}
+#enddef
+
+#define TELEPORT_TO_LEADER_MENU LEADER EASY NORMAL HARD
+    [set_menu_item]
+        id=teleport_to_{LEADER}
+        description= _ "Teleport units to {LEADER}"
+        [show_if]
+            [have_unit]
+                x,y=$x1,$y1
+                id={LEADER}
+            [/have_unit]
+            [and]
+                [variable]
+                    name=teleport_wait
+                    greater_than_equal_to=$teleport_interval
+                [/variable]
+            [/and]
+        [/show_if]
+        [command]
+            {VARIABLE teleport_wait 0}
+            [store_unit]
+                [filter]
+                    side=1
+                    [not]
+                        id={LEADER}
+                    [/not]
+                [/filter]
+                kill=no
+                variable=teleport_store
+            [/store_unit]
+            [foreach]
+                array=teleport_store
+                [do]
+                    [teleport]
+                        [filter]
+                            id=$this_item.id
+                        [/filter]
+                        x,y=$x1,$y1
+                        clear_shroud=yes
+                        animate=no
+                    [/teleport]
+                [/do]
+            [/foreach]
+            {CLEAR_VARIABLE teleport_store}
+        [/command]
+    [/set_menu_item]
+    [set_menu_item]
+        id=cannot_teleport_to_{LEADER}
+        description= _ "<span font-style='oblique'>Spell to teleport units to {LEADER} is recharging</span>"
+        [show_if]
+            [have_unit]
+                x,y=$x1,$y1
+                id={LEADER}
+            [/have_unit]
+            [and]
+                [variable]
+                    name=teleport_wait
+                    less_than=$teleport_interval
+                [/variable]
+            [/and]
+        [/show_if]
+        [command]
+        [/command]
+    [/set_menu_item]
+    # BEGIN backward compatibility
+    [clear_menu_item]
+        id=zz_ch6s9_teleport
+    [/clear_menu_item]
+    # END backward compatibility
+
+    [event]
+        first_time_only=no        # for debugging
+        name=prestart
+        id=teleport_leader_prestart
+#ifdef EASY
+        {VARIABLE teleport_interval {EASY}}
+#endif
+#ifdef NORMAL
+        {VARIABLE teleport_interval {NORMAL}}
+#endif
+#ifdef HARD
+        {VARIABLE teleport_interval {HARD}}
+#endif
+
+        {VARIABLE teleport_wait $teleport_interval}
+    [/event]
+    [event]
+        name=new turn
+        first_time_only=yes
+#ifdef EASY
+        {VARIABLE teleport_interval {EASY}}
+#endif
+#ifdef NORMAL
+        {VARIABLE teleport_interval {NORMAL}}
+#endif
+#ifdef HARD
+        {VARIABLE teleport_interval {HARD}}
+#endif
+        {VARIABLE teleport_wait $teleport_interval}
+    [/event]
+    [event]
+        name=new turn
+        first_time_only=no
+        {VARIABLE_OP teleport_wait add 1}
+    [/event]
+    [event]
+        name=scenario_end
+        {CLEAR_VARIABLE teleport_wait,teleport_interval}
+        [clear_menu_item]
+            id=teleport_to_{LEADER}
+        [/clear_menu_item]
+        [clear_menu_item]
+            id=cannot_teleport_to_{LEADER}
+        [/clear_menu_item]
+    [/event]
 #enddef


### PR DESCRIPTION
I left in the configurable leader and interval based on difficulty.  Probably won't be used, but it's there, and  {TELEPORT_TO_LEADER_MENU Efraim 10 10 10} provides exactly the same functionality as there was before.

Everything (initialization, teleport_wait++, cleanup, etc) is encapsulated in the macro, save for updating objectives.