### PR TITLE
fix crafting side-effect

### DIFF
--- a/lua/crafting.lua
+++ b/lua/crafting.lua
@@ -599,7 +599,7 @@ loti.gem.show_crafting_window = function(x, y)
 					dialog.gui_recipe_chosen:remove_items_at(1, 0)
 
 					order = 1
-					for _, i in ipairs(loti.item.type.numbers_between(word_from, word_to + 1)) do
+					for _, i in ipairs(loti.item.type.numbers_between(word_from, word_to)) do
 						local item = loti.item.type[i]
 						dialog.gui_recipe_chosen[order].gui_recipe_name.label = item.name
 						if can_craft(i) then


### PR DESCRIPTION
When I fixed loti.item.type.numbers_between, I introduced a side-effect in crafting.

This time I did a search, and nothing else should have been affected.

I still don't like the whole idea of that function.  If you look at item_list.cfg there's a comment that Dugi's Wrath will  have the highest number.  Next you see several items with higher numbers.  Because things change.  Oh well, I used it myself, so who am I to complain?