### PR TITLE
Abilities

### DIFF
--- a/scenarios10/13_Black_Souls.cfg
+++ b/scenarios10/13_Black_Souls.cfg
@@ -5,7 +5,7 @@
     map_data="{~add-ons/Legend_of_the_Invincibles/maps/13_Laboratory_Centre.map}"
     next_scenario=14_End_of_the_World
     {GLOBAL_EVENTS}
-    {TURNS 25 23 21}
+    {TURNS 27 25 23}
     experience_modifier=80
     victory_when_enemies_defeated=no
     {INDOORS}
@@ -150,6 +150,9 @@
         [/recall]
         {PLACE_IMAGE scenery/portal-red.png 1 30}
         {VARIABLE spawn_count 30}
+#ifdef EASY
+        {VARIABLE spawn_count 25}
+#endif
         [while]
             [variable]
                 name=spawn_count
@@ -159,7 +162,12 @@
                 {VARIABLE_OP spawn_type rand (Bowman,Spearman,Heavy Infantryman,Dark Adept,Longbowman,Swordsman,Javelineer,Pikeman,Shock Trooper,Dark Sorcerer)}
                 [unit]
                     type=$spawn_type
+#ifdef HARD
                     x,y=26,28
+#endif
+#ifndef HARD
+                    x,y=27,29
+#endif
                     side=3
                     to_variable=blackening_store
                     generate_name=yes

--- a/utils/abilities.cfg
+++ b/utils/abilities.cfg
@@ -566,9 +566,7 @@ Enemy units cannot see this unit during dawn or dusk, except if they have units 
         cumulative=no
         name= _ "leadership (as level " + {LEVEL} + _" unit)"
         female_name= _ "female^leadership"
-        description= _ "This unit can lead your own units that are next to it, making them fight better.
-
-Adjacent own units of lower level will do more damage in battle. When a unit adjacent to, of a lower level than, and on the same side as a unit with Leadership engages in combat, its attacks do 25% more damage times the difference in their levels."
+        description= _ "This unit can lead your own units that are next to it, making them fight better.  Adjacent own units of lower level will do more damage in battle. When a unit adjacent to, of a lower level than, and on the same side as a unit with Leadership engages in combat, its attacks do 25% more damage times the difference in their levels."
         special_note = _"The leadership of this unit enables adjacent units of the same side to deal more damage in combat, though this only applies to units of lower level."
         affect_self=no
         [affect_adjacent]
@@ -657,12 +655,8 @@ Adjacent own units of lower level will do more damage in battle. When a unit adj
         female_name= _ "female^snow ambush"
         name_inactive= _ "snow ambush"
         female_name_inactive= _ "female^snow ambush"
-        description= _ "This unit can hide on frozen terrains, and remain undetected by its enemies.
-
-Enemy units cannot see this unit while it is on frozen terrains, except if they have units next to it. Any enemy unit that first discovers this unit immediately loses all its remaining movement."
-        description_inactive= _ "This unit can hide on frozen terrains, and remain undetected by its enemies.
-
-Enemy units cannot see this unit while it is on frozen terrains, except if they have units next to it. Any enemy unit that first discovers this unit immediately loses all its remaining movement."
+        description= _ "This unit can hide on frozen terrains when not next to an enemy unit, and remain undetected by its enemies.  Any enemy unit that first discovers this unit immediately loses all its remaining movement."
+        description_inactive= _ "This unit can hide on frozen terrains when not next to an enemy unit, and remain undetected by its enemies.  Any enemy unit that first discovers this unit immediately loses all its remaining movement."
         affect_self=yes
         [filter_self]
             [filter_location]
@@ -678,12 +672,8 @@ Enemy units cannot see this unit while it is on frozen terrains, except if they 
         female_name= _ "female^lesser ambush"
         name_inactive= _ "lesser ambush"
         female_name_inactive= _ "female^lesser ambush"
-        description= _ "This unit can hide in forest, and remain undetected by its enemies. But only in deciduous forest.
-
-Enemy units cannot see this unit while it is in forest, except if they have units next to it. Any enemy unit that first discovers this unit immediately loses all its remaining movement."
-        description_inactive= _ "This unit can hide in forest, and remain undetected by its enemies. But only in deciduous forest.
-
-Enemy units cannot see this unit while it is in forest, except if they have units next to it. Any enemy unit that first discovers this unit immediately loses all its remaining movement."
+        description= _ "This unit can hide in deciduous forest when not next to an enemy unit, and remain undetected by its enemies.  Any enemy unit that first discovers this unit immediately loses all its remaining movement."
+        description_inactive= _ "This unit can hide in deciduous forest when not next to an enemy unit, and remain undetected by its enemies.  Any enemy unit that first discovers this unit immediately loses all its remaining movement."
         affect_self=yes
         [filter_self]
             [filter_location]
@@ -791,9 +781,7 @@ Does not affect poisoned enemies."
         cumulative=yes
         name= _ "heals +"+{VALUE}
         female_name= _ "female^heals +"+{VALUE}
-        description= _ "This unit combines herbal remedies with magic to heal units more quickly than is normally possible on the battlefield.
-
-A unit cared for by this healer may heal up to "+{VALUE}+_" HP per turn, or be cured of poisoning."
+        description= _ "This unit combines herbal remedies with magic to heal units more quickly than is normally possible on the battlefield.  A unit cared for by this healer may heal up to "+{VALUE}+_" HP per turn, or be cured of poisoning."
         affect_self=no
         poison=cured
         [affect_adjacent]
@@ -964,12 +952,8 @@ A unit cared for by this healer may heal up to "+{VALUE}+_" HP per turn, or be c
         id=lesser nightstalk
         name= _ "lesser nightstalk"
         female_name= _ "lesser nightstalk"
-        description= _ "The unit becomes invisible during night, but only in forests, hills, mountains and villages.
-
-Enemy units cannot see this unit at night, except if they have units next to it. Any enemy unit that first discovers this unit immediately loses all its remaining movement."
-        description_inactive= _ "The unit becomes invisible during night, but only in forests, hills, mountains and villages.
-
-Enemy units cannot see this unit at night, except if they have units next to it. Any enemy unit that first discovers this unit immediately loses all its remaining movement."
+        description= _ "The unit becomes invisible during night when not next to an enemy unit, but only in forests, hills, mountains and villages.  Any enemy unit that first discovers this unit immediately loses all its remaining movement."
+        description_inactive= _ "The unit becomes invisible during night when not next to an enemy unit, but only in forests, hills, mountains and villages.  Any enemy unit that first discovers this unit immediately loses all its remaining movement."
         affect_self=yes
         [filter_self]
             [filter_location]
@@ -986,12 +970,8 @@ Enemy units cannot see this unit at night, except if they have units next to it.
         female_name= _ "nocturnal ambush"
         name_inactive= _ "nocturnal ambush"
         female_name_inactive= _ "female^nocturnal ambush"
-        description= _ "The unit becomes invisible in forests, but only at night.
-
-Enemy units cannot see this unit at night, except if they have units next to it. Any enemy unit that first discovers this unit immediately loses all its remaining movement."
-        description_inactive= _ "The unit becomes invisible in forests, but only at night.
-
-Enemy units cannot see this unit at night, except if they have units next to it. Any enemy unit that first discovers this unit immediately loses all its remaining movement."
+        description= _ "The unit becomes invisible in forests when not next to an enemy unit, but only at night.  Any enemy unit that first discovers this unit immediately loses all its remaining movement."
+        description_inactive= _ "The unit becomes invisible in forests when not next to an enemy unit, but only at night.  Any enemy unit that first discovers this unit immediately loses all its remaining movement."
         affect_self=yes
         [filter_self]
             [filter_location]


### PR DESCRIPTION
I have an enhancement request to improve how wesnoth handles tooltips for units with lots of items. 

https://forums.wesnoth.org/viewtopic.php?p=682946#p682946

Of course, we can always go to Unit Information, but I'd prefer to do that only when necessary.  To make it more likely that the abilities will fit in the main wesnoth gui tooltip, I propose shortening some of the descriptions.

I'd also like to figure out where wesnoth adds blankline, ----------, blankline to the list and get rid of those.