### PR TITLE
a little easier

### DIFF
--- a/scenarios10/13_Black_Souls.cfg
+++ b/scenarios10/13_Black_Souls.cfg
@@ -5,7 +5,7 @@
     map_data="{~add-ons/Legend_of_the_Invincibles/maps/13_Laboratory_Centre.map}"
     next_scenario=14_End_of_the_World
     {GLOBAL_EVENTS}
-    {TURNS 25 23 21}
+    {TURNS 27 25 23}
     experience_modifier=80
     victory_when_enemies_defeated=no
     {INDOORS}
@@ -150,6 +150,9 @@
         [/recall]
         {PLACE_IMAGE scenery/portal-red.png 1 30}
         {VARIABLE spawn_count 30}
+#ifdef EASY
+        {VARIABLE spawn_count 25}
+#endif
         [while]
             [variable]
                 name=spawn_count
@@ -159,7 +162,12 @@
                 {VARIABLE_OP spawn_type rand (Bowman,Spearman,Heavy Infantryman,Dark Adept,Longbowman,Swordsman,Javelineer,Pikeman,Shock Trooper,Dark Sorcerer)}
                 [unit]
                     type=$spawn_type
+#ifdef HARD
                     x,y=26,28
+#endif
+#ifndef HARD
+                    x,y=27,29
+#endif
                     side=3
                     to_variable=blackening_store
                     generate_name=yes


### PR DESCRIPTION
While testing, I played 10/13 Black Souls.  It was as bad as I remember.  Choosing/crafting just the right gear, moving/attacking very very carefully, save loading a couple times, taking about 4 greater healing potions, and using skirmisher to race through the last 20% or so of the map, I barely made it in time.  Having a anti-demon potion was probably the difference between success and failure.

Propose a few tweaks.  It's still going to be quite hard, but it is the last real scenario.  I tried these on normal, and I found the changes to be just enough to give you a fair chance of surviving the first few turns without cheating (granted, I only played it once, and only for the first several turns).

- Added two turns
- Decreased number of black souls at beginning on easy
- For easy/normal, move black souls back slightly, giving player a chance to live through turn 2