### PR TITLE
rewrite of redeeming event

### DIFF
--- a/lua/redeem.lua
+++ b/lua/redeem.lua
@@ -565,3 +565,101 @@ function wesnoth.wml_actions.max_redeem_count_from_level(cfg)
     local level = cfg.level or wml.error("[max_redeem_from_level]: missing level= .")
     wml.variables[to_variable] = max_redeem_count_from_level(level)
 end
+
+-- redeem_hit_chance returns the chance of redeem success based on redeem level and target's level
+-- distance indicates whether target is the unit redeemer attacks (distance=0), or a unit adjacent to the
+-- unit redeemer attacks (distance=1)
+local function redeem_hit_chance(redeem_level,target_level,distance)
+	-- nil result indicates no chance
+	local hit_chance = 0
+
+	if (distance < 0) or (distance > 1) then wml.error("does_redeem_hit:  distance must be 0 or 1") end
+	local chance={ 	-- chance to sucessfully hit redeem defender
+			-- index = redeem level, value = table of probablity by target level (from 0)
+		{ 100, 100,  50,  25 },
+		{ 100, 100, 100,  50,  25 },
+		{ 100, 100, 100,  75,  50,  25,  10},
+		{ 100, 100, 100, 100,  75,  50,  25,  10},
+		{ 100, 100, 100, 100,  75,  50,  25,  10}, -- redeem level 5
+		{ 100, 100, 100, 100, 100,  75,  50,  25,  10},
+		{ 100, 100, 100, 100, 100, 100,  75,  50,  25,  10},
+		{ 100, 100, 100, 100, 100, 100, 100,  75,  50,  25,  10},
+		{ 100, 100, 100, 100, 100, 100,  90,  60,  40,  30,  20,  10},
+		{ 100, 100, 100, 100, 100, 100, 100,  90,  60,  40,  30,  20,  10},  -- redeem level 10
+		{ 100, 100, 100, 100, 100, 100, 100, 100,  90,  60,  40,  30,  20,  10},
+		{ 100, 100, 100, 100, 100, 100, 100,  90,  80,  70,  60,  50,  40,  30,  20,  10},
+		{ 100, 100, 100, 100, 100, 100, 100, 100,  90,  80,  70,  60,  50,  40,  30,  20,  10},
+		{ 100, 100, 100, 100, 100, 100, 100, 100, 100,  90,  80,  70,  60,  50,  40,  30,  20,  10},
+		{ 100, 100, 100, 100, 100, 100, 100, 100, 100, 100,  90,  80,  70,  60,  50,  40,  30,  20,  10}, -- redeem level 15
+		{ 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100,  90,  80,  70,  60,  50,  40,  30,  20,  10},
+		{ 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100,  90,  80,  70,  60,  50,  40,  30,  20,  10},
+		{ 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100,  90,  80,  70,  60,  50,  40,  30,  20,  10},
+		{ 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100,  90,  80,  70,  60,  50,  40,  30,  20,  10},
+		{ 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100,  90,  80,  70,  60,  50,  40,  30,  20,  10}
+	}
+
+	local adj_chance={	-- chance to sucessfully hit unit adjacent to redeem defender
+				-- index = redeem level, value = table of probablity by target level (from 0)
+		{},{},{},{},   -- redeem level 1-4 don't hit adjacent to target
+		{ 100, 100,  50,  25}, -- redeem level 5
+		{ 100, 100,  50,  25},
+		{ 100, 100, 100,  50,  25},
+		{ 100, 100, 100,  50,  25},
+		{ 100, 100, 100, 100,  50,  25},
+		{ 100, 100, 100, 100,  50,  25}, -- redeem level 10
+		{ 100, 100, 100, 100, 100,  50,  25},
+		{ 100, 100, 100, 100, 100,  50,  25},
+		{ 100, 100, 100, 100, 100, 100,  50,  25},
+		{ 100, 100, 100, 100, 100, 100,  50,  25},
+		{ 100, 100, 100, 100, 100, 100, 100,  50,  25}, -- redeem level 15
+		{ 100, 100, 100, 100, 100, 100, 100,  50,  25},
+		{ 100, 100, 100, 100, 100, 100, 100, 100,  50,  25},
+		{ 100, 100, 100, 100, 100, 100, 100, 100,  50,  25},
+		{ 100, 100, 100, 100, 100, 100, 100, 100, 100,  50,  25},
+		{ 100, 100, 100, 100, 100, 100, 100, 100, 100,  50,  25}
+	}
+
+	local lookup=0
+	if (distance == 0) and (chance[redeem_level] ~= nil) then lookup = chance[redeem_level][target_level+1] end
+	if (distance == 1) and (adj_chance[redeem_level] ~= nil) then lookup = adj_chance[redeem_level][target_level+1] end
+	if (lookup ~= nil) then hit_chance=lookup end
+	return hit_chance
+end
+
+-- Tag [does_redeem_hit_target] determines success/fail of redeeming target
+-- Requires cfg.redeem_level=, cfg.target_level=
+-- Returns true/false in variable identified by cfg.to_variable
+function wesnoth.wml_actions.does_redeem_hit_target(cfg)
+	local redeem_level = cfg.redeem_level or wml.error("[does_redeem_hit_target]: requires redeem_level= ")
+	local target_level = cfg.target_level or wml.error("[does_redeem_hit_target]: requires target_level= ")
+	local to_variable = cfg.to_variable or wml.error("[does_redeem_hit_target]: requires to_variable= ")
+	local debug = cfg.debug
+
+	local hit_chance = redeem_hit_chance(redeem_level,target_level,0)
+	local rand = math.random(0, 99)
+	if (debug) then print(string.format("[does_redeem_hit_target]: rlel = %d, tlel = %d, hit = %d, rand = %d",
+		redeem_level,target_level,hit_chance,rand))
+	end
+	local ret_val=false
+	if rand < hit_chance then ret_val=true end
+	wml.variables[to_variable]=ret_val
+end
+
+-- Tag [does_redeem_hit_adjacent_to_target] determines success/fail of redeeming unit adjacent to redeem target
+-- Requires cfg.redeem_level=, cfg.target_level=
+-- Returns true/false in variable identified by cfg.to_variable
+function wesnoth.wml_actions.does_redeem_hit_adjacent_to_target(cfg)
+	local redeem_level = cfg.redeem_level or wml.error("[does_redeem_hit_adjacent_to_target]: requires redeem_level= ")
+	local target_level = cfg.target_level or wml.error("[does_redeem_hit_adjacent_to_target]: requires target_level= ")
+	local to_variable = cfg.to_variable or wml.error("[does_redeem_hit_adjacent_to_target]: requires to_variable= ")
+	local debug = cfg.debug
+
+	local hit_chance = redeem_hit_chance(redeem_level,target_level,1)
+	local rand = math.random(0, 99)
+	if (debug) then print(string.format("[does_redeem_hit_adjacent_to_target]: rlel = %d, tlel = %d, hit = %d, rand = %d",
+		redeem_level,target_level,hit_chance,rand))
+	end
+	local ret_val=false
+	if rand < hit_chance then ret_val=true end
+	wml.variables[to_variable]=ret_val
+end

--- a/lua/redeem.lua
+++ b/lua/redeem.lua
@@ -574,6 +574,7 @@ local function redeem_hit_chance(redeem_level,target_level,distance)
 	local hit_chance = 0
 
 	if (distance < 0) or (distance > 1) then wml.error("does_redeem_hit:  distance must be 0 or 1") end
+	-- tables based on formulae that can be found at https://github.com/Dugy/Legend_of_the_Invincibles/blob/7397831e6b6693612bb455a8acb26acf8be4e69f/utils/redeeming.cfg#L264
 	local chance={ 	-- chance to sucessfully hit redeem defender
 			-- index = redeem level, value = table of probablity by target level (from 0)
 		{ 100, 100,  50,  25 },

--- a/utils/redeeming.cfg
+++ b/utils/redeeming.cfg
@@ -31,7 +31,7 @@
     [damage]
         id=redeem 5
         name= _ "redeem (5)"
-        description= _ "The target of this attack is fully absorbed into the attacker's soul, a much better place than the world he was taken from. The attacker may get new advancements unlocked thanks to this. This attack kills any target of level 3 or lower, level 4 targets are absorbed with a 75% chance, level 5 targets are absorbed with a 50% chance, level 6 targets are absorbed with a 25% chance and the chance to absorb level 7 targets is only 10%. Targets adjacent to the target are absorbed with a 100% chance if their level is 0 or less, 50% chance if their level is 1 and 25% chance if their level is 2. Experience is not gained. 17 redeems are required to get new advancements. This attack may be used only once per three turns."
+        description= _ "The target of this attack is fully absorbed into the attacker's soul, a much better place than the world he was taken from. The attacker may get new advancements unlocked thanks to this. This attack kills any target of level 3 or lower, level 4 targets are absorbed with a 75% chance, level 5 targets are absorbed with a 50% chance, level 6 targets are absorbed with a 25% chance and the chance to absorb level 7 targets is only 10%. Targets adjacent to the target are absorbed with a 100% chance if their level is 1 or less, 50% chance if their level is 2 and 25% chance if their level is 3. Experience is not gained. 17 redeems are required to get new advancements. This attack may be used only once per three turns."
     [/damage]
 #enddef
 #define WEAPON_SPECIAL_REDEEM_6
@@ -45,7 +45,7 @@
     [damage]
         id=redeem 7
         name= _ "redeem (7)"
-        description= _ "The target of this attack is fully absorbed into the attacker's soul, a much better place than the world he was taken from. The attacker may get new advancements unlocked thanks to this. This attack kills any target of level 5 or lower, level 6 targets are absorbed with a 75% chance, level 7 targets are absorbed with a 50% chance, level 8 targets are absorbed with a 25% chance and the chance to absorb level 9 targets is only 10%. Targets adjacent to the target are absorbed with a 100% chance if their level is 1 or less, 50% chance if their level is 2 and 25% chance if their level is 3. Experience is not gained. 29 redeems are required to get new advancements. This attack may be used only once per three turns."
+        description= _ "The target of this attack is fully absorbed into the attacker's soul, a much better place than the world he was taken from. The attacker may get new advancements unlocked thanks to this. This attack kills any target of level 5 or lower, level 6 targets are absorbed with a 75% chance, level 7 targets are absorbed with a 50% chance, level 8 targets are absorbed with a 25% chance and the chance to absorb level 9 targets is only 10%. Targets adjacent to the target are absorbed with a 100% chance if their level is 2 or less, 50% chance if their level is 3 and 25% chance if their level is 4. Experience is not gained. 29 redeems are required to get new advancements. This attack may be used only once per three turns."
     [/damage]
 #enddef
 #define WEAPON_SPECIAL_REDEEM_8
@@ -59,7 +59,7 @@
     [damage]
         id=redeem 9
         name= _ "redeem (9)"
-        description= _ "The target of this attack is fully absorbed into the attacker's soul, a much better place than the world he was taken from. The attacker may get new advancements unlocked thanks to this. This attack kills any target of level 5 or lower, level 6 targets are absorbed with a 90% chance, level 7 targets are absorbed with a 60% chance, level 8 targets are absorbed with a 40% chance, level 9 targets are absorbed with a 30% chance, level 10 targets are absorbed with a 20% chance and the chance to absorb level 11 targets is only 10%. Targets adjacent to the target are absorbed with a 100% chance if their level is 2 or less, 50% chance if their level is 3 and 25% chance if their level is 4. Experience is not gained. 50 redeems are required to get new advancements. This attack may be used only once per three turns."
+        description= _ "The target of this attack is fully absorbed into the attacker's soul, a much better place than the world he was taken from. The attacker may get new advancements unlocked thanks to this. This attack kills any target of level 5 or lower, level 6 targets are absorbed with a 90% chance, level 7 targets are absorbed with a 60% chance, level 8 targets are absorbed with a 40% chance, level 9 targets are absorbed with a 30% chance, level 10 targets are absorbed with a 20% chance and the chance to absorb level 11 targets is only 10%. Targets adjacent to the target are absorbed with a 100% chance if their level is 3 or less, 50% chance if their level is 4 and 25% chance if their level is 5. Experience is not gained. 50 redeems are required to get new advancements. This attack may be used only once per three turns."
     [/damage]
 #enddef
 #define WEAPON_SPECIAL_REDEEM_10
@@ -73,7 +73,7 @@
     [damage]
         id=redeem 11
         name= _ "redeem (11)"
-        description= _ "The target of this attack is fully absorbed into the attacker's soul, a much better place than the world he was taken from. The attacker may get new advancements unlocked thanks to this. This attack kills any target of level 7 or lower, level 8 targets are absorbed with a 90% chance, level 9 targets are absorbed with a 60% chance, level 10 targets are absorbed with a 40% chance, level 11 targets are absorbed with a 30% chance, level 12 targets are absorbed with a 20% chance and the chance to absorb level 13 targets is only 10%. Targets adjacent to the target are absorbed with a 100% chance if their level is 3 or less, 50% chance if their level is 4 and 25% chance if their level is 5. Experience is not gained. 88 redeems are required to get new advancements. This attack may be used only once per three turns."
+        description= _ "The target of this attack is fully absorbed into the attacker's soul, a much better place than the world he was taken from. The attacker may get new advancements unlocked thanks to this. This attack kills any target of level 7 or lower, level 8 targets are absorbed with a 90% chance, level 9 targets are absorbed with a 60% chance, level 10 targets are absorbed with a 40% chance, level 11 targets are absorbed with a 30% chance, level 12 targets are absorbed with a 20% chance and the chance to absorb level 13 targets is only 10%. Targets adjacent to the target are absorbed with a 100% chance if their level is 4 or less, 50% chance if their level is 5 and 25% chance if their level is 6. Experience is not gained. 88 redeems are required to get new advancements. This attack may be used only once per three turns."
     [/damage]
 #enddef
 #define WEAPON_SPECIAL_REDEEM_12
@@ -87,7 +87,7 @@
     [damage]
         id=redeem 13
         name= _ "redeem (13)"
-        description= _ "The target of this attack is fully absorbed into the attacker's soul, a much better place than the world he was taken from. The attacker may get new advancements unlocked thanks to this. This attack kills any target of level 7 or lower, level 8 targets are absorbed with a 90% chance, level 9 targets are absorbed with an 80% chance, level 10 targets are absorbed with a 70% chance, level 11 targets are absorbed with a 60% chance, level 12 targets are absorbed with a 50%, level 13 targets are absorbed with a 40%, level 14 targets are absorbed with a 30% chance, level 15 targets are absorbed with a 20% and the chance to absorb level 16 targets is only 10%. Targets adjacent to the target are absorbed with a 100% chance if their level is 4 or less, 50% chance if their level is 5 and 25% chance if their level is 6. Experience is not gained. 156 redeems are required to get new advancements. This attack may be used only once per three turns."
+        description= _ "The target of this attack is fully absorbed into the attacker's soul, a much better place than the world he was taken from. The attacker may get new advancements unlocked thanks to this. This attack kills any target of level 7 or lower, level 8 targets are absorbed with a 90% chance, level 9 targets are absorbed with an 80% chance, level 10 targets are absorbed with a 70% chance, level 11 targets are absorbed with a 60% chance, level 12 targets are absorbed with a 50%, level 13 targets are absorbed with a 40%, level 14 targets are absorbed with a 30% chance, level 15 targets are absorbed with a 20% and the chance to absorb level 16 targets is only 10%. Targets adjacent to the target are absorbed with a 100% chance if their level is 5 or less, 50% chance if their level is 6 and 25% chance if their level is 7. Experience is not gained. 156 redeems are required to get new advancements. This attack may be used only once per three turns."
     [/damage]
 #enddef
 #define WEAPON_SPECIAL_REDEEM_14
@@ -101,42 +101,42 @@
     [damage]
         id=redeem 15
         name= _ "redeem (15)"
-        description= _ "The target of this attack is fully absorbed into the attacker's soul, a much better place than the world he was taken from. The attacker may get new advancements unlocked thanks to this. This attack kills any target of level 9 or lower, level 10 targets are absorbed with a 90% chance, level 11 targets are absorbed with an 80% chance, level 12 targets are absorbed with a 70% chance, level 13 targets are absorbed with a 60% chance, level 14 targets are absorbed with a 50%, level 15 targets are absorbed with a 40%, level 16 targets are absorbed with a 30% chance, level 17 targets are absorbed with a 20% and the chance to absorb level 18 targets is only 10%. Targets adjacent to the target are absorbed with a 100% chance if their level is 5 or less, 50% chance if their level is 7 and 25% chance if their level is 8. Experience is not gained. 277 redeems are required to get new advancements. This attack may be used only once per three turns."
+        description= _ "The target of this attack is fully absorbed into the attacker's soul, a much better place than the world he was taken from. The attacker may get new advancements unlocked thanks to this. This attack kills any target of level 9 or lower, level 10 targets are absorbed with a 90% chance, level 11 targets are absorbed with an 80% chance, level 12 targets are absorbed with a 70% chance, level 13 targets are absorbed with a 60% chance, level 14 targets are absorbed with a 50%, level 15 targets are absorbed with a 40%, level 16 targets are absorbed with a 30% chance, level 17 targets are absorbed with a 20% and the chance to absorb level 18 targets is only 10%. Targets adjacent to the target are absorbed with a 100% chance if their level is 6 or less, 50% chance if their level is 7 and 25% chance if their level is 8. Experience is not gained. 277 redeems are required to get new advancements. This attack may be used only once per three turns."
     [/damage]
 #enddef
 #define WEAPON_SPECIAL_REDEEM_16
     [damage]
         id=redeem 16
         name= _ "redeem (16)"
-        description= _ "The target of this attack is fully absorbed into the attacker's soul, a much better place than the world he was taken from. The attacker may get new advancements unlocked thanks to this. This attack kills any target of level 10 or lower, level 11 targets are absorbed with a 90% chance, level 12 targets are absorbed with an 80% chance, level 13 targets are absorbed with a 70% chance, level 14 targets are absorbed with a 60% chance, level 15 targets are absorbed with a 50%, level 16 targets are absorbed with a 40%, level 17 targets are absorbed with a 30% chance, level 18 targets are absorbed with a 20% and the chance to absorb level 19 targets is only 10%. Targets adjacent to the target are absorbed with a 100% chance if their level is 6 or less, 50% chance if their level is 8 and 25% chance if their level is 9. Experience is not gained. 369 redeems are required to get new advancements. This attack may be used only once per three turns."
+        description= _ "The target of this attack is fully absorbed into the attacker's soul, a much better place than the world he was taken from. The attacker may get new advancements unlocked thanks to this. This attack kills any target of level 10 or lower, level 11 targets are absorbed with a 90% chance, level 12 targets are absorbed with an 80% chance, level 13 targets are absorbed with a 70% chance, level 14 targets are absorbed with a 60% chance, level 15 targets are absorbed with a 50%, level 16 targets are absorbed with a 40%, level 17 targets are absorbed with a 30% chance, level 18 targets are absorbed with a 20% and the chance to absorb level 19 targets is only 10%. Targets adjacent to the target are absorbed with a 100% chance if their level is 6 or less, 50% chance if their level is 7 and 25% chance if their level is 8. Experience is not gained. 369 redeems are required to get new advancements. This attack may be used only once per three turns."
     [/damage]
 #enddef
 #define WEAPON_SPECIAL_REDEEM_17
     [damage]
         id=redeem 17
         name= _ "redeem (17)"
-        description= _ "The target of this attack is fully absorbed into the attacker's soul, a much better place than the world he was taken from. The attacker may get new advancements unlocked thanks to this. This attack kills any target of level 11 or lower, level 12 targets are absorbed with a 90% chance, level 13 targets are absorbed with an 80% chance, level 14 targets are absorbed with a 70% chance, level 15 targets are absorbed with a 60% chance, level 16 targets are absorbed with a 50%, level 17 targets are absorbed with a 40%, level 18 targets are absorbed with a 30% chance, level 19 targets are absorbed with a 20% and the chance to absorb level 20 targets is only 10%. Targets adjacent to the target are absorbed with a 100% chance if their level is 6 or less, 50% chance if their level is 9 and 25% chance if their level is 10. Experience is not gained. 492 redeems are required to get new advancements. This attack may be used only once per three turns."
+        description= _ "The target of this attack is fully absorbed into the attacker's soul, a much better place than the world he was taken from. The attacker may get new advancements unlocked thanks to this. This attack kills any target of level 11 or lower, level 12 targets are absorbed with a 90% chance, level 13 targets are absorbed with an 80% chance, level 14 targets are absorbed with a 70% chance, level 15 targets are absorbed with a 60% chance, level 16 targets are absorbed with a 50%, level 17 targets are absorbed with a 40%, level 18 targets are absorbed with a 30% chance, level 19 targets are absorbed with a 20% and the chance to absorb level 20 targets is only 10%. Targets adjacent to the target are absorbed with a 100% chance if their level is 7 or less, 50% chance if their level is 8 and 25% chance if their level is 9. Experience is not gained. 492 redeems are required to get new advancements. This attack may be used only once per three turns."
     [/damage]
 #enddef
 #define WEAPON_SPECIAL_REDEEM_18
     [damage]
         id=redeem 18
         name= _ "redeem (18)"
-        description= _ "The target of this attack is fully absorbed into the attacker's soul, a much better place than the world he was taken from. The attacker may get new advancements unlocked thanks to this. This attack kills any target of level 12 or lower, level 13 targets are absorbed with a 90% chance, level 14 targets are absorbed with an 80% chance, level 15 targets are absorbed with a 70% chance, level 16 targets are absorbed with a 60% chance, level 17 targets are absorbed with a 50%, level 18 targets are absorbed with a 40%, level 19 targets are absorbed with a 30% chance, level 20 targets are absorbed with a 20% and the chance to absorb level 21 targets is only 10%. Targets adjacent to the target are absorbed with a 100% chance if their level is 7 or less, 50% chance if their level is 10 and 25% chance if their level is 11. Experience is not gained. 656 redeems are required to get new advancements. This attack may be used only once per three turns."
+        description= _ "The target of this attack is fully absorbed into the attacker's soul, a much better place than the world he was taken from. The attacker may get new advancements unlocked thanks to this. This attack kills any target of level 12 or lower, level 13 targets are absorbed with a 90% chance, level 14 targets are absorbed with an 80% chance, level 15 targets are absorbed with a 70% chance, level 16 targets are absorbed with a 60% chance, level 17 targets are absorbed with a 50%, level 18 targets are absorbed with a 40%, level 19 targets are absorbed with a 30% chance, level 20 targets are absorbed with a 20% and the chance to absorb level 21 targets is only 10%. Targets adjacent to the target are absorbed with a 100% chance if their level is 7 or less, 50% chance if their level is 8 and 25% chance if their level is 9. Experience is not gained. 656 redeems are required to get new advancements. This attack may be used only once per three turns."
     [/damage]
 #enddef
 #define WEAPON_SPECIAL_REDEEM_19
     [damage]
         id=redeem 19
         name= _ "redeem (19)"
-        description= _ "The target of this attack is fully absorbed into the attacker's soul, a much better place than the world he was taken from. The attacker may get new advancements unlocked thanks to this. This attack kills any target of level 13 or lower, level 14 targets are absorbed with a 90% chance, level 15 targets are absorbed with an 80% chance, level 16 targets are absorbed with a 70% chance, level 17 targets are absorbed with a 60% chance, level 18 targets are absorbed with a 50%, level 19 targets are absorbed with a 40%, level 20 targets are absorbed with a 30% chance, level 21 targets are absorbed with a 20% and the chance to absorb level 22 targets is only 10%. Targets adjacent to the target are absorbed with a 100% chance if their level is 7 or less, 50% chance if their level is 11 and 25% chance if their level is 12. Experience is not gained. 874 redeems are required to get new advancements. This attack may be used only once per three turns."
+        description= _ "The target of this attack is fully absorbed into the attacker's soul, a much better place than the world he was taken from. The attacker may get new advancements unlocked thanks to this. This attack kills any target of level 13 or lower, level 14 targets are absorbed with a 90% chance, level 15 targets are absorbed with an 80% chance, level 16 targets are absorbed with a 70% chance, level 17 targets are absorbed with a 60% chance, level 18 targets are absorbed with a 50%, level 19 targets are absorbed with a 40%, level 20 targets are absorbed with a 30% chance, level 21 targets are absorbed with a 20% and the chance to absorb level 22 targets is only 10%. Targets adjacent to the target are absorbed with a 100% chance if their level is 8 or less, 50% chance if their level is 9 and 25% chance if their level is 10. Experience is not gained. 874 redeems are required to get new advancements. This attack may be used only once per three turns."
     [/damage]
 #enddef
 #define WEAPON_SPECIAL_REDEEM_20
     [damage]
         id=redeem 20
         name= _ "redeem (20)"
-        description= _ "The target of this attack is fully absorbed into the attacker's soul, a much better place than the world he was taken from. The attacker may get new advancements unlocked thanks to this. This attack kills any target of level 14 or lower, level 15 targets are absorbed with a 90% chance, level 16 targets are absorbed with an 80% chance, level 17 targets are absorbed with a 70% chance, level 18 targets are absorbed with a 60% chance, level 19 targets are absorbed with a 50%, level 20 targets are absorbed with a 40%, level 21 targets are absorbed with a 30% chance, level 22 targets are absorbed with a 20% and the chance to absorb level 23 targets is only 10%. Targets adjacent to the target are absorbed with a 100% chance if their level is 8 or less, 50% chance if their level is 12 and 25% chance if their level is 14. Experience is not gained. 1165 redeems are required to get new advancements. This attack may be used only once per three turns."
+        description= _ "The target of this attack is fully absorbed into the attacker's soul, a much better place than the world he was taken from. The attacker may get new advancements unlocked thanks to this. This attack kills any target of level 14 or lower, level 15 targets are absorbed with a 90% chance, level 16 targets are absorbed with an 80% chance, level 17 targets are absorbed with a 70% chance, level 18 targets are absorbed with a 60% chance, level 19 targets are absorbed with a 50%, level 20 targets are absorbed with a 40%, level 21 targets are absorbed with a 30% chance, level 22 targets are absorbed with a 20% and the chance to absorb level 23 targets is only 10%. Targets adjacent to the target are absorbed with a 100% chance if their level is 8 or less, 50% chance if their level is 9 and 25% chance if their level is 10. Experience is not gained. 1165 redeems are required to get new advancements. This attack may be used only once per three turns."
     [/damage]
 #enddef
 
@@ -221,36 +221,6 @@
     {CLEAR_VARIABLE redeemer}
 #enddef
 
-#define REDEEM_SURE_LEVEL LEVEL
-    [if]
-        [variable]
-            name=second_unit.level
-            less_than_equal_to={LEVEL}
-        [/variable]
-        [then]
-            {VARIABLE redeemed 1}
-        [/then]
-    [/if]
-#enddef
-
-#define REDEEM_UNSURE_LEVEL LEVEL PROBABILITY
-    [if]
-        [variable]
-            name=second_unit.level
-            equals={LEVEL}
-        [/variable]
-        [and]
-            [variable]
-                name=luck
-                greater_than={PROBABILITY}
-            [/variable]
-        [/and]
-        [then]
-            {VARIABLE redeemed 1}
-        [/then]
-    [/if]
-#enddef
-
 #define REDEEMING
     [event]
         name=attacker hits
@@ -259,216 +229,61 @@
             name=redeem
         [/filter_attack]
         {GET_REDEEM_LEVEL unit redeem_level}
-        {VARIABLE old_redeem_level $redeem_level}
         {VARIABLE redeemed_in_total 0}
+
+        # BEGIN redeem enemy units adjacent to target
+        #
+        # We need to do the adjacent targets first -- if we redeem (kill) the target there won't be any adjacent
+        # targets for [store_unit] to find.
+        #
+        # It would be ever so slightly faster to hardcode a check here.  Currently, at redeem level < 5 you
+        # never redeem more than 1 unit, so you could skip this block completely.
+        [store_unit]
+            [filter]
+                [filter_adjacent]
+                    id=$second_unit.id
+                [/filter_adjacent]
+                [not]
+                    [filter_wml]
+                        [variables]
+                            unredeemable=yes
+                        [/variables]
+                    [/filter_wml]
+                [/not]
+                side=$enemy_sides
+            [/filter]
+            variable=redeem_store
+            kill=no
+        [/store_unit]
+        [foreach]
+            array=redeem_store
+            [do]
+                {VARIABLE redeemed no}
+                [does_redeem_hit_adjacent_to_target]
+                    redeem_level=$redeem_level
+                    target_level=$this_item.level
+                    to_variable=redeemed
+                [/does_redeem_hit_adjacent_to_target]
+                [if]
+                    [variable]
+                        name=redeemed
+                        equals=yes
+                    [/variable]
+                    [then]
+                        [kill]
+                            id=$this_item.id
+                            animate=no
+                            fire_event=yes
+                        [/kill]
+                        {VARIABLE_OP redeemed_in_total add 1}
+                    [/then]
+                [/if]
+            [/do]
+        [/foreach]
+        # END redeem enemy units adjacent to target
+
+        # BEGIN redeem target unit
         [if]
-            [variable]
-                name=redeem_level
-                greater_than=4
-            [/variable]
-            [then]
-                {VARIABLE_OP redeem_level sub 4}
-                [set_variable]
-                    name=redeem_level
-                    divide=2
-                    round=ceil
-                [/set_variable]
-                [store_unit]
-                    [filter]
-                        [filter_adjacent]
-                            id=$second_unit.id
-                        [/filter_adjacent]
-                        [not]
-                            [filter_wml]
-                                [variables]
-                                    unredeemable=yes
-                                [/variables]
-                            [/filter_wml]
-                        [/not]
-                        side=$enemy_sides
-                    [/filter]
-                    variable=redeem_store
-                    kill=no
-                [/store_unit]
-                [foreach]
-                    array=redeem_store
-                    [do]
-                        {VARIABLE_OP luck rand (0,1,2,3)}
-                        {VARIABLE redeemed 0}
-                        [if]
-                            [variable]
-                                name=this_item.level
-                                less_than_equal_to=$redeem_level
-                            [/variable]
-                            [then]
-                                {VARIABLE redeemed 1}
-                            [/then]
-                        [/if]
-                        {VARIABLE redeem_level_higher "$($redeem_level+1)"}
-                        [if]
-                            [variable]
-                                name=this_item.level
-                                equals=$redeem_level_higher
-                            [/variable]
-                            [and]
-                                [variable]
-                                    name=luck
-                                    greater_than=1
-                                [/variable]
-                            [/and]
-                            [then]
-                                {VARIABLE redeemed 1}
-                            [/then]
-                        [/if]
-                        {VARIABLE redeem_level_higher "$($redeem_level+2)"}
-                        [if]
-                            [variable]
-                                name=this_item.level
-                                equals=$redeem_level_higher
-                            [/variable]
-                            [and]
-                                [variable]
-                                    name=luck
-                                    greater_than=2
-                                [/variable]
-                            [/and]
-                            [then]
-                                {VARIABLE redeemed 1}
-                            [/then]
-                        [/if]
-                        [if]
-                            [variable]
-                                name=redeemed
-                                equals=1
-                            [/variable]
-                            [then]
-                                [kill]
-                                    id=$this_item.id
-                                    animate=no
-                                    fire_event=yes
-                                [/kill]
-                                {VARIABLE_OP redeemed_in_total add 1}
-                            [/then]
-                        [/if]
-                    [/do]
-                [/foreach]
-                {CLEAR_VARIABLE redeem_level_higher,redeem_store}
-                {VARIABLE redeem_level $old_redeem_level}
-            [/then]
-        [/if]
-        [if]
-            [variable]
-                name=redeem_level
-                less_than_equal_to=2
-            [/variable]
-            [then]
-                {VARIABLE_OP luck rand (0,1,2,3)}
-                {VARIABLE redeemed 0}
-                {REDEEM_SURE_LEVEL $redeem_level}
-                {REDEEM_UNSURE_LEVEL "$($redeem_level+1)" 1}
-                {REDEEM_UNSURE_LEVEL "$($redeem_level+2)" 2}
-            [/then]
-        [/if]
-        [if]
-            [variable]
-                name=redeem_level
-                equals=5
-            [/variable]
-            [then]	#Redeem level 5's direct effect is identical to level 4, it has an extra AoE
-                {VARIABLE redeem_level 4}
-            [/then]
-        [/if]
-        [if]
-            [variable]
-                name=redeem_level
-                less_than_equal_to=4
-            [/variable]
-            [and]
-                [variable]
-                    name=redeem_level
-                    greater_than=2
-                [/variable]
-            [/and]
-            [then]
-                {VARIABLE_OP luck rand (1..20)}
-                {VARIABLE redeemed 0}
-                {REDEEM_SURE_LEVEL "$($redeem_level-1)"}
-                {REDEEM_UNSURE_LEVEL "$redeem_level" 4}
-                {REDEEM_UNSURE_LEVEL "$($redeem_level+1)" 9}
-                {REDEEM_UNSURE_LEVEL "$($redeem_level+2)" 14}
-                # Redeem level 5 was set to 4 to simplify calculations, so we should correct it back
-                {VARIABLE redeem_level $old_redeem_level}
-            [/then]
-        [/if]
-        [if]
-            [variable]
-                name=redeem_level
-                less_than_equal_to=8
-            [/variable]
-            [and]
-                [variable]
-                    name=redeem_level
-                    greater_than=5
-                [/variable]
-            [/and]
-            [then]
-                {VARIABLE_OP luck rand (1..20)}
-                {VARIABLE redeemed 0}
-                {REDEEM_SURE_LEVEL "$($redeem_level-2)"}
-                {REDEEM_UNSURE_LEVEL "$($redeem_level-1)" 4}
-                {REDEEM_UNSURE_LEVEL "$redeem_level" 9}
-                {REDEEM_UNSURE_LEVEL "$($redeem_level+1)" 14}
-                {REDEEM_UNSURE_LEVEL "$($redeem_level+2)" 18}
-            [/then]
-        [/if]
-        [if]
-            [variable]
-                name=redeem_level
-                less_than_equal_to=11
-            [/variable]
-            [and]
-                [variable]
-                    name=redeem_level
-                    greater_than=8
-                [/variable]
-            [/and]
-            [then]
-                {VARIABLE_OP luck rand (1..20)}
-                {VARIABLE redeemed 0}
-                {REDEEM_SURE_LEVEL "$($redeem_level-4)"}
-                {REDEEM_UNSURE_LEVEL "$($redeem_level-3)" 2}
-                {REDEEM_UNSURE_LEVEL "$($redeem_level-2)" 8}
-                {REDEEM_UNSURE_LEVEL "$($redeem_level-1)" 12}
-                {REDEEM_UNSURE_LEVEL "$($redeem_level)" 14}
-                {REDEEM_UNSURE_LEVEL "$($redeem_level+1)" 16}
-                {REDEEM_UNSURE_LEVEL "$($redeem_level+2)" 18}
-            [/then]
-        [/if]
-        [if]
-            [variable]
-                name=redeem_level
-                greater_than=11
-            [/variable]
-            [then]
-                {VARIABLE_OP luck rand (1..20)}
-                {VARIABLE redeemed 0}
-                {REDEEM_SURE_LEVEL "$($redeem_level-6)"}
-                {REDEEM_UNSURE_LEVEL "$($redeem_level-5)" 2}
-                {REDEEM_UNSURE_LEVEL "$($redeem_level-4)" 4}
-                {REDEEM_UNSURE_LEVEL "$($redeem_level-3)" 6}
-                {REDEEM_UNSURE_LEVEL "$($redeem_level-2)" 8}
-                {REDEEM_UNSURE_LEVEL "$($redeem_level-1)" 10}
-                {REDEEM_UNSURE_LEVEL "$redeem_level" 12}
-                {REDEEM_UNSURE_LEVEL "$($redeem_level+1)" 14}
-                {REDEEM_UNSURE_LEVEL "$($redeem_level+2)" 16}
-                {REDEEM_UNSURE_LEVEL "$($redeem_level+3)" 18}
-            [/then]
-        [/if]
-        [if]
-            [variable]
-                name=redeemed
-                greater_than_equal_to=1
-            [/variable]
             [not]
                 [variable]
                     name=second_unit.variables.unredeemable
@@ -476,49 +291,37 @@
                 [/variable]
             [/not]
             [then]
-                [kill]
-                    id=$second_unit.id
-                    animate=yes
-                    experience=no
-                    fire_event=yes
-                [/kill]
-                [if]
+                {VARIABLE redeemed no}
+                [does_redeem_hit_target]
+                    redeem_level=$redeem_level
+                    target_level=$second_unit.level
+                    to_variable=redeemed
+                [/does_redeem_hit_target]
+                [if] # target is redeemed
                     [variable]
-                        name=redeemed_in_total
-                        greater_than_equal_to=1
+                        name=redeemed
+                        equals=yes
                     [/variable]
-                    [else]
-                        [fire_event]
-                            name=redeem
-                            [primary_unit]
-                                id=$unit.id
-                            [/primary_unit]
-                        [/fire_event]
-                    [/else]
+                    [then]
+                        [kill]
+                            id=$second_unit.id
+                            animate=yes
+                            experience=no
+                            fire_event=yes
+                        [/kill]
+                        {VARIABLE_OP redeemed_in_total add 1}
+                    [/then]
                 [/if]
             [/then]
-            [else]
-                [floating_text]
-                    text=_"Redeem failed!"
-                    x,y=$x1,$y1
-                [/floating_text]
-            [/else]
         [/if]
+        # END redeem target unit
+
         [if]
             [variable]
                 name=redeemed_in_total
                 greater_than_equal_to=1
             [/variable]
             [then]
-                [if]
-                    [variable]
-                        name=redeemed
-                        equals=0
-                    [/variable]
-                    [then]
-                        {VARIABLE_OP redeemed_in_total sub 1}
-                    [/then]
-                [/if]
                 [store_unit]
                     [filter]
                         id=$unit.id
@@ -549,8 +352,14 @@
                     [/primary_unit]
                 [/fire_event]
             [/then]
+            [else]
+                [floating_text]
+                    text=_"Redeem failed!"
+                    x,y=$x1,$y1
+                [/floating_text]
+            [/else]
         [/if]
-        {CLEAR_VARIABLE redeemed,luck,redeem_level,redeemed_in_total,old_redeem_level}
+        {CLEAR_VARIABLE redeemed,redeem_level,redeemed_in_total}
         {REDEEM_COOLDOWN}
     [/event]
 
@@ -583,7 +392,6 @@
                 greater_than=0
             [/variable]
             [then]
-                {VARIABLE_OP redeemer.variables.redeem_count add 1}
                 [if]
                     [variable]
                         name=redeemer.variables.redeem_count
@@ -1110,9 +918,9 @@
                 [if]
                     [variable]
                         name=redeemer[$i].variables.redeem_wait
-                        equals=0
+                        greater_than=0
                     [/variable]
-                    [then]
+                    [else]
                         {CLEAR_VARIABLE redeemer[$i].status.redeem_waiting}
                         {CLEAR_VARIABLE redeemer[$i].variables.redeem_wait}
                         [for]
@@ -1135,7 +943,7 @@
                             {COLOR_HEAL}
                             text= _ "Redeem recharged!"
                         [/unstore_unit]
-                    [/then]
+                    [/else]
                 [/if]
                 [if]
                     [variable]

--- a/utils/redeeming.cfg
+++ b/utils/redeeming.cfg
@@ -938,11 +938,19 @@
                                 [/if]
                             [/do]
                         [/for]
+                        [scroll_to_unit]
+                            for_side=$redeemer[$i].side
+                            id=$redeemer[$i].id
+                        [/scroll_to_unit]
                         [unstore_unit]
                             variable=redeemer[$i]
                             {COLOR_HEAL}
                             text= _ "Redeem recharged!"
                         [/unstore_unit]
+                        [delay]
+                            time=500
+                            accelerate=yes
+                        [/delay]
                     [/else]
                 [/if]
                 [if]


### PR DESCRIPTION
I took the calculations in redeeming and put the results in a lua table of probabilities, then added a couple tags which return yes/no for a redeem on a target.  I think this version is a lot easier to read.

There were some disagreements between the redeem level descriptions and the results of the WML calculations.  I assumed the calculations were always the intended behaviour and produced correct results.  There should be no difference in the results.

The redeem level descriptions have been updated to reflect actual behaviour.

I did a hundred or so redeem attacks with both redeem level <5 and level >5, while watching the lookup results and spot checking the probabilities were correct.  Also advanced a few times.  All went as planned (eventually, took me awhile to understand why you did the check for adjacent units FIRST which seemed kind of backward -- at the time).

Closes #561