### PR TITLE
add EVASION macro

### DIFF
--- a/scenarios7/10_The_Dragon_and_the_Princess.cfg
+++ b/scenarios7/10_The_Dragon_and_the_Princess.cfg
@@ -586,47 +586,8 @@
         [/endlevel]
     [/event]
 
-    [event]
-        name=attacker_misses
-        first_time_only=no
-        [filter_second]
-            ability=lethalia_evasion
-        [/filter_second]
-        [store_locations]
-            [filter_adjacent_location]
-                x,y=$x2,$y2
-            [/filter_adjacent_location]
-            [not]
-                terrain=Xuc,Xu,Xol,Xos
-            [/not]
-            variable=dodge_locs
-        [/store_locations]
-        [foreach]
-            array=dodge_locs
-            [do]
-                [if]
-                    [have_unit]
-                        x,y=$this_item.x,$this_item.y
-                    [/have_unit]
-                    [else]
-                        {MOVE_UNIT id=$second_unit.id $this_item.x $this_item.y}
-                        [break][/break]
-                    [/else]
-                [/if]
-            [/do]
-        [/foreach]
-        {CLEAR_VARIABLE dodge_locs}
-    [/event]
-    [event]
-        name=attacker_misses
-        [filter_second]
-            ability=lethalia_evasion
-        [/filter_second]
-        [message]
-            speaker=Lethalia_evil
-            message= _ "Hahaha, nobody can match my dexterity!"
-        [/message]
-    [/event]
+    {EVASION lethalia_evasion "Xuc,Xu,Xol,Xos"}
+
     {GENERIC_DEATHS}
     {DROPS 5 7 (axe,axe,staff,staff,sword,sword,sword,knife,bow,bow,xbow,spear,spear,bow,dagger,mace) yes 2,3,4}
     [event]

--- a/scenarios7/10_The_Dragon_and_the_Princess.cfg
+++ b/scenarios7/10_The_Dragon_and_the_Princess.cfg
@@ -586,7 +586,7 @@
         [/endlevel]
     [/event]
 
-    {EVASION lethalia_evasion "Xuc,Xu,Xol,Xos"}
+    {EVASION lethalia_evasion}
 
     {GENERIC_DEATHS}
     {DROPS 5 7 (axe,axe,staff,staff,sword,sword,sword,knife,bow,bow,xbow,spear,spear,bow,dagger,mace) yes 2,3,4}

--- a/scenarios7/12_The_Last_Enemy.cfg
+++ b/scenarios7/12_The_Last_Enemy.cfg
@@ -426,47 +426,7 @@
             experience=no
         [/kill]
     [/event]
-    [event]
-        name=attacker_misses
-        first_time_only=no
-        [filter_second]
-            ability=lethalia_evasion
-        [/filter_second]
-        [store_locations]
-            [filter_adjacent_location]
-                x,y=$x2,$y2
-            [/filter_adjacent_location]
-            [not]
-                terrain=Xuc,Xu,Xol,Xos
-            [/not]
-            variable=dodge_locs
-        [/store_locations]
-        [foreach]
-            array=dodge_locs
-            [do]
-                [if]
-                    [have_unit]
-                        x,y=$this_item.x,$this_item.y
-                    [/have_unit]
-                    [else]
-                        {MOVE_UNIT id=$second_unit.id $this_item.x $this_item.y}
-                        [break][/break]
-                    [/else]
-                [/if]
-            [/do]
-        [/foreach]
-        {CLEAR_VARIABLE dodge_locs}
-    [/event]
-    [event]
-        name=attacker_misses
-        [filter_second]
-            ability=lethalia_evasion
-        [/filter_second]
-        [message]
-            speaker=second_unit
-            message= _ "Hahaha, you still think you can match my dexterity?"
-        [/message]
-    [/event]
+    {EVASION lethalia_evasion "Xuc,Xu,Xol,Xos"}
     [event]
         name=new turn
         first_time_only=no

--- a/scenarios7/12_The_Last_Enemy.cfg
+++ b/scenarios7/12_The_Last_Enemy.cfg
@@ -426,7 +426,7 @@
             experience=no
         [/kill]
     [/event]
-    {EVASION lethalia_evasion "Xuc,Xu,Xol,Xos"}
+    {EVASION lethalia_evasion}
     [event]
         name=new turn
         first_time_only=no

--- a/scenarios7/14_Arctic_Wastelands.cfg
+++ b/scenarios7/14_Arctic_Wastelands.cfg
@@ -962,7 +962,7 @@ You can build a keep anywhere for 50 gold, or a village for 10 gold. (see option
             experience=no
         [/kill]
     [/event]
-    {EVASION lethalia_evasion "Xuc,Xu,Xol,Xos,Zic,Ms^Xm"}
+    {EVASION lethalia_evasion}
     [event]
         name=attacker_hits
         [filter_second]

--- a/scenarios7/14_Arctic_Wastelands.cfg
+++ b/scenarios7/14_Arctic_Wastelands.cfg
@@ -962,47 +962,7 @@ You can build a keep anywhere for 50 gold, or a village for 10 gold. (see option
             experience=no
         [/kill]
     [/event]
-    [event]
-        name=attacker_misses
-        first_time_only=no
-        [filter_second]
-            ability=lethalia_evasion
-        [/filter_second]
-        [store_locations]
-            [filter_adjacent_location]
-                x,y=$x2,$y2
-            [/filter_adjacent_location]
-            [not]
-                terrain=Xuc,Xu,Xol,Xos,Zic,Ms^Xm
-            [/not]
-            variable=dodge_locs
-        [/store_locations]
-        [foreach]
-            array=dodge_locs
-            [do]
-                [if]
-                    [have_unit]
-                        x,y=$this_item.x,$this_item.y
-                    [/have_unit]
-                    [else]
-                        {MOVE_UNIT id=$second_unit.id $this_item.x $this_item.y}
-                        [break][/break]
-                    [/else]
-                [/if]
-            [/do]
-        [/foreach]
-        {CLEAR_VARIABLE dodge_locs}
-    [/event]
-    [event]
-        name=attacker_misses
-        [filter_second]
-            ability=lethalia_evasion
-        [/filter_second]
-        [message]
-            speaker=second_unit
-            message= _ "Hahaha, you still think you can match my dexterity?"
-        [/message]
-    [/event]
+    {EVASION lethalia_evasion "Xuc,Xu,Xol,Xos,Zic,Ms^Xm"}
     [event]
         name=attacker_hits
         [filter_second]

--- a/scenarios7/15_Annihilation.cfg
+++ b/scenarios7/15_Annihilation.cfg
@@ -520,7 +520,7 @@
         [/if]
         {CLEAR_VARIABLE Lethstore,spawn_type,enemy_store}
     [/event]
-    {EVASION lethalia_evasion "Xuc,Xu,Xol,Xos"}
+    {EVASION lethalia_evasion}
     [event]
         name=die
         [filter]

--- a/scenarios7/15_Annihilation.cfg
+++ b/scenarios7/15_Annihilation.cfg
@@ -520,48 +520,7 @@
         [/if]
         {CLEAR_VARIABLE Lethstore,spawn_type,enemy_store}
     [/event]
-
-    [event]
-        name=attacker_misses
-        first_time_only=no
-        [filter_second]
-            ability=lethalia_evasion
-        [/filter_second]
-        [store_locations]
-            [filter_adjacent_location]
-                x,y=$x2,$y2
-            [/filter_adjacent_location]
-            [not]
-                terrain=Xuc,Xu,Xol,Xos
-            [/not]
-            variable=dodge_locs
-        [/store_locations]
-        [foreach]
-            array=dodge_locs
-            [do]
-                [if]
-                    [have_unit]
-                        x,y=$this_item.x,$this_item.y
-                    [/have_unit]
-                    [else]
-                        {MOVE_UNIT id=$second_unit.id $this_item.x $this_item.y}
-                        [break][/break]
-                    [/else]
-                [/if]
-            [/do]
-        [/foreach]
-        {CLEAR_VARIABLE odge_locs}
-    [/event]
-    [event]
-        name=attacker_misses
-        [filter_second]
-            ability=lethalia_evasion
-        [/filter_second]
-        [message]
-            speaker=second_unit
-            message= _ "Hahaha, you still think you can match my dexterity?"
-        [/message]
-    [/event]
+    {EVASION lethalia_evasion "Xuc,Xu,Xol,Xos"}
     [event]
         name=die
         [filter]

--- a/units/Uria.cfg
+++ b/units/Uria.cfg
@@ -670,5 +670,6 @@
             [/frame]
         [/attack_anim]
     [/variation]
-    {EVASION uria_evasion "X*,Q*"}
+    #{EVASION uria_evasion "X*,Q*"}
+    {EVASION uria_evasion}
 [/unit_type]

--- a/units/Uria.cfg
+++ b/units/Uria.cfg
@@ -670,6 +670,5 @@
             [/frame]
         [/attack_anim]
     [/variation]
-    #{EVASION uria_evasion "X*,Q*"}
     {EVASION uria_evasion}
 [/unit_type]

--- a/units/Uria.cfg
+++ b/units/Uria.cfg
@@ -670,44 +670,5 @@
             [/frame]
         [/attack_anim]
     [/variation]
-    [event]
-        name=attacker_misses
-        first_time_only=no
-        [filter_second]
-            ability=uria_evasion
-        [/filter_second]
-        [store_locations]
-            [filter_adjacent_location]
-                x,y=$x2,$y2
-            [/filter_adjacent_location]
-            [not]
-                terrain=X*,Q*
-            [/not]
-            variable=dodge_locs
-        [/store_locations]
-        {VARIABLE moved 0}
-        [foreach]
-            array=dodge_locs
-            [do]
-                [if]
-                    [have_unit]
-                        x,y=$this_item.x,$this_item.y
-                    [/have_unit]
-                    [else]
-                        [if]
-                            [variable]
-                                name=moved
-                                equals=0
-                            [/variable]
-                            [then]
-                                {MOVE_UNIT id=$second_unit.id $this_item.x $this_item.y}
-                                {VARIABLE moved 1}
-                            [/then]
-                        [/if]
-                    [/else]
-                [/if]
-            [/do]
-        [/foreach]
-        {CLEAR_VARIABLE moved,dodge_locs}
-    [/event]
+    {EVASION uria_evasion "X*,Q*"}
 [/unit_type]

--- a/utils/utils.cfg
+++ b/utils/utils.cfg
@@ -1838,7 +1838,7 @@ $item_info.description"
     [/event]
 #enddef
 
-#define EVASION ABILITY AVOID_TERRAIN
+#define EVASION ABILITY
     [event]
         name=attacker_misses
         id=evasion_taunt
@@ -1854,16 +1854,16 @@ $item_info.description"
                 message=_"Hahaha, nobody can match my dexterity!"
             [/value]
             [value]
-                message=_"Missed me by that <span font='oblique'>that</span> much"   # TV show Get Smart
+                message=_"Missed me by that <span font='oblique'>that</span> much"   # Translation hint: TV show Get Smart
             [/value]
             [value]
-                message=_"Hey man, nice shot!"  # Really lame pop song by American band Filter
+                message=_"Hey man, nice shot!"  # Translation hint: Really lame pop song by American band Filter
             [/value]
             [value]
-                message=_"A swing and a miss!"  # Movie named Major League
+                message=_"A swing and a miss!"  # Translation hint: Movie named Major League
             [/value]
             [value]
-                message=_"Just a <span font='oblique'>bit</span> outside!"  # Movie named Major League
+                message=_"Just a <span font='oblique'>bit</span> outside!"  # Translation hint: Movie named Major League
             [/value]
         [/set_variables]
         {VARIABLE_OP rand rand (1..$msgs.length)}
@@ -1880,8 +1880,8 @@ $item_info.description"
                     equals="Efraim"
                 [/variable]
             [/and]
-            [then]
-                {VARIABLE msg _"Missed me, missed me, now ya gotta kiss me!"}   # Child's taunt
+            [then]    # Translation hint: Common child's taunt, chosen based on earlier dialog by Lethalia_evil regarding her feelings for Efraim
+                {VARIABLE msg _"Missed me, missed me, now ya gotta kiss me!"}
             [/then]
         [/if]
         [message]
@@ -1902,7 +1902,7 @@ $item_info.description"
                 x,y=$x2,$y2
             [/filter_adjacent_location]
             [not]
-                terrain={AVOID_TERRAIN}
+                terrain="Ms^Xm,Q*,X*,Zic"
             [/not]
             variable=dodge_locs
         [/store_locations]

--- a/utils/utils.cfg
+++ b/utils/utils.cfg
@@ -1837,3 +1837,89 @@ $item_info.description"
         [/clear_menu_item]
     [/event]
 #enddef
+
+#define EVASION ABILITY AVOID_TERRAIN
+    [event]
+        name=attacker_misses
+        id=evasion_taunt
+        [filter_second]
+            ability={ABILITY}
+        [/filter_second]
+        [set_variables]
+            name=msgs
+            [value]
+                message=_"Hahaha, you think you can match my dexterity, $unit.name|?"
+            [/value]
+            [value]
+                message=_"Hahaha, nobody can match my dexterity!"
+            [/value]
+            [value]
+                message=_"Missed me by that <span font='oblique'>that</span> much"   # TV show Get Smart
+            [/value]
+            [value]
+                message=_"Hey man, nice shot!"  # Really lame pop song by American band Filter
+            [/value]
+            [value]
+                message=_"A swing and a miss!"  # Movie named Major League
+            [/value]
+            [value]
+                message=_"Just a <span font='oblique'>bit</span> outside!"  # Movie named Major League
+            [/value]
+        [/set_variables]
+        {VARIABLE_OP rand rand (1..$msgs.length)}
+        {VARIABLE_OP rand sub 1}
+        {VARIABLE msg $msgs[$rand].message}
+        [if]
+            [variable]
+                name=second_unit.id
+                equals="Lethalia_evil"
+            [/variable]
+            [and]
+                [variable]
+                    name=unit.id
+                    equals="Efraim"
+                [/variable]
+            [/and]
+            [then]
+                {VARIABLE msg _"Missed me, missed me, now ya gotta kiss me!"}   # Child's taunt
+            [/then]
+        [/if]
+        [message]
+            speaker=second_unit
+            message=$msg
+        [/message]
+        {CLEAR_VARIABLE msgs,rand,msg}
+    [/event]
+    [event]
+        name=attacker_misses
+        id=evasion
+        first_time_only=no
+        [filter_second]
+            ability={ABILITY}
+        [/filter_second]
+        [store_locations]
+            [filter_adjacent_location]
+                x,y=$x2,$y2
+            [/filter_adjacent_location]
+            [not]
+                terrain={AVOID_TERRAIN}
+            [/not]
+            variable=dodge_locs
+        [/store_locations]
+        [foreach]
+            array=dodge_locs
+            [do]
+                [if]
+                    [have_unit]
+                        x,y=$this_item.x,$this_item.y
+                    [/have_unit]
+                    [else]
+                        {MOVE_UNIT id=$second_unit.id $this_item.x $this_item.y}
+                        [break][/break]
+                    [/else]
+                [/if]
+            [/do]
+        [/foreach]
+        {CLEAR_VARIABLE dodge_locs}
+    [/event]
+#enddef


### PR DESCRIPTION
Move some redundant code into a single macro.

Originally, there was one taunt for the first time (unless you got extremely lucky), and then one for subsequent misses.  I broke that, could fix it, but I don't think it's worth it (I was thinking you pass a message when you want a specific message, or "" to let the macro pick one for you).

I put a variable in a message.  I really like it.  I can take it out.

It looks like only one attacker_misses is getting used.  Reversing the order (so the one time taunt comes first) was the only way to get the taunt event to run (other than commenting out the other one).  This is consistent with the previous version, but probably not what was originally intended.

