### PR TITLE
replace FOREACH in spinoffs

### DIFF
--- a/spinoffs/Affably_Evil/scenarios/05_Dark_Days_Upon_Us.cfg
+++ b/spinoffs/Affably_Evil/scenarios/05_Dark_Days_Upon_Us.cfg
@@ -11,17 +11,17 @@
 
     [story]
         [part]
-        show_title=no
+            show_title=no
             background=story/forest-chat.jpg
             story= _ "Initially, they told no one about their plan to travel north. Of course, everyone else knew about it, but Fowleri was unaware of it. They begun preparing it. For convenience, Fowleri decided that it was time to scout the forest in pairs and report any interesting landmarks."
         [/part]
         [part]
-        show_title=no
+            show_title=no
             background=story/forest-chat.jpg
             story= _ "However, her explanation was that it helps them see more in the forest than just trees and leaf litter. The real reason was, of course, to be with Krux alone."
         [/part]
         [part]
-        show_title=no
+            show_title=no
             background=story/krux-fowleri-kiss.jpg
             story= _ "Those days were amazing, for both. Fowleri's horrible memories how her first love ended faded like a boring dream and Krux learned the difference between toying with people and love. However, these idyllic days were bound to end. Unpleasantly."
         [/part]
@@ -30,9 +30,9 @@
     [side]
         type=Krux_father
         id=Krux
-    name=_"Krux"
+        name=_"Krux"
         canrecruit=yes
-    unrenamable=yes
+        unrenamable=yes
         side=1
         controller=human
         recruit=
@@ -49,25 +49,24 @@
         side=2
         team_name=nuisance
         user_team_name=_"Nuisance"
-    [ai]
-        agression=1.0
-    [/ai]
+        [ai]
+            agression=1.0
+        [/ai]
     [/side]
     [side]
         no_leader=yes
         side=3
         team_name=nuisance
         user_team_name=_"More nuisance"
-    [ai]
-        agression=1.0
-    [/ai]
+        [ai]
+            agression=1.0
+        [/ai]
     [/side]
 
-
     [event]
-    name=prestart
-    {VARIABLE current_scenario dark_days_upon_us}
-    {AE_RECALL_ALL 47 26}
+        name=prestart
+        {VARIABLE current_scenario dark_days_upon_us}
+        {AE_RECALL_ALL 47 26}
         [objectives]
             side=1
             [objective]
@@ -86,200 +85,200 @@
     [/event]
 
     [event]
-    name=start
-    [message]
-        speaker=Antipos
-        message=_"During today's practice, we have improved our skill at travelling through forest at night. Without using illumination. It is amazing me what I can do now, before I could do it only in winter when the nocturnal sky was visible through the bare trees. Or in deserts where trees do not grow."
-    [/message]
-    [message]
-        speaker=Acanthamoeba
-        message=_"I have also noticed that there is a river west from here. It leads through a wall of mountains and across a valley, and then it flows through other mountains. But the trail there was rather for dwarves."
-    [/message]
-    [message]
-        speaker=Krux
-        message=_"We..."
-    [/message]
-    {GENERIC_UNIT 2 "Orcish Warrior" 48 32}
-    [+unit]
-        id=first_orc
-    [/unit]
-    {GENERIC_UNIT 2 "Orcish Grunt" 47 32}
-    [+unit]
-        id=second_orc
-    [/unit]
-    [message]
-        speaker=first_orc
-        message=_"Look, man, there are some humans or something."
-    [/message]
-    [message]
-        speaker=second_orc
-        message=_"Yes, we found them. Hey, captain, humans are here! This way, we should follow them!"
-    [/message]
-    [message]
-        speaker=first_orc
-        message=_"They might be elves actually. I cannot see from this distance what they are."
-    [/message]
-    [message]
-        speaker=Acanthamoeba
-        message=_"Orcs! It is time to cut some heads off without remorse!"
-    [/message]
-    [message]
-        speaker=Antipos
-        message=_"Orcs were not here for very long. If they appeared, they are most likely more numerous than two grunts and one captain."
-    [/message]
-    [message]
-        speaker=Fowleri
-        message=_"Orcs... these parasites are coming again. They breed like rats, if you forget to kill some who hid, after a single century there will be an army of them again. These orcs will be just a vanguard, but they are most likely too numerous for us to handle. And even if we managed to destroy them, the main force would come and crush us."
-    [/message]
-    [repeating_message]
-        speaker=Acanthamoeba
-        first=_"What should we do?"
-        message=_"Any more ideas?"
-        [option]
-        message=_"We could run to the hills. They would not find us. When they pass, we can return and alarm the army."
-        [command]
-            [message]
-                speaker=Hare
-                message=_"I like that. Exactly my style, hiding in the hills!"
-            [/message]
-            [message]
-                speaker=Xalzaxx
-                message=_"Are we such cowards? Or do you think that it is reasonable to be cowards?"
-            [/message]
-            [message]
-                speaker=Fowleri
-                message=_"The orcs had to pass through the hills. They are not coming from the north only because they were wandering around looking for anybody. The hills most likely mean only more orcs."
-            [/message]
-            [message]
-                speaker=Antipos
-                message=_"And orcs have a certain advantage on hills, I think."
-            [/message]
-        [/command]
-        [/option]
-        [option]
-        message=_"That path that crosses the mountains you told us about. An army cannot pass through a narrow mountain trail quickly."
-        [command]
-            [message]
-                speaker=Judas
-                message=_"Nice memory, Krux. I have been there with her and this did not come to my mind."
-            [/message]
-            [message]
-                speaker=Fowleri
-                message=_"If I remember the map correctly, the path should lead into Amaranth, an elvish town. They should be alarmed about the orcs."
-            [/message]
-            [message]
-                speaker=Acanthamoeba
-                message=_"And fellow humans?"
-            [/message]
-            [message]
-                speaker=Krux
-                message=_"I can send short messages to my mother at distance. Magic."
-            [/message]
-            [message]
-                speaker=Antipos
-                message=_"It sounds like a decent plan."
-            [/message]
-            [break]
-            [/break]
-        [/command]
-        [/option]
-        [option]
-        message=_"Can you, better experts on magic than I, prepare a powerful spell that would help us slay these orcs quickly and report to Emants as soon as possible?"
-        [command]
-            [message]
-                speaker=Lucretia
-                message=_"Sorry, I have skill only with usual combat magic, deeper knowledge that would be required for spells like that eludes me."
-            [/message]
-            [message]
-                speaker=Judas
-                message=_"Do not look at me, I am only a healer."
-            [/message]
-            [message]
-                speaker=Antipos
-                message=_"My magic is much different from Fowleri's. It would take us very long to understand each other's priciples of magic so that we could collaborate like that."
-            [/message]
-            [message]
-                speaker=Fowleri
-                message=_"Yes, exactly as he said."
-            [/message]
-        [/command]
-        [/option]
-        [option]
-        message=_"How about having Acantha marry their boss?"
-        [command]
-            [message]
-                speaker=Fowleri
-                message=_"Are you insane?"
-            [/message]
-            [message]
-                speaker=Krux
-                message=_"No, this is only an old joke of ours. No one was taking it seriously. Am I right, Acantha?"
-            [/message]
-            [message]
-                speaker=Acanthamoeba
-                message=_"No, no! You are deadly serious! Always when you tell it, near every enemy that is not undead!"
-            [/message]
-            [message]
-                speaker=Krux
-                message=_"What is your problem with marrying liches?"
-            [/message]
-            [message]
-                speaker=Acanthamoeba
-                message=_"Well, you know..."
-            [/message]
-            [message]
-                speaker=Krux
-                message=_"Ah, yes, you like men with muscles."
-            [/message]
-        [/command]
-        [/option]
-    [/repeating_message]
-    [message]
-        speaker=Acanthamoeba
-        message=_"Now, another issue. Most of us cannot travel through forest as fast as elves can and the orcs might catch you. They move quite fast through hills and we will have to cross some hills. What shall we do?"
-    [/message]
-    [message]
-        speaker=Krux
-        message=_"Fowleri, you were quite good at using various magical tricks to amaze people. Can you use something like that to slow them down?"
-    [/message]
-    [message]
-        speaker=Fowleri
-        message=_"Yes, I can. I can summon magical mists that are invisible until you step into them, and inside you see almost nothing, getting lost very fast. They will lose their way very often, but due to the nature of the spell, they will find it again quite qickly."
-    [/message]
-    [message]
-        speaker=Antipos
-        message=_"There is another issue. We cannot know how many orcish scouts are ahead of us. You have taught us how to be stealthy, and that might have made the scouts fail to notice us."
-    [/message]
-    [message]
-        speaker=Acanthamoeba
-        message=_"We might simply kill them on the way, they are scouts, not fighters, and most likely they will not be in large packs. If the spell delays the orcs behind us sufficiently..."
-    [/message]
-    [message]
-        speaker=dwarf_merc
-        message=_"Beautiful. Now we are going to have also some fun on the way. It seems that I should not have regretted joining you."
-    [/message]
-    [message]
-        speaker=Krux
-        message=_"By the way, I have just magically sent a message to my mother to send soldiers to help Amaranth. We need to arrive as soon as possible to explain the elves what is the problem so that they would let them in."
-    [/message]
-    {SCENARIO_DURATION_VARIABLE spawn_count 0}
-    {VARIABLE count 10}
-    [while]
-        [variable]
-            name=count
-            greater_than=0
-        [/variable]
-        [do]
-            {VARIABLE_OP type rand "Orcish Warlord,Orcish Warrior,Orcish Slurbow,Orcish Crossbowman,Orcish Slayer"}
-            {GENERIC_UNIT 2 $type 48 33}
-            [+unit]
-                id=spawn_$spawn_count
-            [/unit]
-            {MOVE_UNIT id=spawn_$spawn_count 48 32}
-            {VARIABLE_OP count sub 1}
-            {VARIABLE_OP spawn_count add 1}
-        [/do]
-    [/while]
+        name=start
+        [message]
+            speaker=Antipos
+            message=_"During today's practice, we have improved our skill at travelling through forest at night. Without using illumination. It is amazing me what I can do now, before I could do it only in winter when the nocturnal sky was visible through the bare trees. Or in deserts where trees do not grow."
+        [/message]
+        [message]
+            speaker=Acanthamoeba
+            message=_"I have also noticed that there is a river west from here. It leads through a wall of mountains and across a valley, and then it flows through other mountains. But the trail there was rather for dwarves."
+        [/message]
+        [message]
+            speaker=Krux
+            message=_"We..."
+        [/message]
+        {GENERIC_UNIT 2 "Orcish Warrior" 48 32}
+        [+unit]
+            id=first_orc
+        [/unit]
+        {GENERIC_UNIT 2 "Orcish Grunt" 47 32}
+        [+unit]
+            id=second_orc
+        [/unit]
+        [message]
+            speaker=first_orc
+            message=_"Look, man, there are some humans or something."
+        [/message]
+        [message]
+            speaker=second_orc
+            message=_"Yes, we found them. Hey, captain, humans are here! This way, we should follow them!"
+        [/message]
+        [message]
+            speaker=first_orc
+            message=_"They might be elves actually. I cannot see from this distance what they are."
+        [/message]
+        [message]
+            speaker=Acanthamoeba
+            message=_"Orcs! It is time to cut some heads off without remorse!"
+        [/message]
+        [message]
+            speaker=Antipos
+            message=_"Orcs were not here for very long. If they appeared, they are most likely more numerous than two grunts and one captain."
+        [/message]
+        [message]
+            speaker=Fowleri
+            message=_"Orcs... these parasites are coming again. They breed like rats, if you forget to kill some who hid, after a single century there will be an army of them again. These orcs will be just a vanguard, but they are most likely too numerous for us to handle. And even if we managed to destroy them, the main force would come and crush us."
+        [/message]
+        [repeating_message]
+            speaker=Acanthamoeba
+            first=_"What should we do?"
+            message=_"Any more ideas?"
+            [option]
+                message=_"We could run to the hills. They would not find us. When they pass, we can return and alarm the army."
+                [command]
+                    [message]
+                        speaker=Hare
+                        message=_"I like that. Exactly my style, hiding in the hills!"
+                    [/message]
+                    [message]
+                        speaker=Xalzaxx
+                        message=_"Are we such cowards? Or do you think that it is reasonable to be cowards?"
+                    [/message]
+                    [message]
+                        speaker=Fowleri
+                        message=_"The orcs had to pass through the hills. They are not coming from the north only because they were wandering around looking for anybody. The hills most likely mean only more orcs."
+                    [/message]
+                    [message]
+                        speaker=Antipos
+                        message=_"And orcs have a certain advantage on hills, I think."
+                    [/message]
+                [/command]
+            [/option]
+            [option]
+                message=_"That path that crosses the mountains you told us about. An army cannot pass through a narrow mountain trail quickly."
+                [command]
+                    [message]
+                        speaker=Judas
+                        message=_"Nice memory, Krux. I have been there with her and this did not come to my mind."
+                    [/message]
+                    [message]
+                        speaker=Fowleri
+                        message=_"If I remember the map correctly, the path should lead into Amaranth, an elvish town. They should be alarmed about the orcs."
+                    [/message]
+                    [message]
+                        speaker=Acanthamoeba
+                        message=_"And fellow humans?"
+                    [/message]
+                    [message]
+                        speaker=Krux
+                        message=_"I can send short messages to my mother at distance. Magic."
+                    [/message]
+                    [message]
+                        speaker=Antipos
+                        message=_"It sounds like a decent plan."
+                    [/message]
+                    [break]
+                    [/break]
+                [/command]
+            [/option]
+            [option]
+                message=_"Can you, better experts on magic than I, prepare a powerful spell that would help us slay these orcs quickly and report to Emants as soon as possible?"
+                [command]
+                    [message]
+                        speaker=Lucretia
+                        message=_"Sorry, I have skill only with usual combat magic, deeper knowledge that would be required for spells like that eludes me."
+                    [/message]
+                    [message]
+                        speaker=Judas
+                        message=_"Do not look at me, I am only a healer."
+                    [/message]
+                    [message]
+                        speaker=Antipos
+                        message=_"My magic is much different from Fowleri's. It would take us very long to understand each other's priciples of magic so that we could collaborate like that."
+                    [/message]
+                    [message]
+                        speaker=Fowleri
+                        message=_"Yes, exactly as he said."
+                    [/message]
+                [/command]
+            [/option]
+            [option]
+                message=_"How about having Acantha marry their boss?"
+                [command]
+                    [message]
+                        speaker=Fowleri
+                        message=_"Are you insane?"
+                    [/message]
+                    [message]
+                        speaker=Krux
+                        message=_"No, this is only an old joke of ours. No one was taking it seriously. Am I right, Acantha?"
+                    [/message]
+                    [message]
+                        speaker=Acanthamoeba
+                        message=_"No, no! You are deadly serious! Always when you tell it, near every enemy that is not undead!"
+                    [/message]
+                    [message]
+                        speaker=Krux
+                        message=_"What is your problem with marrying liches?"
+                    [/message]
+                    [message]
+                        speaker=Acanthamoeba
+                        message=_"Well, you know..."
+                    [/message]
+                    [message]
+                        speaker=Krux
+                        message=_"Ah, yes, you like men with muscles."
+                    [/message]
+                [/command]
+            [/option]
+        [/repeating_message]
+        [message]
+            speaker=Acanthamoeba
+            message=_"Now, another issue. Most of us cannot travel through forest as fast as elves can and the orcs might catch you. They move quite fast through hills and we will have to cross some hills. What shall we do?"
+        [/message]
+        [message]
+            speaker=Krux
+            message=_"Fowleri, you were quite good at using various magical tricks to amaze people. Can you use something like that to slow them down?"
+        [/message]
+        [message]
+            speaker=Fowleri
+            message=_"Yes, I can. I can summon magical mists that are invisible until you step into them, and inside you see almost nothing, getting lost very fast. They will lose their way very often, but due to the nature of the spell, they will find it again quite qickly."
+        [/message]
+        [message]
+            speaker=Antipos
+            message=_"There is another issue. We cannot know how many orcish scouts are ahead of us. You have taught us how to be stealthy, and that might have made the scouts fail to notice us."
+        [/message]
+        [message]
+            speaker=Acanthamoeba
+            message=_"We might simply kill them on the way, they are scouts, not fighters, and most likely they will not be in large packs. If the spell delays the orcs behind us sufficiently..."
+        [/message]
+        [message]
+            speaker=dwarf_merc
+            message=_"Beautiful. Now we are going to have also some fun on the way. It seems that I should not have regretted joining you."
+        [/message]
+        [message]
+            speaker=Krux
+            message=_"By the way, I have just magically sent a message to my mother to send soldiers to help Amaranth. We need to arrive as soon as possible to explain the elves what is the problem so that they would let them in."
+        [/message]
+        {SCENARIO_DURATION_VARIABLE spawn_count 0}
+        {VARIABLE count 10}
+        [while]
+            [variable]
+                name=count
+                greater_than=0
+            [/variable]
+            [do]
+                {VARIABLE_OP type rand "Orcish Warlord,Orcish Warrior,Orcish Slurbow,Orcish Crossbowman,Orcish Slayer"}
+                {GENERIC_UNIT 2 $type 48 33}
+                [+unit]
+                    id=spawn_$spawn_count
+                [/unit]
+                {MOVE_UNIT id=spawn_$spawn_count 48 32}
+                {VARIABLE_OP count sub 1}
+                {VARIABLE_OP spawn_count add 1}
+            [/do]
+        [/while]
     [/event]
 
     [event]
@@ -294,332 +293,334 @@
     [/event]
 
     [event]
-    name=turn 3
-    {VARIABLE count 10}
-    [while]
-        [variable]
-            name=count
-            greater_than=0
-        [/variable]
-        [do]
-            {VARIABLE_OP type rand "Orcish Warlord,Orcish Warrior,Orcish Slurbow,Orcish Crossbowman,Orcish Slayer"}
-            {GENERIC_UNIT 2 $type 48 33}
-            [+unit]
-                id=spawn_$spawn_count
-            [/unit]
-            {MOVE_UNIT id=spawn_$spawn_count 48 32}
-            {VARIABLE_OP count sub 1}
-            {VARIABLE_OP spawn_count add 1}
-        [/do]
-    [/while]
-    [/event]
-
-    [event]
-    name=new turn
-    first_time_only=no
-    {VARIABLE count 5}
-    [while]
-        [variable]
-            name=count
-            greater_than=0
-        [/variable]
-        [do]
-            {VARIABLE_OP type rand "Orcish Grunt,Orcish Warrior,Orcish Archer,Orcish Crossbowman,Wolf Rider,Orcish Assassin,Orcish Slayer"}
-            {GENERIC_UNIT 2 $type 48 33}
-            [+unit]
-                id=spawn_$spawn_count
-            [/unit]
-            {MOVE_UNIT id=spawn_$spawn_count 50 31}
-            {VARIABLE_OP count sub 1}
-            {VARIABLE_OP spawn_count add 1}
-        [/do]
-    [/while]
-    [/event]
-
-    [event]
-    name=side 2 turn refresh
-    first_time_only=no
-    [store_unit]
-        [filter]
-            side=2
-        [/filter]
-        variable=lost
-        kill=no
-    [/store_unit]
-    {FOREACH lost i}
-        {VARIABLE_OP is_lost rand "0,0,0,0,1,2,3,4,5,6"}
-        [if]
+        name=turn 3
+        {VARIABLE count 10}
+        [while]
             [variable]
-                name=is_lost
-                equals=1
-            [/variable]
-            [then]
-                {VARIABLE target_x "$(2+$lost[$i].x)"}
-                {VARIABLE target_y "$(1+$lost[$i].y)"}
-            [/then]
-        [/if]
-        [if]
-            [variable]
-                name=is_lost
-                equals=2
-            [/variable]
-            [then]
-                {VARIABLE target_x "$(-2+$lost[$i].x)"}
-                {VARIABLE target_y "$(1+$lost[$i].y)"}
-            [/then]
-        [/if]
-        [if]
-            [variable]
-                name=is_lost
-                equals=3
-            [/variable]
-            [then]
-                {VARIABLE target_x "$lost[$i].x"}
-                {VARIABLE target_y "$(3+$lost[$i].y)"}
-            [/then]
-        [/if]
-        [if]
-            [variable]
-                name=is_lost
-                equals=4
-            [/variable]
-            [then]
-                {VARIABLE target_x "$(2+$lost[$i].x)"}
-                {VARIABLE target_y "$(-1+$lost[$i].y)"}
-            [/then]
-        [/if]
-        [if]
-            [variable]
-                name=is_lost
-                equals=5
-            [/variable]
-            [then]
-                {VARIABLE target_x "$(-2+$lost[$i].x)"}
-                {VARIABLE target_y "$(-1+$lost[$i].y)"}
-            [/then]
-        [/if]
-        [if]
-            [variable]
-                name=is_lost
-                equals=6
-            [/variable]
-            [then]
-                {VARIABLE target_x "$lost[$i].x"}
-                {VARIABLE target_y "$(-3+$lost[$i].y)"}
-            [/then]
-        [/if]
-        [if]
-            [variable]
-                name=is_lost
+                name=count
                 greater_than=0
             [/variable]
-            [then]
+            [do]
+                {VARIABLE_OP type rand "Orcish Warlord,Orcish Warrior,Orcish Slurbow,Orcish Crossbowman,Orcish Slayer"}
+                {GENERIC_UNIT 2 $type 48 33}
+                [+unit]
+                    id=spawn_$spawn_count
+                [/unit]
+                {MOVE_UNIT id=spawn_$spawn_count 48 32}
+                {VARIABLE_OP count sub 1}
+                {VARIABLE_OP spawn_count add 1}
+            [/do]
+        [/while]
+    [/event]
+
+    [event]
+        name=new turn
+        first_time_only=no
+        {VARIABLE count 5}
+        [while]
+            [variable]
+                name=count
+                greater_than=0
+            [/variable]
+            [do]
+                {VARIABLE_OP type rand "Orcish Grunt,Orcish Warrior,Orcish Archer,Orcish Crossbowman,Wolf Rider,Orcish Assassin,Orcish Slayer"}
+                {GENERIC_UNIT 2 $type 48 33}
+                [+unit]
+                    id=spawn_$spawn_count
+                [/unit]
+                {MOVE_UNIT id=spawn_$spawn_count 50 31}
+                {VARIABLE_OP count sub 1}
+                {VARIABLE_OP spawn_count add 1}
+            [/do]
+        [/while]
+    [/event]
+
+    [event]
+        name=side 2 turn refresh
+        first_time_only=no
+        [store_unit]
+            [filter]
+                side=2
+            [/filter]
+            variable=lost
+            kill=no
+        [/store_unit]
+        [for]
+            array=lost
+            [do]
+                {VARIABLE_OP is_lost rand "0,0,0,0,1,2,3,4,5,6"}
                 [if]
                     [variable]
-                        name=target_x
-                        less_than=53
+                        name=is_lost
+                        equals=1
                     [/variable]
-                    [and]
-                        [variable]
-                            name=target_x
-                            greater_than=0
-                        [/variable]
-                    [/and]
-                    [and]
-                        [variable]
-                            name=target_y
-                            less_than=34
-                        [/variable]
-                    [/and]
-                    [and]
-                        [variable]
-                            name=target_y
-                            greater_than=0
-                        [/variable]
-                    [/and]
                     [then]
-                        [find_path]
-                            [traveler]
-                                id=$lost[$i].id
-                            [/traveler]
-                            [destination]
-                                x=$target_x
-                                y=$target_y
-                            [/destination]
-                            variable=path
-                            allow_multiple_turns=yes
-                        [/find_path]
+                        {VARIABLE target_x "$(2+$lost[$i].x)"}
+                        {VARIABLE target_y "$(1+$lost[$i].y)"}
+                    [/then]
+                [/if]
+                [if]
+                    [variable]
+                        name=is_lost
+                        equals=2
+                    [/variable]
+                    [then]
+                        {VARIABLE target_x "$(-2+$lost[$i].x)"}
+                        {VARIABLE target_y "$(1+$lost[$i].y)"}
+                    [/then]
+                [/if]
+                [if]
+                    [variable]
+                        name=is_lost
+                        equals=3
+                    [/variable]
+                    [then]
+                        {VARIABLE target_x "$lost[$i].x"}
+                        {VARIABLE target_y "$(3+$lost[$i].y)"}
+                    [/then]
+                [/if]
+                [if]
+                    [variable]
+                        name=is_lost
+                        equals=4
+                    [/variable]
+                    [then]
+                        {VARIABLE target_x "$(2+$lost[$i].x)"}
+                        {VARIABLE target_y "$(-1+$lost[$i].y)"}
+                    [/then]
+                [/if]
+                [if]
+                    [variable]
+                        name=is_lost
+                        equals=5
+                    [/variable]
+                    [then]
+                        {VARIABLE target_x "$(-2+$lost[$i].x)"}
+                        {VARIABLE target_y "$(-1+$lost[$i].y)"}
+                    [/then]
+                [/if]
+                [if]
+                    [variable]
+                        name=is_lost
+                        equals=6
+                    [/variable]
+                    [then]
+                        {VARIABLE target_x "$lost[$i].x"}
+                        {VARIABLE target_y "$(-3+$lost[$i].y)"}
+                    [/then]
+                [/if]
+                [if]
+                    [variable]
+                        name=is_lost
+                        greater_than=0
+                    [/variable]
+                    [then]
                         [if]
                             [variable]
-                                name=path.hexes
-                                less_than=8
+                                name=target_x
+                                less_than=53
                             [/variable]
                             [and]
                                 [variable]
-                                    name=path.hexes
+                                    name=target_x
                                     greater_than=0
                                 [/variable]
                             [/and]
-                            [not]
+                            [and]
                                 [variable]
-                                    name=path.required_turns
-                                    greater_than=1
+                                    name=target_y
+                                    less_than=34
                                 [/variable]
-                            [/not]
+                            [/and]
+                            [and]
+                                [variable]
+                                    name=target_y
+                                    greater_than=0
+                                [/variable]
+                            [/and]
                             [then]
-                                {MOVE_UNIT id=$lost[$i].id $target_x $target_y}
+                                [find_path]
+                                    [traveler]
+                                        id=$lost[$i].id
+                                    [/traveler]
+                                    [destination]
+                                        x=$target_x
+                                        y=$target_y
+                                    [/destination]
+                                    variable=path
+                                    allow_multiple_turns=yes
+                                [/find_path]
+                                [if]
+                                    [variable]
+                                        name=path.hexes
+                                        less_than=8
+                                    [/variable]
+                                    [and]
+                                        [variable]
+                                            name=path.hexes
+                                            greater_than=0
+                                        [/variable]
+                                    [/and]
+                                    [not]
+                                        [variable]
+                                            name=path.required_turns
+                                            greater_than=1
+                                        [/variable]
+                                    [/not]
+                                    [then]
+                                        {MOVE_UNIT id=$lost[$i].id $target_x $target_y}
+                                    [/then]
+                                [/if]
                             [/then]
                         [/if]
+                        [modify_unit]
+                            [filter]
+                                id=lost[$i].id
+                            [/filter]
+                            moves=0
+                        [/modify_unit]
                     [/then]
                 [/if]
-                [modify_unit]
-                    [filter]
-                        id=lost[$i].id
-                    [/filter]
-                    moves=0
-                [/modify_unit]
-            [/then]
-        [/if]
-    {NEXT i}
-    {CLEAR_VARIABLE lost,is_lost,path,target_x,target_y}
+            [/do]
+        [/for]
+        {CLEAR_VARIABLE lost,is_lost,path,target_x,target_y}
     [/event]
-
 
     [event]
         name=turn 4
-    {AE_SPAWN_UNITS 3 0.3 "Wolf Rider" 49 3 "Goblin Knight" boss_1}
+        {AE_SPAWN_UNITS 3 0.3 "Wolf Rider" 49 3 "Goblin Knight" boss_1}
     [/event]
 
     [event]
         name=turn 6
-    {AE_SPAWN_UNITS 3 0.3 "Wolf Rider,Orcish Grunt" 24 29 "Goblin Knight" boss_2}
+        {AE_SPAWN_UNITS 3 0.3 "Wolf Rider,Orcish Grunt" 24 29 "Goblin Knight" boss_2}
     [/event]
 
     [event]
         name=turn 8
-    {AE_SPAWN_UNITS 3 0.4 "Wolf Rider,Orcish Archer" 12 2 "Goblin Knight" boss_3}
+        {AE_SPAWN_UNITS 3 0.4 "Wolf Rider,Orcish Archer" 12 2 "Goblin Knight" boss_3}
     [/event]
 
     [event]
         name=turn 12
-    {AE_SPAWN_UNITS 3 0.3 "Wolf Rider,Orcish Assassin" 12 32 "Goblin Knight" boss_4}
+        {AE_SPAWN_UNITS 3 0.3 "Wolf Rider,Orcish Assassin" 12 32 "Goblin Knight" boss_4}
     [/event]
 
     [event]
         name=moveto
-    [filter]
-        side=1
-        x=1-26
-    [/filter]
-    [event]
-        name=new turn
-        [message]
-            speaker=Fowleri
-            message=_"I have an idea how we could make it to Amaranth faster. The river runs quite fast through the mountains. How about sailing it down on tree trunks? Getting some suitable trunks is a matter of minutes and it might save us days of travel. And help us gain a few days' advantage."
-        [/message]
-        [message]
-            speaker=Krux
-            message=_"Are you crazy? It will turn under us and we will drown! If it does not, we will suffer from severe hypothermia. And as far as I know, elves are not more cold resistant than humans."
-        [/message]
-        [message]
-            speaker=Fowleri
-            message=_"It seems I forgot that you cannot simply stand on a tree trunk that moves through water. I can, all problems I would suffer is water in my boots. We elves are dextrous enough for that, if we can walk on tree branches during gales, this is not a problem for us - it is quite an amusement. You can make a raft if you need."
-        [/message]
-        [message]
-            speaker=Krux
-            message=_"It does not make it much less insane. The raft will break in the quickly flowing water and we will drown!"
-        [/message]
-        [message]
-            speaker=Fowleri
-            message=_"You cannot use some magic to avoid crashing into rocks?"
-        [/message]
-        [message]
-            speaker=Krux
-            message=_"Controlling it is hard enough. And to push ourselves, I would need to stand on the rock we would have to avoid crashing into."
-        [/message]
-        [if]
-            [have_unit]
-                id=Lucretia
-            [/have_unit]
-            [then]
-                [message]
-                    speaker=Lucretia
-                    message=_"That is not a problem if I am with you. I know such spells, I can walk on water, run before you and keep you away from sharp rocks."
-                [/message]
-            [/then]
-            [else]
-                [message]
-                    speaker=Acanthamoeba
-                    message=_"We might take long, hard sticks to push into the stones and keep us away from them."
-                [/message]
-            [/else]
-        [/if]
-        [message]
-            speaker=Krux
-            message=_"That might work."
-        [/message]
-        [message]
-            speaker=Fowleri
-            message=_"Excellent. I will ride separately from you, it might allow me to help you at times."
-        [/message]
-    [/event]
-    [event]
-        name=die
         [filter]
-            id=Lucretia
+            side=1
+            x=1-26
+        [/filter]
+        [event]
+            name=new turn
+            [message]
+                speaker=Fowleri
+                message=_"I have an idea how we could make it to Amaranth faster. The river runs quite fast through the mountains. How about sailing it down on tree trunks? Getting some suitable trunks is a matter of minutes and it might save us days of travel. And help us gain a few days' advantage."
+            [/message]
+            [message]
+                speaker=Krux
+                message=_"Are you crazy? It will turn under us and we will drown! If it does not, we will suffer from severe hypothermia. And as far as I know, elves are not more cold resistant than humans."
+            [/message]
+            [message]
+                speaker=Fowleri
+                message=_"It seems I forgot that you cannot simply stand on a tree trunk that moves through water. I can, all problems I would suffer is water in my boots. We elves are dextrous enough for that, if we can walk on tree branches during gales, this is not a problem for us - it is quite an amusement. You can make a raft if you need."
+            [/message]
+            [message]
+                speaker=Krux
+                message=_"It does not make it much less insane. The raft will break in the quickly flowing water and we will drown!"
+            [/message]
+            [message]
+                speaker=Fowleri
+                message=_"You cannot use some magic to avoid crashing into rocks?"
+            [/message]
+            [message]
+                speaker=Krux
+                message=_"Controlling it is hard enough. And to push ourselves, I would need to stand on the rock we would have to avoid crashing into."
+            [/message]
+            [if]
+                [have_unit]
+                    id=Lucretia
+                [/have_unit]
+                [then]
+                    [message]
+                        speaker=Lucretia
+                        message=_"That is not a problem if I am with you. I know such spells, I can walk on water, run before you and keep you away from sharp rocks."
+                    [/message]
+                [/then]
+                [else]
+                    [message]
+                        speaker=Acanthamoeba
+                        message=_"We might take long, hard sticks to push into the stones and keep us away from them."
+                    [/message]
+                [/else]
+            [/if]
+            [message]
+                speaker=Krux
+                message=_"That might work."
+            [/message]
+            [message]
+                speaker=Fowleri
+                message=_"Excellent. I will ride separately from you, it might allow me to help you at times."
+            [/message]
+        [/event]
+        [event]
+            name=die
+            [filter]
+                id=Lucretia
+            [/filter]
+            [message]
+                speaker=Krux
+                message=_"She was our key to surviving the ride down the river."
+            [/message]
+            [message]
+                speaker=Acanthamoeba
+                message=_"We might take long, hard sticks to push into the stones and keep us away from them."
+            [/message]
+            [message]
+                speaker=Krux
+                message=_"Yes, we might do that."
+            [/message]
+        [/event]
+    [/event]
+
+    [event]
+        name=moveto
+        [filter]
+            side=1
+            x,y=1-4,23-28
         [/filter]
         [message]
             speaker=Krux
-            message=_"She was our key to surviving the ride down the river."
+            message=_"Made it! So hurry, let us make a raft!"
         [/message]
         [message]
             speaker=Acanthamoeba
-            message=_"We might take long, hard sticks to push into the stones and keep us away from them."
+            message=_"Goodbye, nice health. I will be so sick tomorrow."
+        [/message]
+        [message]
+            speaker=Fowleri
+            message=_"Worry not, you will not fall into the river. And Krux will be heating you."
+        [/message]
+        [message]
+            speaker=Acanthamoeba
+            message=_"Are... you... serious?"
+        [/message]
+        [message]
+            speaker=Fowleri
+            message=_"What, people keep accusing you two of... ehm, I did not mean that. He can use some magic, and magical heating is one of the easiest things. Will your spells keep everyone warm, Krux?"
         [/message]
         [message]
             speaker=Krux
-            message=_"Yes, we might do that."
+            message=_"Indeed. But if many of us fall, I will not be able to keep you all warm."
         [/message]
-    [/event]
-    [/event]
-
-    [event]
-        name=moveto
-    [filter]
-        side=1
-        x,y=1-4,23-28
-    [/filter]
-    [message]
-        speaker=Krux
-        message=_"Made it! So hurry, let us make a raft!"
-    [/message]
-    [message]
-        speaker=Acanthamoeba
-        message=_"Goodbye, nice health. I will be so sick tomorrow."
-    [/message]
-    [message]
-        speaker=Fowleri
-        message=_"Worry not, you will not fall into the river. And Krux will be heating you."
-    [/message]
-    [message]
-        speaker=Acanthamoeba
-        message=_"Are... you... serious?"
-    [/message]
-    [message]
-        speaker=Fowleri
-        message=_"What, people keep accusing you two of... ehm, I did not mean that. He can use some magic, and magical heating is one of the easiest things. Will your spells keep everyone warm, Krux?"
-    [/message]
-    [message]
-        speaker=Krux
-        message=_"Indeed. But if many of us fall, I will not be able to keep you all warm."
-    [/message]
-    [endlevel]
-        result=victory
-        bonus=no
-                {NEW_GOLD_CARRYOVER 100}
-                linger_mode=no
-                carryover_report=no
-    [/endlevel]
+        [endlevel]
+            result=victory
+            bonus=no
+            {NEW_GOLD_CARRYOVER 100}
+            linger_mode=no
+            carryover_report=no
+        [/endlevel]
     [/event]
 
     [event]

--- a/spinoffs/Affably_Evil/scenarios/06_Krux_the_Saviour.cfg
+++ b/spinoffs/Affably_Evil/scenarios/06_Krux_the_Saviour.cfg
@@ -11,17 +11,17 @@
 
     [story]
         [part]
-        show_title=no
+            show_title=no
             background=story/rafting.jpg
             story= _ "At the beginning of the trail, the river was broad and slow so that Krux had to use a stick to maintain a decent speed (Fowleri was kicking into nearby rocks). But then it begun to flow faster and faster, making it harder and harder to avoid crashing into obstacles."
         [/part]
         [part]
-        show_title=no
+            show_title=no
             background=story/rafting.jpg
             story= _ "Eventually, they ran into a rock in the middle of the river because both the left side and the right side were too narrow to pass through. The raft took some damage, but survived. Shortly after, they had to squeeze through a narrow and extremely fast part, further damaging their raft."
         [/part]
         [part]
-        show_title=no
+            show_title=no
             background=story/rafting.jpg
             story= _ "They saw plains and forests before them when they ran into a waterfall. The ride through the waterfall damaged the raft so badly that it had to be held together manually, and next waterfall broke it apart completely. Everyone caught some of its remains and hoped that the end of the trail was near. And it was."
         [/part]
@@ -30,9 +30,9 @@
     [side]
         type=Krux_father
         id=Krux
-    name=_"Krux"
+        name=_"Krux"
         canrecruit=yes
-    unrenamable=yes
+        unrenamable=yes
         side=1
         controller=human
         recruit=
@@ -46,106 +46,105 @@
     [/side]
     [side]
         id=ally
-    type=Elvish Lord
-    generate_name=yes
-    canrecruit=yes
-    recruit=Elvish Fighter,Elvish Archer,Elvish Scout,Elvish Shaman,Wose
+        type=Elvish Lord
+        generate_name=yes
+        canrecruit=yes
+        recruit=Elvish Fighter,Elvish Archer,Elvish Scout,Elvish Shaman,Wose
         side=2
         team_name=allies
         user_team_name=_"Allies"
-    village_gold=0
-    [ai]
-        passive_leader=yes
-        agression=0.9
-        [aspect]
-        id=attacks
-        [facet]
-            invalidate_on_gamestate_change=yes
-            [filter_enemy]
-            side=3,4
-            [/filter_enemy]
-        [/facet]
-        [/aspect]
-    [/ai]
+        village_gold=0
+        [ai]
+            passive_leader=yes
+            agression=0.9
+            [aspect]
+                id=attacks
+                [facet]
+                    invalidate_on_gamestate_change=yes
+                    [filter_enemy]
+                        side=3,4
+                    [/filter_enemy]
+                [/facet]
+            [/aspect]
+        [/ai]
     [/side]
     [side]
         no_leader=yes
         side=3
         team_name=enemies
         user_team_name=_"Enemies"
-    [ai]
-        agression=1.0
-        passive_leader=yes
-    [/ai]
-    recruit=Orcish Grunt,Orcish Archer,Wolf Rider,Orcish Assassin,Troll Whelp
+        [ai]
+            agression=1.0
+            passive_leader=yes
+        [/ai]
+        recruit=Orcish Grunt,Orcish Archer,Wolf Rider,Orcish Assassin,Troll Whelp
     [/side]
     [side]
         no_leader=yes
         side=4
         team_name=enemies
         user_team_name=_"Enemies"
-    [ai]
-        agression=1.0
-        passive_leader=yes
-    [/ai]
-    recruit=Orcish Warrior,Orcish Crossbowman,Goblin Knight,Orcish Slayer,Troll
+        [ai]
+            agression=1.0
+            passive_leader=yes
+        [/ai]
+        recruit=Orcish Warrior,Orcish Crossbowman,Goblin Knight,Orcish Slayer,Troll
     [/side]
     [side]
         no_leader=yes
         side=5
         team_name=enemies
         user_team_name=_"Enemies"
-    [ai]
-        agression=1.0
-        [aspect]
-        id=attacks
-        [facet]
-            invalidate_on_gamestate_change=yes
-            [filter_enemy]
-            side=1
-            [/filter_enemy]
-        [/facet]
-        [/aspect]
-    [/ai]
+        [ai]
+            agression=1.0
+            [aspect]
+                id=attacks
+                [facet]
+                    invalidate_on_gamestate_change=yes
+                    [filter_enemy]
+                        side=1
+                    [/filter_enemy]
+                [/facet]
+            [/aspect]
+        [/ai]
     [/side]
 
-
     [event]
-    name=prestart
-    {VARIABLE current_scenario krux_the_saviour}
-    [recall]
-        id=Fowleri
-        x,y=8,6
-        show=no
-    [/recall]
-    [recall]
-        id=Lucretia
-        x,y=9,4
-        show=no
-    [/recall]
-    {AE_RECALL_ALL 6 4}
-    {SCENARIO_DURATION_VARIABLE phase 1}
+        name=prestart
+        {VARIABLE current_scenario krux_the_saviour}
+        [recall]
+            id=Fowleri
+            x,y=8,6
+            show=no
+        [/recall]
+        [recall]
+            id=Lucretia
+            x,y=9,4
+            show=no
+        [/recall]
+        {AE_RECALL_ALL 6 4}
+        {SCENARIO_DURATION_VARIABLE phase 1}
         [objectives]
             side=1
             [objective]
                 description= _ "Reach the elvish town on southeast and take a keep"
                 condition=win
-        [show_if]
-            [variable]
-                name=phase
-                equals=1
-            [/variable]
-        [/show_if]
+                [show_if]
+                    [variable]
+                        name=phase
+                        equals=1
+                    [/variable]
+                [/show_if]
             [/objective]
             [objective]
                 description= _ "Defeat both enemy leaders"
                 condition=win
-        [show_if]
-            [variable]
-                name=phase
-                equals=2
-            [/variable]
-        [/show_if]
+                [show_if]
+                    [variable]
+                        name=phase
+                        equals=2
+                    [/variable]
+                [/show_if]
             [/objective]
             [objective]
                 description=_ "Death of the Krux, Acanthamoeba, Anitipater or Fowleri"
@@ -160,23 +159,25 @@
                 condition=lose
             [/objective]
         [/objectives]
-    [store_unit]
-        [filter]
-            side=1
-            [not]
-                id=Fowleri
-            [/not]
-            [not]
-                id=Lucretia
-            [/not]
-        [/filter]
-        variable=cold
-        kill=no
-    [/store_unit]
-    {FOREACH cold i}
-        {VARIABLE_OP amount rand "1..20"}
-        {VARIABLE_OP has_poison rand "yes,no"}
-        {VARIABLE_OP has_slow rand "yes,no"}
+        [store_unit]
+            [filter]
+                side=1
+                [not]
+                    id=Fowleri
+                [/not]
+                [not]
+                    id=Lucretia
+                [/not]
+            [/filter]
+            variable=cold
+            kill=no
+        [/store_unit]
+        [for]
+            array=cold
+            [do]
+                {VARIABLE_OP amount rand "1..20"}
+                {VARIABLE_OP has_poison rand "yes,no"}
+                {VARIABLE_OP has_slow rand "yes,no"}
                 [harm_unit]
                     [filter]
                         id=$cold[$i].id
@@ -186,363 +187,364 @@
                     slowed=$has_slow
                     fire_event=no
                     experience=no
-            kill=no
+                    kill=no
                 [/harm_unit]
-    {NEXT i}
-    {CLEAR_VARIABLE cold,amount,has_poison,has_slow}
+            [/do]
+        [/foreach]
+        {CLEAR_VARIABLE cold,amount,has_poison,has_slow}
         {CAPTURE_VILLAGES 2 40 30 30}
     [/event]
 
     [event]
-    name=start
-    [message]
-        speaker=Antipos
-        message=_"This was insane! It was only pure luck that no one died! Next time this elf suggests anything, I will vehemently oppose it no matter what it is!"
-    [/message]
-    [message]
-        speaker=Fowleri
-        message=_"How about going out of the water?"
-    [/message]
-    [message]
-        speaker=Antipos
-        message=_"And she even mocks me! If I was a black mage and not a white mage, I would have cursed you!"
-    [/message]
-    [message]
-        speaker=Acanthamoeba
-        message=_"I would like to have a dexterity like Fowleri. I will have to practice a lot. But in the summer, not during early spring. I have such a nasty cold."
-    [/message]
-    [message]
-        speaker=Antipos
-        message=_"Stay near me, I can cure that. Diseases are harder to cure than injuries, but cold is not a big deal."
-    [/message]
-    [message]
-        speaker=Xalzaxx
-        message=_"I have cold too. Achoo!"
-    [/message]
-    [message]
-        speaker=Hare
-        message=_"I think I have also a fever!"
-    [/message]
-    [message]
-        speaker=dwarf_merc
-        message=_"You have to bathe a bit and you are getting sick? Pussies!"
-    [/message]
-    [message]
-        speaker=Fowleri
-        message=_"I must say that I did not expect you to be <i>so</i> clumsy. I have a bit of water in my boots, but you are totally washed. I will have to repeat this with someone else."
-    [/message]
-    [message]
-        speaker=Krux
-        message=_"Silence, all of you! I cannot let you argue like this because this is going far beyond the limits of being friendly. You will listen to <i>me</i> now, okay?"
-    [/message]
-    [message]
-        speaker=Xalzaxx
-        message=_"Yes, mister Krux."
-    [/message]
-    [message]
-        speaker=Hare
-        message=_"Fine, fine."
-    [/message]
-    [message]
-        speaker=Judas
-        message=_"Okay."
-    [/message]
-    [message]
-        speaker=Antipos
-        message=_"Fine."
-    [/message]
-    [message]
-        speaker=Krux
-        message=_"Now I need you, Fowleri, to tell the elves to let our soldiers march in. I will meet them in Amaranth where we will defend the town from the orcs. We have to reach Amaranth before they come because there will be a lot of them."
-    [/message]
-    [message]
-        speaker=Fowleri
-        message=_"It is nice to see you helping us, Krux."
-    [/message]
-    [message]
-        speaker=Krux
-        message=_"Please understand that I would not put the welfare of your people above the welfare of my people and prefer accepting refugees over actively fighting the orcs. But I also know what would happen next. If we evacuate a town, they will take and keep raiding and forcing us to evacuate other towns until the winter comes. The sooner they are defeated, the better it is."
-    [/message]
-    [message]
-        speaker=Antipos
-        message=_"Elvish refugees in our towns might be more helpful to us than elves in a forest. Do you know how much profit it would bring?"
-    [/message]
-    [message]
-        speaker=Krux
-        message=_"They would not stay for long. Only until the departure of the orcs. And that is not the nicest thing to do if we can help them."
-    [/message]
-    [message]
-        speaker=Antipos
-        message=_"Are you in love with her or something?"
-    [/message]
-    [message]
-        speaker=Fowleri
-        message=_"Artrana'quelia asinatha arcturus! HEY, YOU OVER THERE! THE MAYOR OF AMARANTH! CAN YOU HEAR ME?"
-    [/message]
-    [message]
-        speaker=ally
-        message=_"Yes, I do! What do you want?"
-    [/message]
-    [message]
-        speaker=Fowleri
-        message=_"I need to warn you. Orcs are passing through the hills and approaching fast! There is a lot of them."
-    [/message]
-    [message]
-        speaker=ally
-        message=_"You must be kidding! Wait, I can verify it. I would be a bad leader if I dismissed it as a joke. Aratharonara kai'thamyonth assertuysa. Well, in the hills... there is a load of orcs. So damn many of them. Evacuate!"
-    [/message]
-    [message]
-        speaker=Fowleri
-        message=_"It is not so bad. There are humans north from the forest, waiting for someone to let them in. They were sent here to protect you from the orcs, but there was no way to make it clear that they were not preparing to invade you. Let them in and they should help us fend off the orcs."
-    [/message]
-    [message]
-        speaker=ally
-        message=_"Humans knew of them earlier? They do not have problems with the orcs themselves?"
-    [/message]
-    [message]
-        speaker=Fowleri
-        message=_"No, they only happened to learn of them earlier. Let them in so that they can save you."
-    [/message]
-    [message]
-        speaker=ally
-        message=_"And how can I trust you?"
-    [/message]
-    [message]
-        speaker=Fowleri
-        message=_"My dear, have you ever heard of lieutenant Fowleri, the Bane of Orcs? 'tis me! I have shown these lubberworts where they belong a century ago and I will show it again to these sons of three-legged dogs!"
-    [/message]
-    [message]
-        speaker=ally
-        message=_"Ah, you are a living legend! Come here and help us, with your help and the humans, we should be able to survive it."
-    [/message]
+        name=start
+        [message]
+            speaker=Antipos
+            message=_"This was insane! It was only pure luck that no one died! Next time this elf suggests anything, I will vehemently oppose it no matter what it is!"
+        [/message]
+        [message]
+            speaker=Fowleri
+            message=_"How about going out of the water?"
+        [/message]
+        [message]
+            speaker=Antipos
+            message=_"And she even mocks me! If I was a black mage and not a white mage, I would have cursed you!"
+        [/message]
+        [message]
+            speaker=Acanthamoeba
+            message=_"I would like to have a dexterity like Fowleri. I will have to practice a lot. But in the summer, not during early spring. I have such a nasty cold."
+        [/message]
+        [message]
+            speaker=Antipos
+            message=_"Stay near me, I can cure that. Diseases are harder to cure than injuries, but cold is not a big deal."
+        [/message]
+        [message]
+            speaker=Xalzaxx
+            message=_"I have cold too. Achoo!"
+        [/message]
+        [message]
+            speaker=Hare
+            message=_"I think I have also a fever!"
+        [/message]
+        [message]
+            speaker=dwarf_merc
+            message=_"You have to bathe a bit and you are getting sick? Pussies!"
+        [/message]
+        [message]
+            speaker=Fowleri
+            message=_"I must say that I did not expect you to be <i>so</i> clumsy. I have a bit of water in my boots, but you are totally washed. I will have to repeat this with someone else."
+        [/message]
+        [message]
+            speaker=Krux
+            message=_"Silence, all of you! I cannot let you argue like this because this is going far beyond the limits of being friendly. You will listen to <i>me</i> now, okay?"
+        [/message]
+        [message]
+            speaker=Xalzaxx
+            message=_"Yes, mister Krux."
+        [/message]
+        [message]
+            speaker=Hare
+            message=_"Fine, fine."
+        [/message]
+        [message]
+            speaker=Judas
+            message=_"Okay."
+        [/message]
+        [message]
+            speaker=Antipos
+            message=_"Fine."
+        [/message]
+        [message]
+            speaker=Krux
+            message=_"Now I need you, Fowleri, to tell the elves to let our soldiers march in. I will meet them in Amaranth where we will defend the town from the orcs. We have to reach Amaranth before they come because there will be a lot of them."
+        [/message]
+        [message]
+            speaker=Fowleri
+            message=_"It is nice to see you helping us, Krux."
+        [/message]
+        [message]
+            speaker=Krux
+            message=_"Please understand that I would not put the welfare of your people above the welfare of my people and prefer accepting refugees over actively fighting the orcs. But I also know what would happen next. If we evacuate a town, they will take and keep raiding and forcing us to evacuate other towns until the winter comes. The sooner they are defeated, the better it is."
+        [/message]
+        [message]
+            speaker=Antipos
+            message=_"Elvish refugees in our towns might be more helpful to us than elves in a forest. Do you know how much profit it would bring?"
+        [/message]
+        [message]
+            speaker=Krux
+            message=_"They would not stay for long. Only until the departure of the orcs. And that is not the nicest thing to do if we can help them."
+        [/message]
+        [message]
+            speaker=Antipos
+            message=_"Are you in love with her or something?"
+        [/message]
+        [message]
+            speaker=Fowleri
+            message=_"Artrana'quelia asinatha arcturus! HEY, YOU OVER THERE! THE MAYOR OF AMARANTH! CAN YOU HEAR ME?"
+        [/message]
+        [message]
+            speaker=ally
+            message=_"Yes, I do! What do you want?"
+        [/message]
+        [message]
+            speaker=Fowleri
+            message=_"I need to warn you. Orcs are passing through the hills and approaching fast! There is a lot of them."
+        [/message]
+        [message]
+            speaker=ally
+            message=_"You must be kidding! Wait, I can verify it. I would be a bad leader if I dismissed it as a joke. Aratharonara kai'thamyonth assertuysa. Well, in the hills... there is a load of orcs. So damn many of them. Evacuate!"
+        [/message]
+        [message]
+            speaker=Fowleri
+            message=_"It is not so bad. There are humans north from the forest, waiting for someone to let them in. They were sent here to protect you from the orcs, but there was no way to make it clear that they were not preparing to invade you. Let them in and they should help us fend off the orcs."
+        [/message]
+        [message]
+            speaker=ally
+            message=_"Humans knew of them earlier? They do not have problems with the orcs themselves?"
+        [/message]
+        [message]
+            speaker=Fowleri
+            message=_"No, they only happened to learn of them earlier. Let them in so that they can save you."
+        [/message]
+        [message]
+            speaker=ally
+            message=_"And how can I trust you?"
+        [/message]
+        [message]
+            speaker=Fowleri
+            message=_"My dear, have you ever heard of lieutenant Fowleri, the Bane of Orcs? 'tis me! I have shown these lubberworts where they belong a century ago and I will show it again to these sons of three-legged dogs!"
+        [/message]
+        [message]
+            speaker=ally
+            message=_"Ah, you are a living legend! Come here and help us, with your help and the humans, we should be able to survive it."
+        [/message]
     [/event]
 
     [event]
-    name=moveto
-    [filter]
-        side=1
-        x,y=39,26
-    [/filter]
-    {VARIABLE phase 2}
-    [message]
-        speaker=ally
-        message=_"Welcome to our town. How do you like it here? I have brought the army here for you to command."
-    [/message]
-    [move_unit]
-        side=1
-        [not]
-            id=$unit.id
-        [/not]
-        to_x,to_y=39,26
-    [/move_unit]
-    [message]
-        speaker=Acanthamoeba
-        message=_"This town is beautiful. I would like to live here."
-    [/message]
-    [message]
-        speaker=Antipos
-        message=_"Well, our army is here, all we need is wait until Krux gives the command."
-    [/message]
-    [message]
-        speaker=Acanthamoeba
-        message=_"I think that it might not be the best idea. Fighting among ourselves when an enemy army is coming."
-    [/message]
-    [message]
-        speaker=Krux
-        message=_"Antipos, have you lost your mind? This is not the way to deal with our problems. Not only that it is violent beyond any needs, it is also one of the silliest things to do when orcs are coming and most of all, how do you imagine we would keep this town? If you cannot find a trick to take a town without fight, fighting for it is rarely worth the town. You know that we have gained most of our towns by diplomacy. The incident with Marilyn was an exception."
-    [/message]
-    [message]
-        speaker=Antipos
-        message=_"Okay, I will try to suggest more peaceful things... who the hell needs peace anyway..."
-    [/message]
-    [message]
-        speaker=ally
-        message=_"Are you humans always like this?"
-    [/message]
-    [message]
-        speaker=Acanthamoeba
-        message=_"Pardon our friend. He used to be a tyrant before his throne was stolen and we are using him as an advisor. He has a lot of good ideas, but sometimes he gives very opportunistic and violent suggestions and so we have to filter his suggestions carefully. This was one of his excesses. Of course we would never misuse this friendly help to occupy your beautiful town. Making an embassy here might not be such a bad idea, though..."
-    [/message]
-    [repeating_message]
-        speaker=Fowleri
-        first=_"I am sorry to interrupt, but we need to make a plan for the battle. The orcs are probably building camps near the lake by now."
-        message=_"Any more suggestions?"
-        [option]
-        message=_"We are slow in the forest. You elves are much faster. Do you think that you could slow them down? We cannot let them become too strong by sacking the villages for supplies."
-        [command]
-            [message]
-                speaker=ally
-                message=_"We can save villages, but it will cost us lives."
-            [/message]
-            [message]
-                speaker=Xalzaxx
-                message=_"Listen to Krux, you fool."
-            [/message]
-            [message]
-                speaker=Krux
-                message=_"If the orcs collect too much supplies, they might become so strong that they sack Amaranth. That sacrifice, no matter how hard it is, increases the chance to save the lives of children and civilians."
-            [/message]
-            [message]
-                speaker=ally
-                message=_"And also of your people."
-            [/message]
-            [message]
-                speaker=Krux
-                message=_"Not really, we can escape if the situation becomes too hopeless."
-            [/message]
-            [message]
-                speaker=ally
-                message=_"Fine, fine, I will have to do that. It will be a hard decision, though."
-            [/message]
-        [/command]
-        [/option]
-        [option]
-        message=_"What defences do you have?"
-        [command]
-            [message]
-                speaker=ally
-                message=_"Almost none. We never expected such a large group to focus directly on us."
-            [/message]
-            [message]
-                speaker=Fowleri
-                message=_"It could be our fault. They spotted us and guessed that there are some settlements nearby."
-            [/message]
-            [message]
-                speaker=ally
-                message=_"So if we told them where they can find humans, will they split?"
-            [/message]
-            [message]
-                speaker=Acanthamoeba
-                message=_"Hardly. If they have a target nearby, they will focus on it."
-            [/message]
-            [message]
-                speaker=Fowleri
-                message=_"These orcs are longing to sack and pillage. As Acantha said, they will not resist attacking a town that is in sight."
-            [/message]
-            [message]
-                speaker=Krux
-                message=_"You should have thought of safety first. Extra work is worth it if it saves lives."
-            [/message]
-        [/command]
-        [/option]
-        [option]
-        message=_"Is there any way to make them attack other orcs?"
-        [command]
-            [message]
-                speaker=Lucretia
-                message=_"There is one poison that causes insanity, administering it to one of their leaders might have him fight others for domination. Unfortunately, we do not have it."
-            [/message]
-            [message]
-                speaker=Judas
-                message=_"Maybe if Fowleri offered to heal bruises to their leaders, they would end up without leadership. But Fowleri would most likely die in the process and it also might fail. In the worst case, their bruises might be healed."
-            [/message]
-            [message]
-                speaker=Antipos
-                message=_"Do you think that we could pay them, Krux?"
-            [/message]
-            [message]
-                speaker=Krux
-                message=_"Give them gold and they will demand more a few days later until you give them everything. And then they attack."
-            [/message]
-            [message]
-                speaker=Acanthamoeba
-                message=_"How about killing one of their leaders and forging evidence showing that it was another leader?"
-            [/message]
-            [message]
-                speaker=Fowleri
-                message=_"Orcs do not punish or scorn murderers in their ranks. Killing another orc is completely acceptable for them. They would not investigate."
-            [/message]
-            [message]
-                speaker=Acanthamoeba
-                message=_"That is bad."
-            [/message]
-        [/command]
-        [/option]
-        [option]
-        message=_"That is all I can think of."
-        [show_if]
+        name=moveto
+        [filter]
+            side=1
+            x,y=39,26
+        [/filter]
+        {VARIABLE phase 2}
+        [message]
+            speaker=ally
+            message=_"Welcome to our town. How do you like it here? I have brought the army here for you to command."
+        [/message]
+        [move_unit]
+            side=1
             [not]
-                [variable]
-                    name=first_view
-                    equals=true
-                [/variable]
+                id=$unit.id
             [/not]
-        [/show_if]
-        [command]
-            [break]
-            [/break]
-        [/command]
-        [/option]
-    [/repeating_message]
-    [message]
-        speaker=ally
-        message=_"So we have a plan now. Time to fight for survival."
-    [/message]
+            to_x,to_y=39,26
+        [/move_unit]
+        [message]
+            speaker=Acanthamoeba
+            message=_"This town is beautiful. I would like to live here."
+        [/message]
+        [message]
+            speaker=Antipos
+            message=_"Well, our army is here, all we need is wait until Krux gives the command."
+        [/message]
+        [message]
+            speaker=Acanthamoeba
+            message=_"I think that it might not be the best idea. Fighting among ourselves when an enemy army is coming."
+        [/message]
+        [message]
+            speaker=Krux
+            message=_"Antipos, have you lost your mind? This is not the way to deal with our problems. Not only that it is violent beyond any needs, it is also one of the silliest things to do when orcs are coming and most of all, how do you imagine we would keep this town? If you cannot find a trick to take a town without fight, fighting for it is rarely worth the town. You know that we have gained most of our towns by diplomacy. The incident with Marilyn was an exception."
+        [/message]
+        [message]
+            speaker=Antipos
+            message=_"Okay, I will try to suggest more peaceful things... who the hell needs peace anyway..."
+        [/message]
+        [message]
+            speaker=ally
+            message=_"Are you humans always like this?"
+        [/message]
+        [message]
+            speaker=Acanthamoeba
+            message=_"Pardon our friend. He used to be a tyrant before his throne was stolen and we are using him as an advisor. He has a lot of good ideas, but sometimes he gives very opportunistic and violent suggestions and so we have to filter his suggestions carefully. This was one of his excesses. Of course we would never misuse this friendly help to occupy your beautiful town. Making an embassy here might not be such a bad idea, though..."
+        [/message]
+        [repeating_message]
+            speaker=Fowleri
+            first=_"I am sorry to interrupt, but we need to make a plan for the battle. The orcs are probably building camps near the lake by now."
+            message=_"Any more suggestions?"
+            [option]
+                message=_"We are slow in the forest. You elves are much faster. Do you think that you could slow them down? We cannot let them become too strong by sacking the villages for supplies."
+                [command]
+                    [message]
+                        speaker=ally
+                        message=_"We can save villages, but it will cost us lives."
+                    [/message]
+                    [message]
+                        speaker=Xalzaxx
+                        message=_"Listen to Krux, you fool."
+                    [/message]
+                    [message]
+                        speaker=Krux
+                        message=_"If the orcs collect too much supplies, they might become so strong that they sack Amaranth. That sacrifice, no matter how hard it is, increases the chance to save the lives of children and civilians."
+                    [/message]
+                    [message]
+                        speaker=ally
+                        message=_"And also of your people."
+                    [/message]
+                    [message]
+                        speaker=Krux
+                        message=_"Not really, we can escape if the situation becomes too hopeless."
+                    [/message]
+                    [message]
+                        speaker=ally
+                        message=_"Fine, fine, I will have to do that. It will be a hard decision, though."
+                    [/message]
+                [/command]
+            [/option]
+            [option]
+                message=_"What defences do you have?"
+                [command]
+                    [message]
+                        speaker=ally
+                        message=_"Almost none. We never expected such a large group to focus directly on us."
+                    [/message]
+                    [message]
+                        speaker=Fowleri
+                        message=_"It could be our fault. They spotted us and guessed that there are some settlements nearby."
+                    [/message]
+                    [message]
+                        speaker=ally
+                        message=_"So if we told them where they can find humans, will they split?"
+                    [/message]
+                    [message]
+                        speaker=Acanthamoeba
+                        message=_"Hardly. If they have a target nearby, they will focus on it."
+                    [/message]
+                    [message]
+                        speaker=Fowleri
+                        message=_"These orcs are longing to sack and pillage. As Acantha said, they will not resist attacking a town that is in sight."
+                    [/message]
+                    [message]
+                        speaker=Krux
+                        message=_"You should have thought of safety first. Extra work is worth it if it saves lives."
+                    [/message]
+                [/command]
+            [/option]
+            [option]
+                message=_"Is there any way to make them attack other orcs?"
+                [command]
+                    [message]
+                        speaker=Lucretia
+                        message=_"There is one poison that causes insanity, administering it to one of their leaders might have him fight others for domination. Unfortunately, we do not have it."
+                    [/message]
+                    [message]
+                        speaker=Judas
+                        message=_"Maybe if Fowleri offered to heal bruises to their leaders, they would end up without leadership. But Fowleri would most likely die in the process and it also might fail. In the worst case, their bruises might be healed."
+                    [/message]
+                    [message]
+                        speaker=Antipos
+                        message=_"Do you think that we could pay them, Krux?"
+                    [/message]
+                    [message]
+                        speaker=Krux
+                        message=_"Give them gold and they will demand more a few days later until you give them everything. And then they attack."
+                    [/message]
+                    [message]
+                        speaker=Acanthamoeba
+                        message=_"How about killing one of their leaders and forging evidence showing that it was another leader?"
+                    [/message]
+                    [message]
+                        speaker=Fowleri
+                        message=_"Orcs do not punish or scorn murderers in their ranks. Killing another orc is completely acceptable for them. They would not investigate."
+                    [/message]
+                    [message]
+                        speaker=Acanthamoeba
+                        message=_"That is bad."
+                    [/message]
+                [/command]
+            [/option]
+            [option]
+                message=_"That is all I can think of."
+                [show_if]
+                    [not]
+                        [variable]
+                            name=first_view
+                            equals=true
+                        [/variable]
+                    [/not]
+                [/show_if]
+                [command]
+                    [break]
+                    [/break]
+                [/command]
+            [/option]
+        [/repeating_message]
+        [message]
+            speaker=ally
+            message=_"So we have a plan now. Time to fight for survival."
+        [/message]
         [message]
             speaker=Krux
             message= _ "I know that this is unusual for me, but TAKE NO PRISONERS!"
         [/message]
-    [terrain]
-        x,y=7-10,7-8
-        terrain=Ce
-    [/terrain]
-    [terrain]
-        x,y=8,6
-        terrain=Ket
-    [/terrain]
-    [terrain]
-        x,y=8-10,3
-        terrain=Ce
-    [/terrain]
-    [terrain]
-        x,y=9-10,4
-        terrain=Ce
-    [/terrain]
-    [terrain]
-        x,y=7,3
-        terrain=Ket
-    [/terrain]
-    [unit]
-        canrecruit=yes
-        generate_name=yes
-        id=enemy1
-        x,y=8,6
-        type=Orcish Nightblade
-        side=3
-    [/unit]
-    [unit]
-        canrecruit=yes
-        generate_name=yes
-        id=enemy2
-        x,y=7,3
-        type=Orcish Warmonger
-        side=4
-    [/unit]
-    [modify_side]
-        side=1
-        {GOLD 300 280 260}
-        income=0
-        village_gold=2
-        recruit=Spearman,Bowman,Heavy Infantryman,Cavalryman,Fencer,Mage,Horseman
-    [/modify_side]
-    [modify_side]
-        side=2
-        {GOLD 200 180 160}
-        income=0
-        village_gold=2
-    [/modify_side]
-    [modify_side]
-        side=3
-        {GOLD 400 480 560}
-        {INCOME 10 15 20}
-        village_gold=3
-    [/modify_side]
-    [modify_side]
-        side=4
-        {GOLD 400 480 560}
-        {INCOME 10 15 20}
-        village_gold=3
-    [/modify_side]
+        [terrain]
+            x,y=7-10,7-8
+            terrain=Ce
+        [/terrain]
+        [terrain]
+            x,y=8,6
+            terrain=Ket
+        [/terrain]
+        [terrain]
+            x,y=8-10,3
+            terrain=Ce
+        [/terrain]
+        [terrain]
+            x,y=9-10,4
+            terrain=Ce
+        [/terrain]
+        [terrain]
+            x,y=7,3
+            terrain=Ket
+        [/terrain]
+        [unit]
+            canrecruit=yes
+            generate_name=yes
+            id=enemy1
+            x,y=8,6
+            type=Orcish Nightblade
+            side=3
+        [/unit]
+        [unit]
+            canrecruit=yes
+            generate_name=yes
+            id=enemy2
+            x,y=7,3
+            type=Orcish Warmonger
+            side=4
+        [/unit]
+        [modify_side]
+            side=1
+            {GOLD 300 280 260}
+            income=0
+            village_gold=2
+            recruit=Spearman,Bowman,Heavy Infantryman,Cavalryman,Fencer,Mage,Horseman
+        [/modify_side]
+        [modify_side]
+            side=2
+            {GOLD 200 180 160}
+            income=0
+            village_gold=2
+        [/modify_side]
+        [modify_side]
+            side=3
+            {GOLD 400 480 560}
+            {INCOME 10 15 20}
+            village_gold=3
+        [/modify_side]
+        [modify_side]
+            side=4
+            {GOLD 400 480 560}
+            {INCOME 10 15 20}
+            village_gold=3
+        [/modify_side]
     [/event]
 
     [event]
@@ -564,331 +566,331 @@
     [/event]
 
     [event]
-    name=new turn
-    first_time_only=no
-    [filter_condition]
-        [variable]
-            name=phase
-            equals=1
-        [/variable]
-    [/filter_condition]
-    {VARIABLE count 2}
-    [while]
-        [variable]
-            name=count
-            greater_than=0
-        [/variable]
-        [do]
-            {VARIABLE_OP type rand "Wolf,Great Wolf"}
-            {GENERIC_UNIT 5 $type 22 32}
-            {VARIABLE_OP count sub 1}
-        [/do]
-    [/while]
+        name=new turn
+        first_time_only=no
+        [filter_condition]
+            [variable]
+                name=phase
+                equals=1
+            [/variable]
+        [/filter_condition]
+        {VARIABLE count 2}
+        [while]
+            [variable]
+                name=count
+                greater_than=0
+            [/variable]
+            [do]
+                {VARIABLE_OP type rand "Wolf,Great Wolf"}
+                {GENERIC_UNIT 5 $type 22 32}
+                {VARIABLE_OP count sub 1}
+            [/do]
+        [/while]
     [/event]
 
     [event]
-    name=die
-    [filter]
-        id=enemy1
-    [/filter]
-    [filter_condition]
-        [not]
-            [have_unit]
-                id=enemy2
-            [/have_unit]
-        [/not]
-    [/filter_condition]
-    [fire_event]
-        name=killed both
-    [/fire_event]
-    [/event] 
+        name=die
+        [filter]
+            id=enemy1
+        [/filter]
+        [filter_condition]
+            [not]
+                [have_unit]
+                    id=enemy2
+                [/have_unit]
+            [/not]
+        [/filter_condition]
+        [fire_event]
+            name=killed both
+        [/fire_event]
+    [/event]
     [event]
-    name=die
-    [filter]
-        id=enemy2
-    [/filter]
-    [filter_condition]
-        [not]
-            [have_unit]
-                id=enemy1
-            [/have_unit]
-        [/not]
-    [/filter_condition]
-    [fire_event]
-        name=killed both
-    [/fire_event]
-    [/event] 
+        name=die
+        [filter]
+            id=enemy2
+        [/filter]
+        [filter_condition]
+            [not]
+                [have_unit]
+                    id=enemy1
+                [/have_unit]
+            [/not]
+        [/filter_condition]
+        [fire_event]
+            name=killed both
+        [/fire_event]
+    [/event]
 
     [event]
         name=killed both
-    [message]
-        speaker=Krux
-        message=_"We have brought you this major victory. The orcs have been defeated and scattered across the area, now they will be easy prey for anyone who needs training by ambushing them. I shall now send my army away..."
-    [/message]
-    [message]
-        speaker=Antipos
-        message=_"Under these conditions."
-    [/message]
-    [message]
-        speaker=Fowleri
-        message=_"What?"
-    [/message]
-    [message]
-        speaker=Acanthamoeba
-        message=_"Antipos is being crazy again, this time without consulting at all. We will send our soldiers away, with no conditions."
-    [/message]
-    [message]
-        speaker=Krux
-        message=_"Yes, no conditions, any other conditions would be very close to hegemony and lead to violence which I am not very fond of. However, I would be glad if your people could be closer to each other. We are neighbours, separated by less than a day's travel, yet we are so independent that it pains me. This battle has shown how well we can cooperate with each other and it is a waste of efforts if we continue to live like if we were separated by an ocean."
-    [/message]
-    [message]
-        speaker=ally
-        message=_"I fear that would lead to a slow domination by humans."
-    [/message]
-    [message]
-        speaker=Krux
-        message=_"If I wanted to take over your town, I would do it now."
-    [/message]
-    [message]
-        speaker=ally
-        message=_"You cannot do it now without bloodshed. Because you want to avoid bloodshed, you are seeking alternative ways."
-    [/message]
-    [message]
-        speaker=Krux
-        message=_"Now tell me, why am I trying to avoid bloodshed? Because I am a good and merciful man who does not want anything bad to happen to nobody who does not deserve it."
-    [/message]
-    [message]
-        speaker=Acanthamoeba
-        message=_"To realise these neighbourly relationships, I am asking you to allow us to build an embassy in this town. It would have no military presence except weapons necessary for traveling to Ogira and back. It would be used only to discuss trade, culture and spread information about possible dangers like these orcs. It is not a demand, I am just politely asking, if you refuse, it would make me sad, but I would not perform any hostile actions."
-    [/message]
-    [message]
-        speaker=Krux
-        message=_"For this embassy, we would pay taxes to you because this is your land. It would also give free beer to your citizens unless it runs out of supplies."
-    [/message]
-    [message]
-        speaker=ally
-        message=_"What if I refuse?"
-    [/message]
-    [message]
-        speaker=Acanthamoeba
-        message=_"We shall lay waste to your town, burn the forest and practice necromancy on your children."
-    [/message]
-    [message]
-        speaker=ally
-        message=_"So you are giving me no choice, conquerors?"
-    [/message]
-    [message]
-        speaker=Acanthamoeba
-        message=_"That was a joke, you blockhead! Of course we will let you be, but keep in mind that we have saved you. We might not come next time. Such an embassy would assure that we would know if you are in trouble..."
-    [/message]
-    [message]
-        speaker=ally
-        message=_"So that you could join anything that troubles us?"
-    [/message]
-    [message]
-        speaker=Krux
-        message=_"Stop twisting our words. I want cooperation because of mutual profit and mutual protection. If you were officially our friends, it would be easier to muster an army to help you. This time, you survived only because we have noticed them early and nobody with authority was home to block my command to take the army."
-    [/message]
-    [message]
-        speaker=ally
-        message=_"I find your help highly suspicious. When the orcs came before, nobody came to help us."
-    [/message]
-    [message]
-        speaker=Krux
-        message=_"It was a hundred years ago. Our family had no influence back then. We did not have an army to help you and we were not your neighbours yet."
-    [/message]
-    [message]
-        speaker=ally
-        message=_"Nobody else helped us."
-    [/message]
-    [message]
-        speaker=Fowleri
-        message=_"You are treating the human race as whole. Humans are very variable. I have lived with them and I am very sure of that. Some humans behave like orcs and kill and pillage everything that happens to be on their way. Other humans refuse to touch any weapons and live only to help others with healng magic and free food. Judge him, do not judge his entire race."
-    [/message]
-    [message]
-        speaker=ally
-        message=_"Humans change their mind too often."
-    [/message]
-    [message]
-        speaker=Fowleri
-        message=_"That is only because their life is short. Do you remember the days when you wanted to stay out of politics? I do. Do you remember the day when you told that you will never take part in any military action? I do. You are changing too. If they change their approach, we order them to leave our town. We can always do that."
-    [/message]
-    [message]
-        speaker=Krux
-        message=_"Indeed that you would be allowed to revoke that permission at any time."
-    [/message]
-    [message]
-        speaker=ally
-        message=_"There shall be no embassy. Ever."
-    [/message]
-    [message]
-        speaker=Fowleri
-        message=_"Maybe it is time for another election."
-    [/message]
-    [message]
-        speaker=Krux
-        message=_"Seriously, you are so ungrateful and unappreciative that I will have no motivation to help you next time. I will only bother to rescue Fowleri."
-    [/message]
-    [message]
-        speaker=ally
-        message=_"Fowleri, do you seriously expect that you will be elected instead of me? That is not going to happen. You were living among humans and it has made your brain shrink. We have support of most elves from this town. Humans cannot be trusted. Ever. They are rarely evil, but they have betrayal in their blood and you can never expect when it strikes. And they are often friends with dwarves. Krux and his friends will be allowed to enter our town if they do not have an army with them, but that is all reward they will get. Ever."
-    [/message]
-    [message]
-        speaker=Fowleri
-        message=_"I am sometimes wondering if you were not born from a bowel instead of..."
-    [/message]
-    [message]
-        speaker=ally
-        message=_"Stop questioning my authority, Fowleri!"
-    [/message]
-    [message]
-        speaker=Fowleri
-        message=_"I am a military officer and I have a full right to question your authority. I would not do it if you were not behaving like a peacock born from a broken egg. You are so big-headed that I wonder how such a small brain can be in your head. It must be supported by pillars or something..."
-    [/message]
-    [message]
-        speaker=ally
-        message=_"Sod off this town, Fowleri with all those humans of yours."
-    [/message]
-    [message]
-        speaker=Fowleri
-        message=_"I am a high-ranking military officer. I am taking half of your soldiers and moving into a nearby outpost. The orcs are scattered and their groups have to be tracked down and destroyed. I cannot let you in charge because your stupidity is dangerous. Cur."
-    [/message]
-    [message]
-        speaker=Hare
-        message=_"Your disregard for authority pleases me, Fowleri."
-    [/message]
-    [message]
-        speaker=Antipos
-        message=_"Krux, may I have a word with you? In private?"
-    [/message]
-    [store_unit]
-        [filter]
-            id=Antipos
-        [/filter]
-        variable=antipos_store
-        kill=no
-    [/store_unit]
-    {MOVE_UNIT id=Krux $antipos_store.x $antipos_store.y}
-    {CLEAR_VARIABLE antipos_store}
-    [message]
-        speaker=Krux
-        message=_"What did you want?"
-    [/message]
-    [message]
-        speaker=Antipos
-        message=_"This is going nowhere. It appears that the only elf agreeing with us was Fowleri. Others seem to scorn humans as if we were orcs. I may have a little suggestion, though."
-    [/message]
-    [message]
-        speaker=Krux
-        message=_"Taking their town by force?"
-    [/message]
-    [message]
-        speaker=Antipos
-        message=_"How did you know? Joking. Not by force. They will be unfriendly to humans, but a half-elf could be acceptable for them."
-    [/message]
-    [message]
-        speaker=Krux
-        message=_"Unfortunately, I am not a half-elf. If I somehow managed to marry Fowleri, all other elves would scorn me. And my offspring too."
-    [/message]
-    [message]
-        speaker=Antipos
-        message=_"You are not a half-elf, but there is one I know about. And she happens to be of House de Rais. She might need a little preparation to be on our side, though."
-    [/message]
-    [message]
-        speaker=Krux
-        message=_"Who are you talking about?"
-    [/message]
-    [message]
-        speaker=Antipos
-        message=_"Your daughter."
-    [/message]
-    [message]
-        speaker=Krux
-        message=_"What? Fowleri is awaiting a child with me?"
-    [/message]
-    [message]
-        speaker=Antipos
-        message=_"Indeed. She does not know about it though."
-    [/message]
-    [message]
-        speaker=Krux
-        message=_"However, I will hardly get any influence on her. Fowleri will pretend that she is a pure blooded elf..."
-    [/message]
-    [message]
-        speaker=Antipos
-        message=_"Half-elves have blond hair much less often and their ears are not pointy. If you saw one, you most likely concluded that he was a human that looks like an elf a lot. Maybe in the elvish community they hide their ears under their hair, bleach their hair and pretend that they are a bit short and bulky but still elves. I have seen elves that could be mistaken for humans if they wore a full helmet hiding also their hair. I guess that she might pretend that her daughter is pure blooded, although it would require some effort."
-    [/message]
-    [message]
-        speaker=Krux
-        message=_"However, if she does so, she would hardly let me approach her frequently enough."
-    [/message]
-    [message]
-        speaker=Antipos
-        message=_"That is the problem. We have to steal her. I know a spell. It would transfer her into some other woman, the only candidate is Acantha. And Fowleri will never learn."
-    [/message]
-    [message]
-        speaker=Krux
-        message=_"But Acantha is not married. If she does not marry soon enough, he would be an out-of-marriage child, assumed to be the offspring of a bandit who enchanted her during our adventures."
-    [/message]
-    [message]
-        speaker=Antipos
-        message=_"She will have to marry someone very soon. An accusation of a noble of extramarital affairs is considered quite serious in this society. We have like two months for that, human pregnancy takes nine months elvish takes fifteen, twelve is an average, almost a month passed since she was conceived..."
-    [/message]
-    [message]
-        speaker=Krux
-        message=_"We shall not find anyone suitable for her so fast. Those marriage jokes are just jokes. But I have an idea. I will get drunk with a suitable young noblewoman, you will insert the child and I will pretend that it was an accident while we were drunk. A child born to a noblewoman and an important nobleman out of marriage is still quite an important person and she might be taken into our town for long stays."
-    [/message]
-    [message]
-        speaker=Krux
-        message=_"However, how do you want to steal that child? She is now in the army and I will hardly get her away from all her soldiers. Even if I managed she would notice the bleeding and know what I had done. I do not want to cause strife between humans and elves."
-    [/message]
-    [message]
-        speaker=Antipos
-        message=_"We will hire some orcs and send them against her outpost. Her soldiers are not trained well, so the orcs will easily prevail. Once she is wounded and barely conscious, I will use the spell. Then we save them from the orcs. Any harm done on her will be attributed to the orcs and everyone will know that those were orcs who did it."
-    [/message]
-    [message]
-        speaker=Krux
-        message=_"That is quite a needless slaughter of elves."
-    [/message]
-    [message]
-        speaker=Antipos
-        message=_"Some elves will die, especially all witnesses, but killing orcs always brings some casualties. Just that this time, we shall choose those who will sacrifice themselves for the greater good. We will make it easier for the elves to defeat the orcs by issuing them bad commands, especially a reckless and suicidal attack on their leader."
-    [/message]
-    [message]
-        speaker=Krux
-        message=_"A proper partnership with elves will save much more lives than we put at risk with this scheme."
-    [/message]
-    [store_unit]
+        [message]
+            speaker=Krux
+            message=_"We have brought you this major victory. The orcs have been defeated and scattered across the area, now they will be easy prey for anyone who needs training by ambushing them. I shall now send my army away..."
+        [/message]
+        [message]
+            speaker=Antipos
+            message=_"Under these conditions."
+        [/message]
+        [message]
+            speaker=Fowleri
+            message=_"What?"
+        [/message]
+        [message]
+            speaker=Acanthamoeba
+            message=_"Antipos is being crazy again, this time without consulting at all. We will send our soldiers away, with no conditions."
+        [/message]
+        [message]
+            speaker=Krux
+            message=_"Yes, no conditions, any other conditions would be very close to hegemony and lead to violence which I am not very fond of. However, I would be glad if your people could be closer to each other. We are neighbours, separated by less than a day's travel, yet we are so independent that it pains me. This battle has shown how well we can cooperate with each other and it is a waste of efforts if we continue to live like if we were separated by an ocean."
+        [/message]
+        [message]
+            speaker=ally
+            message=_"I fear that would lead to a slow domination by humans."
+        [/message]
+        [message]
+            speaker=Krux
+            message=_"If I wanted to take over your town, I would do it now."
+        [/message]
+        [message]
+            speaker=ally
+            message=_"You cannot do it now without bloodshed. Because you want to avoid bloodshed, you are seeking alternative ways."
+        [/message]
+        [message]
+            speaker=Krux
+            message=_"Now tell me, why am I trying to avoid bloodshed? Because I am a good and merciful man who does not want anything bad to happen to nobody who does not deserve it."
+        [/message]
+        [message]
+            speaker=Acanthamoeba
+            message=_"To realise these neighbourly relationships, I am asking you to allow us to build an embassy in this town. It would have no military presence except weapons necessary for traveling to Ogira and back. It would be used only to discuss trade, culture and spread information about possible dangers like these orcs. It is not a demand, I am just politely asking, if you refuse, it would make me sad, but I would not perform any hostile actions."
+        [/message]
+        [message]
+            speaker=Krux
+            message=_"For this embassy, we would pay taxes to you because this is your land. It would also give free beer to your citizens unless it runs out of supplies."
+        [/message]
+        [message]
+            speaker=ally
+            message=_"What if I refuse?"
+        [/message]
+        [message]
+            speaker=Acanthamoeba
+            message=_"We shall lay waste to your town, burn the forest and practice necromancy on your children."
+        [/message]
+        [message]
+            speaker=ally
+            message=_"So you are giving me no choice, conquerors?"
+        [/message]
+        [message]
+            speaker=Acanthamoeba
+            message=_"That was a joke, you blockhead! Of course we will let you be, but keep in mind that we have saved you. We might not come next time. Such an embassy would assure that we would know if you are in trouble..."
+        [/message]
+        [message]
+            speaker=ally
+            message=_"So that you could join anything that troubles us?"
+        [/message]
+        [message]
+            speaker=Krux
+            message=_"Stop twisting our words. I want cooperation because of mutual profit and mutual protection. If you were officially our friends, it would be easier to muster an army to help you. This time, you survived only because we have noticed them early and nobody with authority was home to block my command to take the army."
+        [/message]
+        [message]
+            speaker=ally
+            message=_"I find your help highly suspicious. When the orcs came before, nobody came to help us."
+        [/message]
+        [message]
+            speaker=Krux
+            message=_"It was a hundred years ago. Our family had no influence back then. We did not have an army to help you and we were not your neighbours yet."
+        [/message]
+        [message]
+            speaker=ally
+            message=_"Nobody else helped us."
+        [/message]
+        [message]
+            speaker=Fowleri
+            message=_"You are treating the human race as whole. Humans are very variable. I have lived with them and I am very sure of that. Some humans behave like orcs and kill and pillage everything that happens to be on their way. Other humans refuse to touch any weapons and live only to help others with healng magic and free food. Judge him, do not judge his entire race."
+        [/message]
+        [message]
+            speaker=ally
+            message=_"Humans change their mind too often."
+        [/message]
+        [message]
+            speaker=Fowleri
+            message=_"That is only because their life is short. Do you remember the days when you wanted to stay out of politics? I do. Do you remember the day when you told that you will never take part in any military action? I do. You are changing too. If they change their approach, we order them to leave our town. We can always do that."
+        [/message]
+        [message]
+            speaker=Krux
+            message=_"Indeed that you would be allowed to revoke that permission at any time."
+        [/message]
+        [message]
+            speaker=ally
+            message=_"There shall be no embassy. Ever."
+        [/message]
+        [message]
+            speaker=Fowleri
+            message=_"Maybe it is time for another election."
+        [/message]
+        [message]
+            speaker=Krux
+            message=_"Seriously, you are so ungrateful and unappreciative that I will have no motivation to help you next time. I will only bother to rescue Fowleri."
+        [/message]
+        [message]
+            speaker=ally
+            message=_"Fowleri, do you seriously expect that you will be elected instead of me? That is not going to happen. You were living among humans and it has made your brain shrink. We have support of most elves from this town. Humans cannot be trusted. Ever. They are rarely evil, but they have betrayal in their blood and you can never expect when it strikes. And they are often friends with dwarves. Krux and his friends will be allowed to enter our town if they do not have an army with them, but that is all reward they will get. Ever."
+        [/message]
+        [message]
+            speaker=Fowleri
+            message=_"I am sometimes wondering if you were not born from a bowel instead of..."
+        [/message]
+        [message]
+            speaker=ally
+            message=_"Stop questioning my authority, Fowleri!"
+        [/message]
+        [message]
+            speaker=Fowleri
+            message=_"I am a military officer and I have a full right to question your authority. I would not do it if you were not behaving like a peacock born from a broken egg. You are so big-headed that I wonder how such a small brain can be in your head. It must be supported by pillars or something..."
+        [/message]
+        [message]
+            speaker=ally
+            message=_"Sod off this town, Fowleri with all those humans of yours."
+        [/message]
+        [message]
+            speaker=Fowleri
+            message=_"I am a high-ranking military officer. I am taking half of your soldiers and moving into a nearby outpost. The orcs are scattered and their groups have to be tracked down and destroyed. I cannot let you in charge because your stupidity is dangerous. Cur."
+        [/message]
+        [message]
+            speaker=Hare
+            message=_"Your disregard for authority pleases me, Fowleri."
+        [/message]
+        [message]
+            speaker=Antipos
+            message=_"Krux, may I have a word with you? In private?"
+        [/message]
+        [store_unit]
+            [filter]
+                id=Antipos
+            [/filter]
+            variable=antipos_store
+            kill=no
+        [/store_unit]
+        {MOVE_UNIT id=Krux $antipos_store.x $antipos_store.y}
+        {CLEAR_VARIABLE antipos_store}
+        [message]
+            speaker=Krux
+            message=_"What did you want?"
+        [/message]
+        [message]
+            speaker=Antipos
+            message=_"This is going nowhere. It appears that the only elf agreeing with us was Fowleri. Others seem to scorn humans as if we were orcs. I may have a little suggestion, though."
+        [/message]
+        [message]
+            speaker=Krux
+            message=_"Taking their town by force?"
+        [/message]
+        [message]
+            speaker=Antipos
+            message=_"How did you know? Joking. Not by force. They will be unfriendly to humans, but a half-elf could be acceptable for them."
+        [/message]
+        [message]
+            speaker=Krux
+            message=_"Unfortunately, I am not a half-elf. If I somehow managed to marry Fowleri, all other elves would scorn me. And my offspring too."
+        [/message]
+        [message]
+            speaker=Antipos
+            message=_"You are not a half-elf, but there is one I know about. And she happens to be of House de Rais. She might need a little preparation to be on our side, though."
+        [/message]
+        [message]
+            speaker=Krux
+            message=_"Who are you talking about?"
+        [/message]
+        [message]
+            speaker=Antipos
+            message=_"Your daughter."
+        [/message]
+        [message]
+            speaker=Krux
+            message=_"What? Fowleri is awaiting a child with me?"
+        [/message]
+        [message]
+            speaker=Antipos
+            message=_"Indeed. She does not know about it though."
+        [/message]
+        [message]
+            speaker=Krux
+            message=_"However, I will hardly get any influence on her. Fowleri will pretend that she is a pure blooded elf..."
+        [/message]
+        [message]
+            speaker=Antipos
+            message=_"Half-elves have blond hair much less often and their ears are not pointy. If you saw one, you most likely concluded that he was a human that looks like an elf a lot. Maybe in the elvish community they hide their ears under their hair, bleach their hair and pretend that they are a bit short and bulky but still elves. I have seen elves that could be mistaken for humans if they wore a full helmet hiding also their hair. I guess that she might pretend that her daughter is pure blooded, although it would require some effort."
+        [/message]
+        [message]
+            speaker=Krux
+            message=_"However, if she does so, she would hardly let me approach her frequently enough."
+        [/message]
+        [message]
+            speaker=Antipos
+            message=_"That is the problem. We have to steal her. I know a spell. It would transfer her into some other woman, the only candidate is Acantha. And Fowleri will never learn."
+        [/message]
+        [message]
+            speaker=Krux
+            message=_"But Acantha is not married. If she does not marry soon enough, he would be an out-of-marriage child, assumed to be the offspring of a bandit who enchanted her during our adventures."
+        [/message]
+        [message]
+            speaker=Antipos
+            message=_"She will have to marry someone very soon. An accusation of a noble of extramarital affairs is considered quite serious in this society. We have like two months for that, human pregnancy takes nine months elvish takes fifteen, twelve is an average, almost a month passed since she was conceived..."
+        [/message]
+        [message]
+            speaker=Krux
+            message=_"We shall not find anyone suitable for her so fast. Those marriage jokes are just jokes. But I have an idea. I will get drunk with a suitable young noblewoman, you will insert the child and I will pretend that it was an accident while we were drunk. A child born to a noblewoman and an important nobleman out of marriage is still quite an important person and she might be taken into our town for long stays."
+        [/message]
+        [message]
+            speaker=Krux
+            message=_"However, how do you want to steal that child? She is now in the army and I will hardly get her away from all her soldiers. Even if I managed she would notice the bleeding and know what I had done. I do not want to cause strife between humans and elves."
+        [/message]
+        [message]
+            speaker=Antipos
+            message=_"We will hire some orcs and send them against her outpost. Her soldiers are not trained well, so the orcs will easily prevail. Once she is wounded and barely conscious, I will use the spell. Then we save them from the orcs. Any harm done on her will be attributed to the orcs and everyone will know that those were orcs who did it."
+        [/message]
+        [message]
+            speaker=Krux
+            message=_"That is quite a needless slaughter of elves."
+        [/message]
+        [message]
+            speaker=Antipos
+            message=_"Some elves will die, especially all witnesses, but killing orcs always brings some casualties. Just that this time, we shall choose those who will sacrifice themselves for the greater good. We will make it easier for the elves to defeat the orcs by issuing them bad commands, especially a reckless and suicidal attack on their leader."
+        [/message]
+        [message]
+            speaker=Krux
+            message=_"A proper partnership with elves will save much more lives than we put at risk with this scheme."
+        [/message]
+        [store_unit]
+            [filter]
+                id=Fowleri
+            [/filter]
+            variable=fowleri_store
+            kill=yes
+        [/store_unit]
+        {VARIABLE names_unlocked.conqueror yes}
+        {CHOOSE_VILLAIN_NAME}
+        [disallow_recruit]
+            side=1
+            type=Spearman,Bowman,Heavy Infantryman,Cavalryman,Fencer,Mage,Horseman
+        [/disallow_recruit]
+        [endlevel]
+            result=victory
+            bonus=yes
+            {NEW_GOLD_CARRYOVER 40}
+        [/endlevel]
+    [/event]
+
+    [event]
+        name=attack
         [filter]
             id=Fowleri
         [/filter]
-        variable=fowleri_store
-        kill=yes
-    [/store_unit]
-    {VARIABLE names_unlocked.conqueror yes}
-    {CHOOSE_VILLAIN_NAME}
-    [disallow_recruit]
-        side=1
-        type=Spearman,Bowman,Heavy Infantryman,Cavalryman,Fencer,Mage,Horseman
-    [/disallow_recruit]
-    [endlevel]
-        result=victory
-        bonus=yes
-                {NEW_GOLD_CARRYOVER 40}
-    [/endlevel]
-    [/event]
-
-    [event]
-    name=attack
-    [filter]
-        id=Fowleri
-    [/filter]
-    [filter_condition]
-        [variable]
-            name=second_unit.hitpoints
-            less_than=$second_unit.max_hitpoints
-        [/variable]
-    [/filter_condition]
+        [filter_condition]
+            [variable]
+                name=second_unit.hitpoints
+                less_than=$second_unit.max_hitpoints
+            [/variable]
+        [/filter_condition]
         [message]
             speaker=Fowleri
             message= _ "Oh, poor creature. You appear to be wounded. Let me help you."
@@ -900,7 +902,7 @@
             amount=100
             fire_event=yes
             experience=yes
-        kill=yes
+            kill=yes
         [/harm_unit]
         [message]
             speaker=Fowleri
@@ -910,13 +912,13 @@
             speaker=Krux
             message= _ "You are an avid supporter of euthanasia, right?"
         [/message]
-    [/event] 
+    [/event]
 
     [event]
-    name=die
-    [filter]
-        id=ally
-    [/filter]
+        name=die
+        [filter]
+            id=ally
+        [/filter]
         [message]
             speaker=ally
             message= _ "Amaranth has fallen!"
@@ -924,7 +926,7 @@
         [endlevel]
             result=defeat
         [/endlevel]
-    [/event] 
+    [/event]
 
     [event]
         name=time over

--- a/spinoffs/Affably_Evil/scenarios/07_The_Unforgivable_Abomination.cfg
+++ b/spinoffs/Affably_Evil/scenarios/07_The_Unforgivable_Abomination.cfg
@@ -13,9 +13,9 @@
     [side]
         type=Krux_father
         id=Krux
-    name=_"Krux"
+        name=_"Krux"
         canrecruit=yes
-    unrenamable=yes
+        unrenamable=yes
         side=1
         controller=human
         recruit=
@@ -29,82 +29,81 @@
     [/side]
     [side]
         no_leader=yes
-    recruit=Elvish Fighter,Elvish Archer,Elvish Scout,Elvish Shaman,Wose
+        recruit=Elvish Fighter,Elvish Archer,Elvish Scout,Elvish Shaman,Wose
         side=2
         team_name=helpless_victims
         user_team_name=_"Helpless Victims"
-    village_gold=2
-    {GOLD 220 240 260}
-    [ai]
-        passive_leader=yes
-        [aspect]
-        id=attacks
-        [facet]
-            invalidate_on_gamestate_change=yes
-            [filter_enemy]
-            side=1
-            [not]
-                [filter_wml]
-                    [variables]
-                        hero=yes
-                    [/variables]
-                [/filter_wml]
-            [/not]
-            [or]
-                side=3
-            [/or]
-            [/filter_enemy]
-        [/facet]
-        [/aspect]
-    [/ai]
+        village_gold=2
+        {GOLD 220 240 260}
+        [ai]
+            passive_leader=yes
+            [aspect]
+                id=attacks
+                [facet]
+                    invalidate_on_gamestate_change=yes
+                    [filter_enemy]
+                        side=1
+                        [not]
+                            [filter_wml]
+                                [variables]
+                                    hero=yes
+                                [/variables]
+                            [/filter_wml]
+                        [/not]
+                        [or]
+                            side=3
+                        [/or]
+                    [/filter_enemy]
+                [/facet]
+            [/aspect]
+        [/ai]
     [/side]
     [side]
         no_leader=yes
-    recruit=Elvish Fighter,Elvish Archer,Elvish Scout,Elvish Shaman,Wose
+        recruit=Elvish Fighter,Elvish Archer,Elvish Scout,Elvish Shaman,Wose
         side=3
         team_name=helpless_victims
         user_team_name=_"Helpless Victims"
-    village_gold=2
-    {GOLD 120 140 160}
+        village_gold=2
+        {GOLD 120 140 160}
     [/side]
 
-
     [event]
-    name=prestart
-    {VARIABLE current_scenario the_unforgivable_abomination}
-    {AE_RECALL_ALL 12 16}
-    {SCENARIO_DURATION_VARIABLE phase 1}
+        name=prestart
+        {VARIABLE current_scenario the_unforgivable_abomination}
+        {AE_RECALL_ALL 12 16}
+        {SCENARIO_DURATION_VARIABLE phase 1}
         [objectives]
             side=1
             [objective]
                 description= _ "Approach Fowleri on less than half of her health with Antipater while Acantha stands next to him"
                 condition=win
-        [show_if]
-            [variable]
-                name=phase
-                equals=1
-            [/variable]
-        [/show_if]
+                [show_if]
+                    [variable]
+                        name=phase
+                        equals=1
+                    [/variable]
+                [/show_if]
             [/objective]
             [objective]
                 description= _ "Get as many orcs killed as possible"
                 condition=win
-        [show_if]
-            [variable]
-                name=phase
-                equals=1
-            [/variable]
-        [/show_if]
+                [show_if]
+                    [variable]
+                        name=phase
+                        equals=1
+                    [/variable]
+                [/show_if]
             [/objective]
             [objective]
                 description= _ "Kill all orcs"
                 condition=win
-        [show_if]
-            [variable]
-                name=phase
-                equals=2
-            [/variable]
-        [/show_if]
+                [show_if]
+                    [variable]
+                        name=phase
+                        equals=2
+                    [/variable]
+                [/show_if]
             [/objective]
             [objective]
                 description=_ "Death of the Krux, Acanthamoeba or Anitipater"
@@ -121,476 +120,482 @@
             [objective]
                 description=_ "Fowleri becomes a witness"
                 condition=lose
-        [show_if]
-            [variable]
-                name=phase
-                equals=1
-            [/variable]
-        [/show_if]
+                [show_if]
+                    [variable]
+                        name=phase
+                        equals=1
+                    [/variable]
+                [/show_if]
             [/objective]
             [objective]
                 description=_ "Turns run out"
                 condition=lose
             [/objective]
-        note=_"Elves will suspect you if one of your units avoids combat or attacks elves next to them. Kill the witnesses as soon as possible."
+            note=_"Elves will suspect you if one of your units avoids combat or attacks elves next to them. Kill the witnesses as soon as possible."
         [/objectives]
-    {VARIABLE fowleri_store.side 2}
-    [unstore_unit]
-        variable=fowleri_store
-        x,y=12,2
-    [/unstore_unit]
+        {VARIABLE fowleri_store.side 2}
+        [unstore_unit]
+            variable=fowleri_store
+            x,y=12,2
+        [/unstore_unit]
         {CAPTURE_VILLAGES 2 12 2 20}
-    [set_variable]
-        name=count
-        {QUANTITY value 20 25 30}
-    [/set_variable]
-    [while]
-        [variable]
+        [set_variable]
             name=count
-            greater_than=0
-        [/variable]
-        [do]
-            {VARIABLE_OP type rand "Orcish Grunt,Orcish Warrior,Orcish Archer,Orcish Crossbowman,Orcish Slayer,Orcish Assassin,Wolf Rider,Goblin Knight"}
-            {GENERIC_UNIT 1 $type 17 11}
-            {VARIABLE_OP count sub 1}
-        [/do]
-    [/while]
-    {AE_SPAWN_UNITS 1 2 "Orcish Warrior,Orcish Crossbowman,Orcish Slayer" 5 12 "Orcish Ruler" orc_talker}
+            {QUANTITY value 20 25 30}
+        [/set_variable]
+        [while]
+            [variable]
+                name=count
+                greater_than=0
+            [/variable]
+            [do]
+                {VARIABLE_OP type rand "Orcish Grunt,Orcish Warrior,Orcish Archer,Orcish Crossbowman,Orcish Slayer,Orcish Assassin,Wolf Rider,Goblin Knight"}
+                {GENERIC_UNIT 1 $type 17 11}
+                {VARIABLE_OP count sub 1}
+            [/do]
+        [/while]
+        {AE_SPAWN_UNITS 1 2 "Orcish Warrior,Orcish Crossbowman,Orcish Slayer" 5 12 "Orcish Ruler" orc_talker}
     [/event]
 
     [event]
-    name=start
-    [message]
-        speaker=Antipos
-        message=_"As I said, I have grouped a few orcs we could find and paid them some gold so that they would follow us. Thanks Fowleri for teaching us how to scout the forests to find these orcs."
-    [/message]
-    [message]
-        speaker=Krux
-        message=_"Now, we are going to have an unpleasant challenge. We are leading these orcs into a suicidal raid on Fowleri's Outpost. We need to have the orcs wound Fowleri, when she is hurt I need you, Antipos, to approach her personally and do the dirty work."
-    [/message]
-    [message]
-        speaker=Antipos
-        message=_"I need to have Acantha next to me."
-    [/message]
-    [message]
-        speaker=Acanthamoeba
-        message=_"I do not like this. But there is no other way."
-    [/message]
-    [message]
-        speaker=Krux
-        message=_"The main dangers I expect is death of Fowleri, too many deaths of elves, orcs eventually winning and being seen. So, be very careful. Kill all elves who witnessed our involvment in this. If Fowleri notices it, we are doomed, it would be very hard to explain and I do not want to kill her - I would prefer to kidnap her instead. Neither of these options seem attractive to me."
-    [/message]
-    [message]
-        speaker=Krux
-        message=_"Warriors! Listen to me, mighty orcs. We are going to lead you into a glorious victory. We have a cunning plan that will transform the town ahead of us into ruins. We will kill them all except those who suit us for slavery. To battle!"
-    [/message]
-    [message]
-        speaker=orc_talker
-        message=_"To battle!"
-    [/message]
-    [message]
-        speaker=Hare
-        message=_"To battle!"
-    [/message]
+        name=start
+        [message]
+            speaker=Antipos
+            message=_"As I said, I have grouped a few orcs we could find and paid them some gold so that they would follow us. Thanks Fowleri for teaching us how to scout the forests to find these orcs."
+        [/message]
+        [message]
+            speaker=Krux
+            message=_"Now, we are going to have an unpleasant challenge. We are leading these orcs into a suicidal raid on Fowleri's Outpost. We need to have the orcs wound Fowleri, when she is hurt I need you, Antipos, to approach her personally and do the dirty work."
+        [/message]
+        [message]
+            speaker=Antipos
+            message=_"I need to have Acantha next to me."
+        [/message]
+        [message]
+            speaker=Acanthamoeba
+            message=_"I do not like this. But there is no other way."
+        [/message]
+        [message]
+            speaker=Krux
+            message=_"The main dangers I expect is death of Fowleri, too many deaths of elves, orcs eventually winning and being seen. So, be very careful. Kill all elves who witnessed our involvment in this. If Fowleri notices it, we are doomed, it would be very hard to explain and I do not want to kill her - I would prefer to kidnap her instead. Neither of these options seem attractive to me."
+        [/message]
+        [message]
+            speaker=Krux
+            message=_"Warriors! Listen to me, mighty orcs. We are going to lead you into a glorious victory. We have a cunning plan that will transform the town ahead of us into ruins. We will kill them all except those who suit us for slavery. To battle!"
+        [/message]
+        [message]
+            speaker=orc_talker
+            message=_"To battle!"
+        [/message]
+        [message]
+            speaker=Hare
+            message=_"To battle!"
+        [/message]
     [/event]
 
     [event]
-    name=moveto
-    first_time_only=no
-    id=the_abomination
-    [filter]
-        id=Antipos
-        [filter_adjacent]
-            id=Fowleri
-        [/filter_adjacent]
-        [and]
+        name=moveto
+        first_time_only=no
+        id=the_abomination
+        [filter]
+            id=Antipos
             [filter_adjacent]
+                id=Fowleri
+            [/filter_adjacent]
+            [and]
+                [filter_adjacent]
+                    id=Acanthamoeba
+                [/filter_adjacent]
+            [/and]
+            [or]
                 id=Acanthamoeba
-            [/filter_adjacent]
-        [/and]
-        [or]
-            id=Acanthamoeba
-            [filter_adjacent]
-                id=Antipos
                 [filter_adjacent]
-                    id=Fowleri
-                [/filter_adjacent]
-            [/filter_adjacent]
-        [/or]
-    [/filter]
-    [store_unit]
-        [filter]
-            id=Fowleri
-        [/filter]
-        variable=fowl
-        kill=no
-    [/store_unit]
-    [if]
-        [variable]
-            name=fowl.hitpoints
-            less_than_equal_to=$($fowl.max_hitpoints/2)
-        [/variable]
-        [then]
-            [message]
-                speaker=Antipos
-                message=_"Hahahahaha. Evil deed done! Acantha, please stay out of injury at any cost."
-            [/message]
-            {VARIABLE phase 2}
-            [modify_side]
-                side=2
-                team_name=house_de_rais
-                user_team_name=_"Allies"
-            [/modify_side]
-            [modify_unit]
-                [filter]
-                    race=orc
-                    [or]
-                        race=wolf
-                    [/or]
-                    [or]
-                        race=goblin
-                    [/or]
-                [/filter]
-                side=3
-            [/modify_unit]
-            [message]
-                speaker=Krux
-                message=_"Fowleri, what have they done to you? You are bleeding!"
-            [/message]
-            [message]
-                speaker=Fowleri
-                message=_"They... they must have stabbed me really badly. They must have damaged my guts somehow, I am bleeding from that part quite badly. I should be able to recover from this, but the orcs are everywhere..."
-            [/message]
-            [message]
-                speaker=Antipos
-                message=_"I have just healed the worst. The battle is quite intense, can you heal yourself?"
-            [/message]
-            [message]
-                speaker=Fowleri
-                message=_"I do not feel like killing myself right now."
-            [/message]
-            [message]
-                speaker=Antipos
-                message=_"Sorry, I forgot that you were a bad healer. The idea that elvish mages are good healers is quite deeply rooted in my head and I cannot get rid of that. I will help you."
-            [/message]
-            [heal_unit]
-                [filter]
-                    id=Fowleri
-                [/filter]
-                [filter_second]
                     id=Antipos
-                [/filter_second]
-                amount=100
-                animate=yes
-            [/heal_unit]
-            [message]
-                speaker=Krux
-                message=_"Kill the orcs, slay the orcs, destroy the orcs!"
-            [/message]
-            [message]
-                speaker=Fowleri
-                message=_"That was poetry too, I think."
-            [/message]
-            [message]
-                speaker=Krux
-                message=_"Yes, it was. You are good at guessing what is a quote, Fowleri."
-            [/message]
-            [remove_event]
-                id=the_abomination
-            [/remove_event]
-        [/then]
-    [/if]
-    [/event]
-
-    [event]
-    name=side 1 turn end
-    first_time_only=no
-    [filter_condition]
-        [variable]
-            name=phase
-            equals=1
-        [/variable]
-    [/filter_condition]
-    [store_unit]
-        [filter]
-            side=2
-            [filter_adjacent]
-                side=1
-                [filter_wml]
-                    [variables]
-                        hero=yes
-                    [/variables]
-                [/filter_wml]
-                [not]
-                    [filter_wml]
-                        attacks_left=0
-                    [/filter_wml]
-                [/not]
-            [/filter_adjacent]
-        [/filter]
-        variable=seen_slacking
-    [/store_unit]
-    {FOREACH seen_slacking i}
-        [fire_event]
-            name=witnessing
-            [primary_unit]
-                find_in=seen_slacking[$i]
-            [/primary_unit]
-        [/fire_event]
-    {NEXT i}
-    {CLEAR_VARIABLE seen_slacking}
-    [/event]
-
-    [event]
-    name=attack
-    first_time_only=no
-    [filter]
-        side=1
-        [filter_wml]
-            [variables]
-                hero=yes
-            [/variables]
-        [/filter_wml]
-    [/filter]
-    [filter_second]
-        side=2
-    [/filter_second]
-    [store_unit]
-        [filter]
-            side=2
-            [filter_adjacent]
-                find_in=unit
-            [/filter_adjacent]
-            [or]
-                side=2
-                [filter_adjacent]
-                    find_in=second_unit
+                    [filter_adjacent]
+                        id=Fowleri
+                    [/filter_adjacent]
                 [/filter_adjacent]
             [/or]
-            [or]
-                find_in=second_unit
-            [/or]
         [/filter]
-        variable=seen_attacking
-    [/store_unit]
-    {FOREACH seen_attacking i}
-        [fire_event]
-            name=witnessing
-            [primary_unit]
-                find_in=seen_attacking[$i]
-            [/primary_unit]
-        [/fire_event]
-    {NEXT i}
-    {CLEAR_VARIABLE seen_attacking}
+        [store_unit]
+            [filter]
+                id=Fowleri
+            [/filter]
+            variable=fowl
+            kill=no
+        [/store_unit]
+        [if]
+            [variable]
+                name=fowl.hitpoints
+                less_than_equal_to=$($fowl.max_hitpoints/2)
+            [/variable]
+            [then]
+                [message]
+                    speaker=Antipos
+                    message=_"Hahahahaha. Evil deed done! Acantha, please stay out of injury at any cost."
+                [/message]
+                {VARIABLE phase 2}
+                [modify_side]
+                    side=2
+                    team_name=house_de_rais
+                    user_team_name=_"Allies"
+                [/modify_side]
+                [modify_unit]
+                    [filter]
+                        race=orc
+                        [or]
+                            race=wolf
+                        [/or]
+                        [or]
+                            race=goblin
+                        [/or]
+                    [/filter]
+                    side=3
+                [/modify_unit]
+                [message]
+                    speaker=Krux
+                    message=_"Fowleri, what have they done to you? You are bleeding!"
+                [/message]
+                [message]
+                    speaker=Fowleri
+                    message=_"They... they must have stabbed me really badly. They must have damaged my guts somehow, I am bleeding from that part quite badly. I should be able to recover from this, but the orcs are everywhere..."
+                [/message]
+                [message]
+                    speaker=Antipos
+                    message=_"I have just healed the worst. The battle is quite intense, can you heal yourself?"
+                [/message]
+                [message]
+                    speaker=Fowleri
+                    message=_"I do not feel like killing myself right now."
+                [/message]
+                [message]
+                    speaker=Antipos
+                    message=_"Sorry, I forgot that you were a bad healer. The idea that elvish mages are good healers is quite deeply rooted in my head and I cannot get rid of that. I will help you."
+                [/message]
+                [heal_unit]
+                    [filter]
+                        id=Fowleri
+                    [/filter]
+                    [filter_second]
+                        id=Antipos
+                    [/filter_second]
+                    amount=100
+                    animate=yes
+                [/heal_unit]
+                [message]
+                    speaker=Krux
+                    message=_"Kill the orcs, slay the orcs, destroy the orcs!"
+                [/message]
+                [message]
+                    speaker=Fowleri
+                    message=_"That was poetry too, I think."
+                [/message]
+                [message]
+                    speaker=Krux
+                    message=_"Yes, it was. You are good at guessing what is a quote, Fowleri."
+                [/message]
+                [remove_event]
+                    id=the_abomination
+                [/remove_event]
+            [/then]
+        [/if]
     [/event]
 
     [event]
-    name=witnessing
-    first_time_only=no
-    [filter]
-        side=2
-        [not]
+        name=side 1 turn end
+        first_time_only=no
+        [filter_condition]
+            [variable]
+                name=phase
+                equals=1
+            [/variable]
+        [/filter_condition]
+        [store_unit]
+            [filter]
+                side=2
+                [filter_adjacent]
+                    side=1
+                    [filter_wml]
+                        [variables]
+                            hero=yes
+                        [/variables]
+                    [/filter_wml]
+                    [not]
+                        [filter_wml]
+                            attacks_left=0
+                        [/filter_wml]
+                    [/not]
+                [/filter_adjacent]
+            [/filter]
+            variable=seen_slacking
+        [/store_unit]
+        [foreach]
+            array=seen_slacking
+            [do]
+                [fire_event]
+                    name=witnessing
+                    [primary_unit]
+                        find_in=this_item
+                    [/primary_unit]
+                [/fire_event]
+            [/do]
+        [/foreach]
+        {CLEAR_VARIABLE seen_slacking}
+    [/event]
+
+    [event]
+        name=attack
+        first_time_only=no
+        [filter]
+            side=1
             [filter_wml]
                 [variables]
-                    witness=yes
+                    hero=yes
                 [/variables]
             [/filter_wml]
-        [/not]
-    [/filter]
-    [if]
-        [variable]
-            name=unit.id
-            equals=Fowleri
-        [/variable]
-        [then]
-            [message]
-                speaker=Fowleri
-                message=_"I should have trusted the mayor. His arguments may have been silly, but he was right after all. You could not be trusted."
-            [/message]
-            [message]
-                speaker=Krux
-                message=_"Stop! I can explain! I just need you to listen to me for a few minutes, it is quite a long story."
-            [/message]
-            [message]
-                speaker=Fowleri
-                message=_"Bulldust. You have summoned the orcs here so that you could play a hero. It is way too clear."
-            [/message]
-            [message]
-                speaker=Krux
-                message=_"How do you think I could do that? Mmph... Okay friends, change of plan. We are going to kidnap her."
-            [/message]
-            [endlevel]
-                result=defeat
-            [/endlevel]
-        [/then]
-        [else]
+        [/filter]
+        [filter_second]
+            side=2
+        [/filter_second]
+        [store_unit]
+            [filter]
+                side=2
+                [filter_adjacent]
+                    find_in=unit
+                [/filter_adjacent]
+                [or]
+                    side=2
+                    [filter_adjacent]
+                        find_in=second_unit
+                    [/filter_adjacent]
+                [/or]
+                [or]
+                    find_in=second_unit
+                [/or]
+            [/filter]
+            variable=seen_attacking
+        [/store_unit]
+        [foreach]
+            array=seen_attacking
+            [do]
+                [fire_event]
+                    name=witnessing
+                    [primary_unit]
+                        find_in=this_item
+                    [/primary_unit]
+                [/fire_event]
+            [/do]
+        [/foreach]
+        {CLEAR_VARIABLE seen_attacking}
+    [/event]
+
+    [event]
+        name=witnessing
+        first_time_only=no
+        [filter]
+            side=2
+            [not]
+                [filter_wml]
+                    [variables]
+                        witness=yes
+                    [/variables]
+                [/filter_wml]
+            [/not]
+        [/filter]
+        [if]
+            [variable]
+                name=unit.id
+                equals=Fowleri
+            [/variable]
+            [then]
+                [message]
+                    speaker=Fowleri
+                    message=_"I should have trusted the mayor. His arguments may have been silly, but he was right after all. You could not be trusted."
+                [/message]
+                [message]
+                    speaker=Krux
+                    message=_"Stop! I can explain! I just need you to listen to me for a few minutes, it is quite a long story."
+                [/message]
+                [message]
+                    speaker=Fowleri
+                    message=_"Bulldust. You have summoned the orcs here so that you could play a hero. It is way too clear."
+                [/message]
+                [message]
+                    speaker=Krux
+                    message=_"How do you think I could do that? Mmph... Okay friends, change of plan. We are going to kidnap her."
+                [/message]
+                [endlevel]
+                    result=defeat
+                [/endlevel]
+            [/then]
+            [else]
                 [floating_text]
                     text=_ "You! I should not have trusted that friend of yours."
                     x,y=$x1,$y1
                 [/floating_text]
-            [unit_overlay]
-                x,y=$x1,$y1
-                image=misc/witness-overlay.png
-            [/unit_overlay]
-            [store_unit]
-                [filter]
+                [unit_overlay]
                     x,y=$x1,$y1
-                [/filter]
-                variable=witness
-            [/store_unit]
-            {VARIABLE witness.variables.witness yes}
-            [unstore_unit]
-                variable=witness
-                find_vacant=no
-            [/unstore_unit]
-            {CLEAR_VARIABLE witness}
-        [/else]
-    [/if]
+                    image=misc/witness-overlay.png
+                [/unit_overlay]
+                [store_unit]
+                    [filter]
+                        x,y=$x1,$y1
+                    [/filter]
+                    variable=witness
+                [/store_unit]
+                {VARIABLE witness.variables.witness yes}
+                [unstore_unit]
+                    variable=witness
+                    find_vacant=no
+                [/unstore_unit]
+                {CLEAR_VARIABLE witness}
+            [/else]
+        [/if]
     [/event]
 
     [event]
-    name=new turn
-    [filter_condition]
-        [have_unit]
-            side=3
-            count=0
-        [/have_unit]
-        [and]
-            [variable]
-                name=phase
-                equals=2
-            [/variable]
-        [/and]
-    [/filter_condition]
-    [fire_event]
-        name=killed em all
-    [/fire_event]
+        name=new turn
+        [filter_condition]
+            [have_unit]
+                side=3
+                count=0
+            [/have_unit]
+            [and]
+                [variable]
+                    name=phase
+                    equals=2
+                [/variable]
+            [/and]
+        [/filter_condition]
+        [fire_event]
+            name=killed em all
+        [/fire_event]
     [/event]
     [event]
-    name=last breath
-    [filter]
-        side=3
-    [/filter]
-    [filter_condition]
-        [have_unit]
+        name=last breath
+        [filter]
             side=3
-            count=0
-        [/have_unit]
-    [/filter_condition]
-    [fire_event]
-        name=killed em all
-    [/fire_event]
+        [/filter]
+        [filter_condition]
+            [have_unit]
+                side=3
+                count=0
+            [/have_unit]
+        [/filter_condition]
+        [fire_event]
+            name=killed em all
+        [/fire_event]
     [/event]
     [event]
-    name=killed em all
-    [message]
-        speaker=Fowleri
-        message=_"You have helped us. Again. Demanding nothing."
-    [/message]
-    [if]
-        [have_unit]
-            [filter_wml]
-                [variables]
-                    witness=yes
-                [/variables]
-            [/filter_wml]
-        [/have_unit]
-        [then]
-            [store_unit]
-                [filter]
-                    [filter_wml]
-                        [variables]
-                            witness=yes
-                        [/variables]
-                    [/filter_wml]
-                [/filter]
-                variable=witness
-            [/store_unit]
-            [message]
-                speaker=$witness.id
-                message=_"I am not going to listen to your lies, Fowleri. They pretend they have helped us, but the personal gain was obvious. I prefer to call their help <i>racketeering</i>. They have attacked us with the orcs, then they begun to pretend that they were saving us. I have seen it, you cannot deny it."
-            [/message]
-            [message]
-                speaker=Fowleri
-                message=_"Seriously? You have seen that?"
-            [/message]
-            [message]
-                speaker=Krux
-                message=_"Do not listen to him, all the blood and death around him has made him go insane."
-            [/message]
-            [message]
-                speaker=$witness.id
-                message=_"No, those are not just vague false memories. It is all real. I will now tell you every detail..."
-            [/message]
-            [message]
-                speaker=Krux
-                message=_"He is crazy, you cannot see it or what?"
-            [/message]
-            [message]
-                speaker=Fowleri
-                message=_"No. You are hiding something really dark. And I will find out soon what is it. In any means, our friendship is over."
-            [/message]
-            [message]
-                speaker=Krux
-                message=_"Do you know how would it be if you were my mistress? Because that is what you are going to become now. Enslave the rest."
-            [/message]
-            [endlevel]
-                result=defeat
-            [/endlevel]
-        [/then]
-        [else]
-            [message]
-                speaker=Krux
-                message=_"Yes, I have. I wanted to return home, but I have found those orcs and pursued them, but they have arrived here too quickly."
-            [/message]
-            [message]
-                speaker=Fowleri
-                message=_"That was close."
-            [/message]
-            [message]
-                speaker=Acanthamoeba
-                message=_"Now, there is much less orcs in the forests, so it should not happen again."
-            [/message]
-            [message]
-                speaker=Fowleri
-                message=_"It is still dangerous. I do not like it here, but what can I do? I have to protect us from the rest of the orcs. When I am done, I will visit you. Your lessons are not over after all."
-            [/message]
-            [message]
-                speaker=Krux
-                message=_"Okay, let me know when you are done. How long shall it take, can you guess?"
-            [/message]
-            [message]
-                speaker=Fowleri
-                message=_"No, I cannot. It might take years, we usually make a payback, chase them into the hills where we kill as many of them as we can to make sure that the entire tribe was slaughtered and will not return."
-            [/message]
-            [message]
-                speaker=Krux
-                message=_"I am always amazed how merciless you are all when it comes to orcs. I always have to tell myself that killing orcs is not a good thing, because these vile creatures only bring more grief and nobody will mourn them. I wish there was a way to make peace with orcs."
-            [/message]
-            [message]
-                speaker=Fowleri
-                message=_"Not with orcs. They are evil by nature and will only seek pillage and devastation. I have watched them wreak havoc to my village, slaughter innocents and destroy whatever they could."
-            [/message]
-            [message]
-                speaker=Krux
-                message=_"Some humans do that too. We treat them like orcs, but only if we fail to force them to abandon their habits."
-            [/message]
-            [message]
-                speaker=Fowleri
-                message=_"You have not seen the feeling of endless pleasure on their faces when they were killing the defenceless. They are so twisted that they deserve anything as long as it brings death and pain."
-            [/message]
-            [message]
-                speaker=Krux
-                message=_"I will try to remember your words. See you later."
-            [/message]
-            {VARIABLE previous_scenario the_unforgivable_abomination}
-            [endlevel]
-                result=victory
-                bonus=no
+        name=killed em all
+        [message]
+            speaker=Fowleri
+            message=_"You have helped us. Again. Demanding nothing."
+        [/message]
+        [if]
+            [have_unit]
+                [filter_wml]
+                    [variables]
+                        witness=yes
+                    [/variables]
+                [/filter_wml]
+            [/have_unit]
+            [then]
+                [store_unit]
+                    [filter]
+                        [filter_wml]
+                            [variables]
+                                witness=yes
+                            [/variables]
+                        [/filter_wml]
+                    [/filter]
+                    variable=witness
+                [/store_unit]
+                [message]
+                    speaker=$witness.id
+                    message=_"I am not going to listen to your lies, Fowleri. They pretend they have helped us, but the personal gain was obvious. I prefer to call their help <i>racketeering</i>. They have attacked us with the orcs, then they begun to pretend that they were saving us. I have seen it, you cannot deny it."
+                [/message]
+                [message]
+                    speaker=Fowleri
+                    message=_"Seriously? You have seen that?"
+                [/message]
+                [message]
+                    speaker=Krux
+                    message=_"Do not listen to him, all the blood and death around him has made him go insane."
+                [/message]
+                [message]
+                    speaker=$witness.id
+                    message=_"No, those are not just vague false memories. It is all real. I will now tell you every detail..."
+                [/message]
+                [message]
+                    speaker=Krux
+                    message=_"He is crazy, you cannot see it or what?"
+                [/message]
+                [message]
+                    speaker=Fowleri
+                    message=_"No. You are hiding something really dark. And I will find out soon what is it. In any means, our friendship is over."
+                [/message]
+                [message]
+                    speaker=Krux
+                    message=_"Do you know how would it be if you were my mistress? Because that is what you are going to become now. Enslave the rest."
+                [/message]
+                [endlevel]
+                    result=defeat
+                [/endlevel]
+            [/then]
+            [else]
+                [message]
+                    speaker=Krux
+                    message=_"Yes, I have. I wanted to return home, but I have found those orcs and pursued them, but they have arrived here too quickly."
+                [/message]
+                [message]
+                    speaker=Fowleri
+                    message=_"That was close."
+                [/message]
+                [message]
+                    speaker=Acanthamoeba
+                    message=_"Now, there is much less orcs in the forests, so it should not happen again."
+                [/message]
+                [message]
+                    speaker=Fowleri
+                    message=_"It is still dangerous. I do not like it here, but what can I do? I have to protect us from the rest of the orcs. When I am done, I will visit you. Your lessons are not over after all."
+                [/message]
+                [message]
+                    speaker=Krux
+                    message=_"Okay, let me know when you are done. How long shall it take, can you guess?"
+                [/message]
+                [message]
+                    speaker=Fowleri
+                    message=_"No, I cannot. It might take years, we usually make a payback, chase them into the hills where we kill as many of them as we can to make sure that the entire tribe was slaughtered and will not return."
+                [/message]
+                [message]
+                    speaker=Krux
+                    message=_"I am always amazed how merciless you are all when it comes to orcs. I always have to tell myself that killing orcs is not a good thing, because these vile creatures only bring more grief and nobody will mourn them. I wish there was a way to make peace with orcs."
+                [/message]
+                [message]
+                    speaker=Fowleri
+                    message=_"Not with orcs. They are evil by nature and will only seek pillage and devastation. I have watched them wreak havoc to my village, slaughter innocents and destroy whatever they could."
+                [/message]
+                [message]
+                    speaker=Krux
+                    message=_"Some humans do that too. We treat them like orcs, but only if we fail to force them to abandon their habits."
+                [/message]
+                [message]
+                    speaker=Fowleri
+                    message=_"You have not seen the feeling of endless pleasure on their faces when they were killing the defenceless. They are so twisted that they deserve anything as long as it brings death and pain."
+                [/message]
+                [message]
+                    speaker=Krux
+                    message=_"I will try to remember your words. See you later."
+                [/message]
+                {VARIABLE previous_scenario the_unforgivable_abomination}
+                [endlevel]
+                    result=victory
+                    bonus=no
                     {NEW_GOLD_CARRYOVER 100}
-            [/endlevel]
-        [/else]
-    [/if]
+                [/endlevel]
+            [/else]
+        [/if]
     [/event]
 
     [event]
@@ -617,10 +622,10 @@
             speaker=Fowleri
             message= _ "One of the orcs told me that he was hired by Krux in order to sell us into slavery. What a perverted villain you are, Krux. I cannot believe that you kept fooling me for so long."
         [/message]
-    [message]
-        speaker=Krux
-        message=_"Listen, it was different. I have paid these orcs to attack you, I did, but I have given them the dumbest commands we could think of. My plan was to gather them and lead them to you, so that they would be easy targets. There was no other way to kill so many orcs without far more casualties!"
-    [/message]
+        [message]
+            speaker=Krux
+            message=_"Listen, it was different. I have paid these orcs to attack you, I did, but I have given them the dumbest commands we could think of. My plan was to gather them and lead them to you, so that they would be easy targets. There was no other way to kill so many orcs without far more casualties!"
+        [/message]
         [message]
             speaker=Fowleri
             message= _ "That is the dumbest excuse I have ever heard!"

--- a/spinoffs/Affably_Evil/scenarios/09_The_Escape.cfg
+++ b/spinoffs/Affably_Evil/scenarios/09_The_Escape.cfg
@@ -10,150 +10,150 @@
     {MIDNIGHT}
 
     [time_area]
-    y=0-10
-    {INDOORS}
+        y=0-10
+        {INDOORS}
     [/time_area]
 
     [story]
         [part]
-        show_title=no
+            show_title=no
             background=story/capture.jpg
             story= _ "They left the dungeons successfully, but outside, they noticed groups of enemy sentries too often and had to flee in a direction they prepared for them. When they realised they were pushed into a trap, they ran into Marilyn and a large group of soldiers."
         [/part]
         [part]
-        show_title=no
+            show_title=no
             background=story/capture.jpg
             story= _ "Marilyn:
 Your undead pets caused me a lot of trouble, but eventually, I made it here. I have defeated you, Krux. And it was easy. All I needed was to send a lot of scouts into forests near Strych, you were so predictable at leaving underground as soon as you could. Let me tell you something. Your parents are dead. Both Prion and Balamuthia. Your brothers are dead. I can legally obtain your lands by getting rid of you and marrying your sister. Luckily, you have so many crimes to respond to. Death sentence can be obtained even for a theft, you know?"
         [/part]
         [part]
-        show_title=no
+            show_title=no
             background=story/capture.jpg
             story= _ "Krux:
 I am innocent. You cannot prove my link with the necromancy outbreak."
         [/part]
         [part]
-        show_title=no
+            show_title=no
             background=story/capture.jpg
             story= _ "Marilyn:
 That is not so important. I can accuse you of warmongering. Of murder of a soldier you killed in battle. And if we really fail to find something, we can always make up a false accusation. Do not worry. You will die in a few days and I will be your heir."
         [/part]
         [part]
-        show_title=no
+            show_title=no
             background=story/capture.jpg
             story= _ "Acanthamoeba:
 Get stuffed. I did not mind marrying you before, but when you have killed everyone I had, I will hate you until I die."
         [/part]
         [part]
-        show_title=no
+            show_title=no
             background=story/capture.jpg
             story= _ "Marilyn:
 Fine, fine. You actually do have a choice. Me or gallows. Gallows for Krux are assured, but in your case, I could push the idea that you were a misguided child and promise to help you get rid of your bad manners."
         [/part]
         [part]
-        show_title=no
+            show_title=no
             background=story/capture.jpg
             story= _ "Krux:
 Accept that, save your life. If Marilyn and his father Charles die, you would become the heir of both House de Rais and House Mansion."
         [/part]
         [part]
-        show_title=no
+            show_title=no
             background=story/capture.jpg
             story= _ "Marilyn:
 I will not die, do not worry. And Krux, who is that lady with you?"
         [/part]
-    [if]
-        [variable]
-            name=quests.took_lucretia
-            equals=yes
-        [/variable]
-        [then]
-            [part]
-                show_title=no
-                background=story/capture.jpg
-                story= _ "Krux:
+        [if]
+            [variable]
+                name=quests.took_lucretia
+                equals=yes
+            [/variable]
+            [then]
+                [part]
+                    show_title=no
+                    background=story/capture.jpg
+                    story= _ "Krux:
 Lucretia? Where is she... she is gone."
-            [/part]
-            [part]
-                show_title=no
-                background=story/capture.jpg
-                story= _ "Marilyn:
+                [/part]
+                [part]
+                    show_title=no
+                    background=story/capture.jpg
+                    story= _ "Marilyn:
 No, I mean the strangely dressed blonde one who looks like an elf."
-            [/part]
-        [/then]
-    [/if]
+                [/part]
+            [/then]
+        [/if]
         [part]
-        show_title=no
+            show_title=no
             background=story/capture.jpg
             story= _ "Krux:
 Hm, ehm, well... so... she is a... Ehm, well. I will tell you truth. She is an elf."
         [/part]
         [part]
-        show_title=no
+            show_title=no
             background=story/capture.jpg
             story= _ "Marilyn:
 How did she end up with you and in chains?"
         [/part]
         [part]
-        show_title=no
+            show_title=no
             background=story/capture.jpg
             story= _ "Krux:
 She was... hm... she... I have... her... I have abducted her. I cannot accuse her of the things you think I have done because it suits you. Such a shame... I have abducted her in the elvish forest, took her with me. There are some things I like doing with her. Against her will."
         [/part]
         [part]
-        show_title=no
+            show_title=no
             background=story/capture.jpg
             story= _ "Acanthamoeba:
 What?"
         [/part]
         [part]
-        show_title=no
+            show_title=no
             background=story/capture.jpg
             story= _ "Krux:
 I had to tell him the truth. There is nothing that can save my life or your freedom. So I just let her go, I am not vengeful. Unlike Marilyn."
         [/part]
         [part]
-        show_title=no
+            show_title=no
             background=story/capture.jpg
             story= _ "Fowleri seemed very surprised. Marilyn untied her and released her. Apparently, he did not want his family to have trouble with elves. Or maybe he seriously believed what Krux said. They were captured and imprisoned."
         [/part]
         [part]
-        show_title=no
+            show_title=no
             background=story/imprisoned.jpg
             story= _ "Krux ended up in an unknown prison. He knew that they wanted to hang him, they did not even let him see his trial. The result of the trial was expectable, death penalty. There was nothing else for him to hope of. He had lost his property, his power, his family, probably also his friends. As the despair of the unavoidably approaching execution strengthened, he felt that he was losing also his mind."
         [/part]
         [part]
-        show_title=no
+            show_title=no
             background=story/hanging.jpg
             story= _ "It did not take long and he was taken to the gallows. He realised where he was, it was on a river beach in Ogira. He was sad that he had not prepared a trick that would help him escape if he was to be hanged there. A crowd of peasants assembled, longing to see someone die. And they were particularly excited because they were told that the man to be hanged was responsible for all their ills. Fowleri also attended, to Krux' surprise."
         [/part]
         [part]
-        show_title=no
+            show_title=no
             background=story/hanging.jpg
             story= _ "He could hear her shouting that he was innocent, that it was his family who was forcing him to do so, that the officials hated him because he did not tolerate embezzlement, that it was all a ruse of the Mansions,... But nobody listened to her. Marilyn was not present, if he was he would have mentioned something like Stockholm syndrome. The closer they were to the execution, the more erratic was her behaviour, as if she was becoming insane... again."
         [/part]
         [part]
-        show_title=no
+            show_title=no
             background=story/hanging-revolt.jpg
             story= _ "She suddenly begun to cast spells. Krux identified some of them as defensive spells, but most of them were not recognisable. Then her spellcasting begun to sound much darker and the guards noticed the bad omen they spread. Then several people near her started screeching, shaking, their clothes tore as some parts of their bodies expanded and they transformed into misshapen ghouls. The hangman became a particularly impressive one."
         [/part]
         [part]
-        show_title=no
+            show_title=no
             background=story/hanging-revolt.jpg
             story= _ "Peasants begun to flee in panic. Guards attacked her and the ghouls, but her protective spells caused that slash wounds afflicted to her were quite shallow and maces caused only large bruises. She killed many, but eventually she fell on the ground, battered unconscious. Krux' execution was postponed. He was accused of bewitching her, but his sentence could not have become any worse. He was taken back to prison."
         [/part]
         [part]
-        show_title=no
+            show_title=no
             background=story/imprisoned.jpg
             story= _ "Fowleri's insane attempt to rescue him gave him some hope, he tried to climb out of the cell hole so that he could attempt to overpower the guards, but the wall was too smooth. Despair returned again, he could only hope that Fowleri would be released as a victim and Acantha would eventually take control of Marilyn, but none of these hopes granted him life. His sanity was draining away, he begun to see things in the darkness."
         [/part]
         [part]
-        show_title=no
+            show_title=no
             background=story/imprisoned.jpg
             story= _ "Then he saw a guard fall next to him to his death. Hallucinating, he saw him rise, his head hanging on a broken neck and his broken legs floating. He heard the cadaver talk about life after death and horrors that it contains, eternal torture that awaits anyone who dies. The nightmare stepped towards him and begun to choke him. Its strength was unmatchable. He struggled a bit, but then he lost conciousness."
         [/part]
         [part]
-        show_title=no
+            show_title=no
             background=story/imprisoned-rescue.jpg
             story= _ "He awoke with Fowleri creeping next to him. She told him to wake up. He opened his eyes. The dead guard's body was lying still and he was being rescued by her. He was not sure if it was a hallucination or not. Without hesitation, Fowleri slapped him across his face a few times to convice him that she was real."
         [/part]
@@ -202,9 +202,9 @@ I tried to be normal for a while, but I enjoy cleansing the world more than livi
     [side]
         type=Krux_father
         id=Krux
-    name=_"Krux"
+        name=_"Krux"
         canrecruit=yes
-    unrenamable=yes
+        unrenamable=yes
         side=1
         controller=human
         recruit=
@@ -228,15 +228,15 @@ I tried to be normal for a while, but I enjoy cleansing the world more than livi
         side=3
         team_name=house_mansion
         user_team_name=_"House Mansion"
-    [ai]
-        [goal]
-        name=target_location
-        [criteria] #NOTE: this is a SLF, because we're targeting a location
-            x,y=20,9
-        [/criteria]
-        value=20
-        [/goal]
-    [/ai]
+        [ai]
+            [goal]
+                name=target_location
+                [criteria] #NOTE: this is a SLF, because we're targeting a location
+                    x,y=20,9
+                [/criteria]
+                value=20
+            [/goal]
+        [/ai]
     [/side]
     [side]
         no_leader=yes
@@ -245,96 +245,95 @@ I tried to be normal for a while, but I enjoy cleansing the world more than livi
         user_team_name=_"House Mansion"
     [/side]
 
-
     [event]
-    name=prestart
-    {VARIABLE current_scenario the_escape}
-    {VARIABLE fowleri_store.side 1}
-    {VARIABLE fowleri_store.moves 4}
-    {VARIABLE fowleri_store.type Fowleri_batshit}
-    {VARIABLE fowleri_store.name _"Lethalia"}
-    {VARIABLE fowleri_store.hero yes}
-    [unstore_unit]
-        variable=fowleri_store
-        x,y=5,3
-    [/unstore_unit]
-    [object]
-        silent=yes
-        [filter]
-            id=Fowleri
-        [/filter]
-        [effect]
-            apply_to=profile
-            portrait=portraits/Fowleri_batshit.png
+        name=prestart
+        {VARIABLE current_scenario the_escape}
+        {VARIABLE fowleri_store.side 1}
+        {VARIABLE fowleri_store.moves 4}
+        {VARIABLE fowleri_store.type Fowleri_batshit}
+        {VARIABLE fowleri_store.name _"Lethalia"}
+        {VARIABLE fowleri_store.hero yes}
+        [unstore_unit]
+            variable=fowleri_store
+            x,y=5,3
+        [/unstore_unit]
+        [object]
+            silent=yes
             [filter]
-                type=Fowleri_batshit
+                id=Fowleri
             [/filter]
-        [/effect]
-    [/object]
-#	{ADVANCE_UNIT id=Fowleri Fowleri_batshit}
-    {GENERIC_UNIT 1 Ghoul 4 2}
-    {GENERIC_UNIT 1 Ghast 7 4}
-    {GENERIC_UNIT 1 Necrophage 10 2}
-    {GENERIC_UNIT 1 Ghoul 8 4}
-    {GENERIC_UNIT 1 Ghast 12 2}
-    {GENERIC_UNIT 1 Abomination 7 8}
-    {GENERIC_UNIT 1 Ghast 3 7}
+            [effect]
+                apply_to=profile
+                portrait=portraits/Fowleri_batshit.png
+                [filter]
+                    type=Fowleri_batshit
+                [/filter]
+            [/effect]
+        [/object]
+        #	{ADVANCE_UNIT id=Fowleri Fowleri_batshit}
+        {GENERIC_UNIT 1 Ghoul 4 2}
+        {GENERIC_UNIT 1 Ghast 7 4}
+        {GENERIC_UNIT 1 Necrophage 10 2}
+        {GENERIC_UNIT 1 Ghoul 8 4}
+        {GENERIC_UNIT 1 Ghast 12 2}
+        {GENERIC_UNIT 1 Abomination 7 8}
+        {GENERIC_UNIT 1 Ghast 3 7}
 #ifndef HARD
-    {GENERIC_UNIT 1 Abomination 8 3}
+        {GENERIC_UNIT 1 Abomination 8 3}
 #endif
 #ifdef EASY
-    {GENERIC_UNIT 1 Necrophage 3 8}
+        {GENERIC_UNIT 1 Necrophage 3 8}
 #endif
-    [fire_event]
-        name=Lethalia update
-        [primary_unit]
-            id=Lethalia
-        [/primary_unit]
-    [/fire_event]
-    
-    [label]
-        x,y=22,11
-        text=_"Office for crime reporting"
-        color=255,255,255
-    [/label]
+        [fire_event]
+            name=Lethalia update
+            [primary_unit]
+                id=Lethalia
+            [/primary_unit]
+        [/fire_event]
+
+        [label]
+            x,y=22,11
+            text=_"Office for crime reporting"
+            color=255,255,255
+        [/label]
 
         [objectives]
             side=1
             [objective]
                 description= _ "Reach the park on the south with both leaders"
                 condition=win
-        [show_if]
-            [not]
-                [have_unit]
-                    id=Krux
-                    x,y=6-44,29-34
-                [/have_unit]
-                [and]
-                    [have_unit]
-                        id=Fowleri
-                        x,y=6-44,29-34
-                    [/have_unit]
-                [/and]
-            [/not]
-        [/show_if]
+                [show_if]
+                    [not]
+                        [have_unit]
+                            id=Krux
+                            x,y=6-44,29-34
+                        [/have_unit]
+                        [and]
+                            [have_unit]
+                                id=Fowleri
+                                x,y=6-44,29-34
+                            [/have_unit]
+                        [/and]
+                    [/not]
+                [/show_if]
             [/objective]
             [objective]
                 description= _ "Kill all witnesses"
                 condition=win
-        [show_if]
-            [have_unit]
-                side=4
-            [/have_unit]
-        [/show_if]
+                [show_if]
+                    [have_unit]
+                        side=4
+                    [/have_unit]
+                [/show_if]
             [/objective]
             [objective]
                 description= _ "Kill any guard going to report the events"
                 condition=win
-        [show_if]
-            [have_unit]
-                side=3
-            [/have_unit]
-        [/show_if]
+                [show_if]
+                    [have_unit]
+                        side=3
+                    [/have_unit]
+                [/show_if]
             [/objective]
             [objective]
                 description=_ "Death of the Krux or Fowleri/Lethalia"
@@ -352,7 +351,7 @@ I tried to be normal for a while, but I enjoy cleansing the world more than livi
                 description=_ "Turns run out"
                 condition=lose
             [/objective]
-        note=_"Avoid the lit areas to avoid guards. Guards will notice you in a radius of 4 hexes. Check out these objectives (defaults to Ctrl+J) regularly to see if there is not some trouble."
+            note=_"Avoid the lit areas to avoid guards. Guards will notice you in a radius of 4 hexes. Check out these objectives (defaults to Ctrl+J) regularly to see if there is not some trouble."
         [/objectives]
     [/event]
 
@@ -362,528 +361,534 @@ I tried to be normal for a while, but I enjoy cleansing the world more than livi
     [/event]
 
     [event]
-    name=start
-    [message]
-        speaker=Fowleri
-        message=_"Fine, you do not seem to be hurt. Free yourself from despair and embrace this only hope of ours."
-    [/message]
-    [message]
-        speaker=Krux
-        message=_"We have some undead. But you cannot heal, I cannot heal either, the undead will not regenerate... I fear we will not make it."
-    [/message]
-    [message]
-        speaker=Fowleri
-        message=_"We can use stealth. All witnesses of my deeds are dead or turned to undead. There are not many soldiers in this prison, I killed most of them. But the way through the city will be hard, the guards are wandering the town and we need to kill anybody who sees us. We can hide in shadows or bushes. And avoid straying too close to them."
-    [/message]
-    [message]
-        speaker=Krux
-        message=_"Can we make more undead?"
-    [/message]
-    [message]
-        speaker=Fowleri
-        message=_"We cannot make ghouls. It would need the enemy to stay close to me for longer, but usually they feel the evil power. In prison, it is quite easy, evil powers are common there, in that crowd it was easy too because everyone was focused on your execution, but it will not be usable anymore. I could create walking corpses, but the problem is that the reviving spell reeks of death and makes a dark aura and that would certainly be noticed."
-    [/message]
-    [message]
-        speaker=Krux
-        message=_"They have not noticed you on your way here?"
-    [/message]
-    [message]
-        speaker=Fowleri
-        message=_"They did not care about me. And the undead were created inside prison. I am now too covered in blood, they will notice."
-    [/message]
-    [message]
-        speaker=Krux
-        message=_"So we have to kill all witnesses. Does not seem very pleasant to me, but as long as it can save my life..."
-    [/message]
-    [message]
-        speaker=Fowleri
-        message=_"If they notice that you have escaped, they will start a massive search. When you were climbing the rope, I have enchanted the dead soldier to look very much like you. It can be spotted if looked at from short distance and they will notice, but they will not want to loose the reputation for having a dangerous prisoner flee and will hang that imitation of you."
-    [/message]
-    [message]
-        speaker=Krux
-        message=_"And how will they explain the number of dead?"
-    [/message]
-    [message]
-        speaker=Fowleri
-        message=_"As a failed attempt to flee. You are already known to be a dangerous necromancer."
-    [/message]
-    [message]
-        speaker=Krux
-        message=_"I am a reputable necromancer. Without knowing a single necromantic spell."
-    [/message]
-    [message]
-        speaker=Fowleri
-        message=_"It is not so hard, I can teach you. But not now."
-    [/message]
-    [message]
-        speaker=Krux
-        message=_"How will they learn what they should do? They might not figure out that it would be good to pretend that the enchanted cadaver is me."
-    [/message]
-    [message]
-        speaker=Fowleri
-        message=_"I have left a letter. Worry not. We need to get into the park south from prison. The park is dark and borders with forests, so if we get into the park, we are safe."
-    [/message]
-    [message]
-        speaker=Krux
-        message=_"You know, I like this new you. Although I think that if you were something between your usual personality and this homicidal maniac, it would be perfect."
-    [/message]
-    [message]
-        speaker=Fowleri
-        message=_"I will try. I am also glad that you stopped hypocritically pretending that you are a better person. I have never seen you from the angle that you tried to change humans and killed those who opposed you, because they all deserve death and you were only showing mercy."
-    [/message]
-    [message]
-        speaker=Krux
-        message=_"I hope that you will abandon your crusade of purification."
-    [/message]
-    [message]
-        speaker=Fowleri
-        message=_"That is how I like you. Let us go! We have to escape before the day breaks."
-    [/message]
-    {GENERIC_UNIT 2 "Iron Mauler" 23 7}
-    {GENERIC_UNIT 2 "Swordsman" 23 3}
-    {GENERIC_UNIT 2 "Iron Mauler" 16 2}
-    {GENERIC_UNIT 2 "Swordsman" 20 6}
-    {GENERIC_UNIT 2 "Pilum Master" 43 13}
-    {GENERIC_UNIT 2 "Longbowman" 41 19}
-    {GENERIC_UNIT 2 "Pilum Master" 37 8}
-    {GENERIC_UNIT 2 "Longbowman" 41 8}
-    {GENERIC_UNIT 2 "Master Bowman" 22 25}
-    {GENERIC_UNIT 2 "Halberdier" 22 15}
-    {GENERIC_UNIT 2 "Javelineer" 3 18}
-    {GENERIC_UNIT 2 "Royal Guard" 6 23}
-    {GENERIC_UNIT 2 "Swordsman" 8 29}
-    {GENERIC_UNIT 2 "Master Bowman" 22 14}
-    {GENERIC_UNIT 2 "Halberdier" 8 14}
-    {GENERIC_UNIT 2 "Javelineer" 5 21}
-    {GENERIC_UNIT 2 "Royal Guard" 2 26}
-    {GENERIC_UNIT 2 "Swordsman" 11 25}
-    {GENERIC_UNIT 2 "Iron Mauler" 24 23}
-    {GENERIC_UNIT 2 "Swordsman" 31 19}
-    {GENERIC_UNIT 2 "Pilum Master" 31 28}
+        name=start
+        [message]
+            speaker=Fowleri
+            message=_"Fine, you do not seem to be hurt. Free yourself from despair and embrace this only hope of ours."
+        [/message]
+        [message]
+            speaker=Krux
+            message=_"We have some undead. But you cannot heal, I cannot heal either, the undead will not regenerate... I fear we will not make it."
+        [/message]
+        [message]
+            speaker=Fowleri
+            message=_"We can use stealth. All witnesses of my deeds are dead or turned to undead. There are not many soldiers in this prison, I killed most of them. But the way through the city will be hard, the guards are wandering the town and we need to kill anybody who sees us. We can hide in shadows or bushes. And avoid straying too close to them."
+        [/message]
+        [message]
+            speaker=Krux
+            message=_"Can we make more undead?"
+        [/message]
+        [message]
+            speaker=Fowleri
+            message=_"We cannot make ghouls. It would need the enemy to stay close to me for longer, but usually they feel the evil power. In prison, it is quite easy, evil powers are common there, in that crowd it was easy too because everyone was focused on your execution, but it will not be usable anymore. I could create walking corpses, but the problem is that the reviving spell reeks of death and makes a dark aura and that would certainly be noticed."
+        [/message]
+        [message]
+            speaker=Krux
+            message=_"They have not noticed you on your way here?"
+        [/message]
+        [message]
+            speaker=Fowleri
+            message=_"They did not care about me. And the undead were created inside prison. I am now too covered in blood, they will notice."
+        [/message]
+        [message]
+            speaker=Krux
+            message=_"So we have to kill all witnesses. Does not seem very pleasant to me, but as long as it can save my life..."
+        [/message]
+        [message]
+            speaker=Fowleri
+            message=_"If they notice that you have escaped, they will start a massive search. When you were climbing the rope, I have enchanted the dead soldier to look very much like you. It can be spotted if looked at from short distance and they will notice, but they will not want to loose the reputation for having a dangerous prisoner flee and will hang that imitation of you."
+        [/message]
+        [message]
+            speaker=Krux
+            message=_"And how will they explain the number of dead?"
+        [/message]
+        [message]
+            speaker=Fowleri
+            message=_"As a failed attempt to flee. You are already known to be a dangerous necromancer."
+        [/message]
+        [message]
+            speaker=Krux
+            message=_"I am a reputable necromancer. Without knowing a single necromantic spell."
+        [/message]
+        [message]
+            speaker=Fowleri
+            message=_"It is not so hard, I can teach you. But not now."
+        [/message]
+        [message]
+            speaker=Krux
+            message=_"How will they learn what they should do? They might not figure out that it would be good to pretend that the enchanted cadaver is me."
+        [/message]
+        [message]
+            speaker=Fowleri
+            message=_"I have left a letter. Worry not. We need to get into the park south from prison. The park is dark and borders with forests, so if we get into the park, we are safe."
+        [/message]
+        [message]
+            speaker=Krux
+            message=_"You know, I like this new you. Although I think that if you were something between your usual personality and this homicidal maniac, it would be perfect."
+        [/message]
+        [message]
+            speaker=Fowleri
+            message=_"I will try. I am also glad that you stopped hypocritically pretending that you are a better person. I have never seen you from the angle that you tried to change humans and killed those who opposed you, because they all deserve death and you were only showing mercy."
+        [/message]
+        [message]
+            speaker=Krux
+            message=_"I hope that you will abandon your crusade of purification."
+        [/message]
+        [message]
+            speaker=Fowleri
+            message=_"That is how I like you. Let us go! We have to escape before the day breaks."
+        [/message]
+        {GENERIC_UNIT 2 "Iron Mauler" 23 7}
+        {GENERIC_UNIT 2 "Swordsman" 23 3}
+        {GENERIC_UNIT 2 "Iron Mauler" 16 2}
+        {GENERIC_UNIT 2 "Swordsman" 20 6}
+        {GENERIC_UNIT 2 "Pilum Master" 43 13}
+        {GENERIC_UNIT 2 "Longbowman" 41 19}
+        {GENERIC_UNIT 2 "Pilum Master" 37 8}
+        {GENERIC_UNIT 2 "Longbowman" 41 8}
+        {GENERIC_UNIT 2 "Master Bowman" 22 25}
+        {GENERIC_UNIT 2 "Halberdier" 22 15}
+        {GENERIC_UNIT 2 "Javelineer" 3 18}
+        {GENERIC_UNIT 2 "Royal Guard" 6 23}
+        {GENERIC_UNIT 2 "Swordsman" 8 29}
+        {GENERIC_UNIT 2 "Master Bowman" 22 14}
+        {GENERIC_UNIT 2 "Halberdier" 8 14}
+        {GENERIC_UNIT 2 "Javelineer" 5 21}
+        {GENERIC_UNIT 2 "Royal Guard" 2 26}
+        {GENERIC_UNIT 2 "Swordsman" 11 25}
+        {GENERIC_UNIT 2 "Iron Mauler" 24 23}
+        {GENERIC_UNIT 2 "Swordsman" 31 19}
+        {GENERIC_UNIT 2 "Pilum Master" 31 28}
 #ifndef EASY
-    {GENERIC_UNIT 2 "Shock Trooper" 35 25}
-    {GENERIC_UNIT 2 "Shock Trooper" 29 15}
-    {GENERIC_UNIT 2 "Pikeman" 33 12}
-    {GENERIC_UNIT 2 "Pikeman" 37 24}
+        {GENERIC_UNIT 2 "Shock Trooper" 35 25}
+        {GENERIC_UNIT 2 "Shock Trooper" 29 15}
+        {GENERIC_UNIT 2 "Pikeman" 33 12}
+        {GENERIC_UNIT 2 "Pikeman" 37 24}
 #endif
 #ifdef HARD
-    {GENERIC_UNIT 2 "Royal Guard" 36 3}
-    {GENERIC_UNIT 2 "Royal Guard" 34 4}
-    {GENERIC_UNIT 2 "Iron Mauler" 20 25}
-    {GENERIC_UNIT 2 "Iron Mauler" 16 22}
+        {GENERIC_UNIT 2 "Royal Guard" 36 3}
+        {GENERIC_UNIT 2 "Royal Guard" 34 4}
+        {GENERIC_UNIT 2 "Iron Mauler" 20 25}
+        {GENERIC_UNIT 2 "Iron Mauler" 16 22}
 #endif
     [/event]
 
     [event]
-    name=side 2 turn refresh, side 2 turn end
-    first_time_only=no
-    [store_unit]
+        name=side 2 turn refresh, side 2 turn end
+        first_time_only=no
+        [store_unit]
+            [filter]
+                side=2
+            [/filter]
+            variable=seekers
+            kill=no
+        [/store_unit]
+        [foreach]
+            array=seekers
+            [do]
+                [if]
+                    # Passes if a unit of side 1 is in the radius of 4 hexes from the unit (not across the walls) and is either next to a side 2 unit or outside darkness
+                    [have_unit]
+                        side=1
+                        [filter_location]
+                            x,y=$this_item.x,$this_item.y
+                            radius=4
+                            [filter_radius]
+                                terrain=!,X*,X*^*,*^X*
+                            [/filter_radius]
+                        [/filter_location]
+                        [and]
+                            [filter_adjacent]
+                                side=2
+                            [/filter_adjacent]
+                            [or]
+                                [not]
+                                    [filter_location]
+                                        time_of_day=chaotic
+                                    [/filter_location]
+                                [/not]
+                            [/or]
+                            [or]
+                                [not]
+                                    [filter_wml]
+                                        attacks_left=0
+                                    [/filter_wml]
+                                [/not]
+                            [/or]
+                        [/and]
+                    [/have_unit]
+                    [then]
+                        [fire_event]
+                            name=witnessing
+                            [primary_unit]
+                                find_in=this_item
+                            [/primary_unit]
+                        [/fire_event]
+                    [/then]
+                [/if]
+            [/do]
+        [/foreach]
+    [/event]
+
+    [event]
+        name=attack
+        first_time_only=no
         [filter]
-            side=2
+            side=1
         [/filter]
-        variable=seekers
-        kill=no
-    [/store_unit]
-    {FOREACH seekers i}
-        [if]
-            # Passes if a unit of side 1 is in the radius of 4 hexes from the unit (not across the walls) and is either next to a side 2 unit or outside darkness
-            [have_unit]
-                side=1
-                [filter_location]
-                    x,y=$seekers[$i].x,$seekers[$i].y
-                    radius=4
-                        [filter_radius]
-                            terrain=!,X*,X*^*,*^X*
-                        [/filter_radius]
-                [/filter_location]
-                [and]
-                    [filter_adjacent]
-                        side=2
-                    [/filter_adjacent]	
-                    [or]
-                        [not]
-                            [filter_location]
-                                time_of_day=chaotic
-                            [/filter_location]
-                        [/not]
-                    [/or]	
-                    [or]
-                        [not]
-                            [filter_wml]
-                                attacks_left=0
-                            [/filter_wml]
-                        [/not]
-                    [/or]
-                [/and]
-            [/have_unit]
-            [then]
-                [fire_event]
-                    name=witnessing
-                    [primary_unit]
-                        find_in=seekers[$i]
-                    [/primary_unit]
-                [/fire_event]
-            [/then]
-        [/if]
-    {NEXT i}
+        [filter_second]
+            side=2,4
+        [/filter_second]
+        [fire_event]
+            name=witnessing
+            [primary_unit]
+                find_in=second_unit
+            [/primary_unit]
+        [/fire_event]
     [/event]
 
     [event]
-    name=attack
-    first_time_only=no
-    [filter]
-        side=1
-    [/filter]
-    [filter_second]
-        side=2,4
-    [/filter_second]
-    [fire_event]
         name=witnessing
-        [primary_unit]
-            find_in=second_unit
-        [/primary_unit]
-    [/fire_event]
-    [/event]
-
-    [event]
-    name=witnessing
-    first_time_only=no
-    [filter]
-        side=2,4
-    [/filter]
-    [if]
-        [variable]
-            name=unit.side
-            equals=4
-        [/variable]
-        [else]
+        first_time_only=no
+        [filter]
+            side=2,4
+        [/filter]
+        [if]
+            [variable]
+                name=unit.side
+                equals=4
+            [/variable]
+            [else]
                 [floating_text]
                     text=_ "Necromancers! That villain is trying to escape!"
                     x,y=$x1,$y1
                 [/floating_text]
-            [unit_overlay]
-                x,y=$x1,$y1
-                image=misc/witness-overlay.png
-            [/unit_overlay]
-            [modify_unit]
-                [filter]
+                [unit_overlay]
                     x,y=$x1,$y1
-                [/filter]
-                side=4
-            [/modify_unit]
-        [/else]
-        [then]
-            {VARIABLE_OP reports rand "no,no,no,no,no,no,no,no,no,yes"}
-            [if]
-                [variable]
-                    name=reports
-                    equals=yes
-                [/variable]
-                [then]
-                    [floating_text]
-                        text=_ "I will better report it."
+                    image=misc/witness-overlay.png
+                [/unit_overlay]
+                [modify_unit]
+                    [filter]
                         x,y=$x1,$y1
-                    [/floating_text]
-                    [modify_unit]
-                        [filter]
+                    [/filter]
+                    side=4
+                [/modify_unit]
+            [/else]
+            [then]
+                {VARIABLE_OP reports rand "no,no,no,no,no,no,no,no,no,yes"}
+                [if]
+                    [variable]
+                        name=reports
+                        equals=yes
+                    [/variable]
+                    [then]
+                        [floating_text]
+                            text=_ "I will better report it."
                             x,y=$x1,$y1
-                        [/filter]
-                        side=3
-                    [/modify_unit]
-                [/then]
-            [/if]
-        [/then]
-    [/if]
+                        [/floating_text]
+                        [modify_unit]
+                            [filter]
+                                x,y=$x1,$y1
+                            [/filter]
+                            side=3
+                        [/modify_unit]
+                    [/then]
+                [/if]
+            [/then]
+        [/if]
     [/event]
 
     [event]
-    name=side 2 turn refresh
-    first_time_only=no
-    [store_unit]
-        [filter]
-            side=2
-        [/filter]
-        variable=wanderer
-        kill=no
-    [/store_unit]
-    {FOREACH wanderer i}
-        {VARIABLE_OP is_wanderer rand "0,1,2,3,4,5,6"}
-        [if]
-            [variable]
-                name=is_wanderer
-                equals=1
-            [/variable]
-            [then]
-                {VARIABLE target_x "$(2+$wanderer[$i].x)"}
-                {VARIABLE target_y "$(1+$wanderer[$i].y)"}
-            [/then]
-        [/if]
-        [if]
-            [variable]
-                name=is_wanderer
-                equals=2
-            [/variable]
-            [then]
-                {VARIABLE target_x "$(-2+$wanderer[$i].x)"}
-                {VARIABLE target_y "$(1+$wanderer[$i].y)"}
-            [/then]
-        [/if]
-        [if]
-            [variable]
-                name=is_wanderer
-                equals=3
-            [/variable]
-            [then]
-                {VARIABLE target_x "$wanderer[$i].x"}
-                {VARIABLE target_y "$(3+$wanderer[$i].y)"}
-            [/then]
-        [/if]
-        [if]
-            [variable]
-                name=is_wanderer
-                equals=4
-            [/variable]
-            [then]
-                {VARIABLE target_x "$(2+$wanderer[$i].x)"}
-                {VARIABLE target_y "$(-1+$wanderer[$i].y)"}
-            [/then]
-        [/if]
-        [if]
-            [variable]
-                name=is_wanderer
-                equals=5
-            [/variable]
-            [then]
-                {VARIABLE target_x "$(-2+$wanderer[$i].x)"}
-                {VARIABLE target_y "$(-1+$wanderer[$i].y)"}
-            [/then]
-        [/if]
-        [if]
-            [variable]
-                name=is_wanderer
-                equals=6
-            [/variable]
-            [then]
-                {VARIABLE target_x "$wanderer[$i].x"}
-                {VARIABLE target_y "$(-3+$wanderer[$i].y)"}
-            [/then]
-        [/if]
-        [if]
-            [variable]
-                name=is_wanderer
-                greater_than=0
-            [/variable]
-            [then]
+        name=side 2 turn refresh
+        first_time_only=no
+        [store_unit]
+            [filter]
+                side=2
+            [/filter]
+            variable=wanderer
+            kill=no
+        [/store_unit]
+        [for]
+            array=wanderer
+            [do]
+                {VARIABLE_OP is_wanderer rand "0,1,2,3,4,5,6"}
                 [if]
                     [variable]
-                        name=target_x
-                        less_than=44
+                        name=is_wanderer
+                        equals=1
                     [/variable]
-                    [and]
-                        [variable]
-                            name=target_x
-                            greater_than=0
-                        [/variable]
-                    [/and]
-                    [and]
-                        [variable]
-                            name=target_y
-                            less_than=34
-                        [/variable]
-                    [/and]
-                    [and]
-                        [variable]
-                            name=target_y
-                            greater_than=0
-                        [/variable]
-                    [/and]
                     [then]
-                        [find_path]
-                            [traveler]
-                                id=$wanderer[$i].id
-                            [/traveler]
-                            [destination]
-                                x=$target_x
-                                y=$target_y
-                            [/destination]
-                            variable=path
-                            allow_multiple_turns=yes
-                        [/find_path]
+                        {VARIABLE target_x "$(2+$wanderer[$i].x)"}
+                        {VARIABLE target_y "$(1+$wanderer[$i].y)"}
+                    [/then]
+                [/if]
+                [if]
+                    [variable]
+                        name=is_wanderer
+                        equals=2
+                    [/variable]
+                    [then]
+                        {VARIABLE target_x "$(-2+$wanderer[$i].x)"}
+                        {VARIABLE target_y "$(1+$wanderer[$i].y)"}
+                    [/then]
+                [/if]
+                [if]
+                    [variable]
+                        name=is_wanderer
+                        equals=3
+                    [/variable]
+                    [then]
+                        {VARIABLE target_x "$wanderer[$i].x"}
+                        {VARIABLE target_y "$(3+$wanderer[$i].y)"}
+                    [/then]
+                [/if]
+                [if]
+                    [variable]
+                        name=is_wanderer
+                        equals=4
+                    [/variable]
+                    [then]
+                        {VARIABLE target_x "$(2+$wanderer[$i].x)"}
+                        {VARIABLE target_y "$(-1+$wanderer[$i].y)"}
+                    [/then]
+                [/if]
+                [if]
+                    [variable]
+                        name=is_wanderer
+                        equals=5
+                    [/variable]
+                    [then]
+                        {VARIABLE target_x "$(-2+$wanderer[$i].x)"}
+                        {VARIABLE target_y "$(-1+$wanderer[$i].y)"}
+                    [/then]
+                [/if]
+                [if]
+                    [variable]
+                        name=is_wanderer
+                        equals=6
+                    [/variable]
+                    [then]
+                        {VARIABLE target_x "$wanderer[$i].x"}
+                        {VARIABLE target_y "$(-3+$wanderer[$i].y)"}
+                    [/then]
+                [/if]
+                [if]
+                    [variable]
+                        name=is_wanderer
+                        greater_than=0
+                    [/variable]
+                    [then]
                         [if]
                             [variable]
-                                name=path.hexes
-                                less_than=8
+                                name=target_x
+                                less_than=44
                             [/variable]
                             [and]
                                 [variable]
-                                    name=path.hexes
+                                    name=target_x
                                     greater_than=0
                                 [/variable]
                             [/and]
-                            [not]
+                            [and]
                                 [variable]
-                                    name=path.required_turns
-                                    greater_than=1
+                                    name=target_y
+                                    less_than=34
                                 [/variable]
-                            [/not]
+                            [/and]
+                            [and]
+                                [variable]
+                                    name=target_y
+                                    greater_than=0
+                                [/variable]
+                            [/and]
                             [then]
-                                {MOVE_UNIT id=$wanderer[$i].id $target_x $target_y}
+                                [find_path]
+                                    [traveler]
+                                        id=$wanderer[$i].id
+                                    [/traveler]
+                                    [destination]
+                                        x=$target_x
+                                        y=$target_y
+                                    [/destination]
+                                    variable=path
+                                    allow_multiple_turns=yes
+                                [/find_path]
+                                [if]
+                                    [variable]
+                                        name=path.hexes
+                                        less_than=8
+                                    [/variable]
+                                    [and]
+                                        [variable]
+                                            name=path.hexes
+                                            greater_than=0
+                                        [/variable]
+                                    [/and]
+                                    [not]
+                                        [variable]
+                                            name=path.required_turns
+                                            greater_than=1
+                                        [/variable]
+                                    [/not]
+                                    [then]
+                                        {MOVE_UNIT id=$wanderer[$i].id $target_x $target_y}
+                                    [/then]
+                                [/if]
                             [/then]
                         [/if]
+                        [modify_unit]
+                            [filter]
+                                id=wanderer[$i].id
+                            [/filter]
+                            moves=0
+                        [/modify_unit]
                     [/then]
                 [/if]
-                [modify_unit]
-                    [filter]
-                        id=wanderer[$i].id
-                    [/filter]
-                    moves=0
-                [/modify_unit]
-            [/then]
-        [/if]
-    {NEXT i}
-    {CLEAR_VARIABLE wanderer,is_wanderer,path,target_x,target_y}
+            [/do]
+        [/for]
+        {CLEAR_VARIABLE wanderer,is_wanderer,path,target_x,target_y}
     [/event]
 
     [event]
-    name=moveto
-    [filter]
-        side=1
-        x,y=15-44,1-10
-    [/filter]
-    [message]
-        speaker=Krux
-        message=_"We should also save my friends."
-    [/message]
-    [message]
-        speaker=Fowleri
-        message=_"I have checked them. All of your friends are either executed or have fled. I do not know."
-    [/message]
-    [message]
-        speaker=Krux
-        message=_"And Acantha?"
-    [/message]
-    [message]
-        speaker=Fowleri
-        message=_"Acanthamoeba Mansion is currently obeying her loving husband. Do not worry about her, she is a manipulative psychopath like you, she will figure something out."
-    [/message]
+        name=moveto
+        [filter]
+            side=1
+            x,y=15-44,1-10
+        [/filter]
+        [message]
+            speaker=Krux
+            message=_"We should also save my friends."
+        [/message]
+        [message]
+            speaker=Fowleri
+            message=_"I have checked them. All of your friends are either executed or have fled. I do not know."
+        [/message]
+        [message]
+            speaker=Krux
+            message=_"And Acantha?"
+        [/message]
+        [message]
+            speaker=Fowleri
+            message=_"Acanthamoeba Mansion is currently obeying her loving husband. Do not worry about her, she is a manipulative psychopath like you, she will figure something out."
+        [/message]
     [/event]
 
     [event]
-    name=moveto
-    first_time_only=no
-    [filter]
-        side=3
-        x,y=20,9
-    [/filter]
-    [message]
-        speaker=unit
-        message=_"Alarm! Krux de Rais is fleeing! Undead are everywhere!"
-    [/message]
-    [message]
-        speaker=Fowleri
-        message=_"This is bad."
-    [/message]
-    [endlevel]
-        result=defeat
-    [/endlevel]
+        name=moveto
+        first_time_only=no
+        [filter]
+            side=3
+            x,y=20,9
+        [/filter]
+        [message]
+            speaker=unit
+            message=_"Alarm! Krux de Rais is fleeing! Undead are everywhere!"
+        [/message]
+        [message]
+            speaker=Fowleri
+            message=_"This is bad."
+        [/message]
+        [endlevel]
+            result=defeat
+        [/endlevel]
     [/event]
 
     [event]
-    name=moveto
-    first_time_only=no
-    [filter]
-        side=1
-        canrecruit=yes
-        x,y=6-44,29-34
-    [/filter]
-    [fire_event]
-        name=check victory
-    [/fire_event]
-    [/event]
-
-    [event]
-    name=die
-    first_time_only=no
-    [filter]
-        side=3,4
-    [/filter]
-    [fire_event]
-        name=check victory
-    [/fire_event]
-    [/event]
-
-    [event]
-    name=turn refresh
-    first_time_only=no
-    [fire_event]
-        name=check victory
-    [/fire_event]
-    [/event]
-
-    [event]
-        name=check victory
-    [filter_condition]
-        [have_unit]
-            id=Krux
+        name=moveto
+        first_time_only=no
+        [filter]
+            side=1
+            canrecruit=yes
             x,y=6-44,29-34
-        [/have_unit]
-        [and]
+        [/filter]
+        [fire_event]
+            name=check victory
+        [/fire_event]
+    [/event]
+
+    [event]
+        name=die
+        first_time_only=no
+        [filter]
+            side=3,4
+        [/filter]
+        [fire_event]
+            name=check victory
+        [/fire_event]
+    [/event]
+
+    [event]
+        name=turn refresh
+        first_time_only=no
+        [fire_event]
+            name=check victory
+        [/fire_event]
+    [/event]
+
+    [event]
+        name=check victory
+        [filter_condition]
             [have_unit]
-                id=Fowleri
+                id=Krux
                 x,y=6-44,29-34
             [/have_unit]
-        [/and]
-        [not]
-            [have_unit]
-                side=4
-            [/have_unit]
-        [/not]
-        [not]
-            [have_unit]
-                side=3
-            [/have_unit]
-        [/not]
-    [/filter_condition]
-    [message]
-        speaker=Krux
-        message=_"We are fleeing. Great. I was so afraid of that execution. I never thought that I would end up butchering my way out of prison."
-    [/message]
-    [message]
-        speaker=Fowleri
-        message=_"They deserved being butchered. It was their fault that they had not listened to reason and sentenced you to death."
-    [/message]
-    [message]
-        speaker=Krux
-        message=_"By the way, are you somehow seeing humans as orcs?"
-    [/message]
-    [message]
-        speaker=Fowleri
-        message=_"Sometimes. Too many humans are like orcs. If you are not a human, seeing humans as orcs is not so hard."
-    [/message]
-    [message]
-        speaker=Krux
-        message=_"You used to be different. Friendly to humans, as far as I know you even served in a human army."
-    [/message]
-    [message]
-        speaker=Fowleri
-        message=_"I felt a certain affection towards the human race. You helped me awaken from it. Humans are monsters. You are a cute little monster that should be by my side."
-    [/message]
-    [message]
-        speaker=Krux
-        message=_"I somehow think that it is <i>you</i> who is the monster."
-    [/message]
-    [message]
-        speaker=Fowleri
-        message=_"I am the one who kills monsters. It is a hard position, because I have to care to avoid becoming a monster myself."
-    [/message]
-    [message]
-        speaker=Krux
-        message=_"You <i>already are</i> a monster. But I have to follow you because there is no other place for me. With that reputation I have..."
-    [/message]
-    [endlevel]
-        result=victory
-        bonus=no
-    [/endlevel]
+            [and]
+                [have_unit]
+                    id=Fowleri
+                    x,y=6-44,29-34
+                [/have_unit]
+            [/and]
+            [not]
+                [have_unit]
+                    side=4
+                [/have_unit]
+            [/not]
+            [not]
+                [have_unit]
+                    side=3
+                [/have_unit]
+            [/not]
+        [/filter_condition]
+        [message]
+            speaker=Krux
+            message=_"We are fleeing. Great. I was so afraid of that execution. I never thought that I would end up butchering my way out of prison."
+        [/message]
+        [message]
+            speaker=Fowleri
+            message=_"They deserved being butchered. It was their fault that they had not listened to reason and sentenced you to death."
+        [/message]
+        [message]
+            speaker=Krux
+            message=_"By the way, are you somehow seeing humans as orcs?"
+        [/message]
+        [message]
+            speaker=Fowleri
+            message=_"Sometimes. Too many humans are like orcs. If you are not a human, seeing humans as orcs is not so hard."
+        [/message]
+        [message]
+            speaker=Krux
+            message=_"You used to be different. Friendly to humans, as far as I know you even served in a human army."
+        [/message]
+        [message]
+            speaker=Fowleri
+            message=_"I felt a certain affection towards the human race. You helped me awaken from it. Humans are monsters. You are a cute little monster that should be by my side."
+        [/message]
+        [message]
+            speaker=Krux
+            message=_"I somehow think that it is <i>you</i> who is the monster."
+        [/message]
+        [message]
+            speaker=Fowleri
+            message=_"I am the one who kills monsters. It is a hard position, because I have to care to avoid becoming a monster myself."
+        [/message]
+        [message]
+            speaker=Krux
+            message=_"You <i>already are</i> a monster. But I have to follow you because there is no other place for me. With that reputation I have..."
+        [/message]
+        [endlevel]
+            result=victory
+            bonus=no
+        [/endlevel]
     [/event]
 
     [event]

--- a/spinoffs/Affably_Evil/scenarios/Strych.cfg
+++ b/spinoffs/Affably_Evil/scenarios/Strych.cfg
@@ -10,20 +10,20 @@
     {DEFAULT_SCHEDULE}
 
     [time_area]
-    x,y=0-8,0-4
-    {INDOORS}
+        x,y=0-8,0-4
+        {INDOORS}
     [/time_area]
     [time_area]
-    x,y=7-17,4-12
-    {INDOORS}
+        x,y=7-17,4-12
+        {INDOORS}
     [/time_area]
 
     [side]
         type=Krux_father
         id=Krux
-    name=_"Krux"
+        name=_"Krux"
         canrecruit=yes
-    unrenamable=yes
+        unrenamable=yes
         side=1
         controller=human
         recruit=
@@ -81,1414 +81,1417 @@
     {AE_PLACE_WAYPOINT 24 14}
 
     [event]
-    name=prestart
-    [label]
-        x,y=23,16
-        text=_"Gear shop"
-        color=255,255,255
-    [/label]
-    [label]
-        x,y=24,13
-        text=_"Gems shop"
-        color=255,255,255
-    [/label]
-    {VARIABLE current_scenario strych}
-    {AE_ORIGIN menacing_hills 3 20}
-    {AE_ORIGIN southern_estates 24 22}
-    {AE_ORIGIN lorendas_forest 24 2}
-    {AE_TRANSITION 0-3 5-25 Menacing_Hills _"Menacing Hills" 2 18}
-    [if]
-        [variable]
-            name=quests.overall
-            greater_than_equal_to=2
-        [/variable]
-        [then]
-            {AE_TRANSITION 14-30 23-25 Southern_Estates _"Southern Estates" 24 23}
-        [/then]
-    [/if]
-    [if]
-        [variable]
-            name=quests.overall
-            equals=5
-        [/variable]
-        [then]
-            [label]
-                x,y=24,1
-                text=_"Lorendas' Forest"
-                color=255,255,255
-            [/label]
-        [/then]
-    [/if]
-    [if]
-        [variable]
-            name=quests.overall
-            greater_than_equal_to=6
-        [/variable]
-        [then]
-            {AE_TRANSITION 11-30 1-2 Lorendas_Forest _"Lorendas' Forest" 24 1}
-        [/then]
-    [/if]
-    [if]
-        [variable]
-            name=quests.overall
-            equals=12
-        [/variable]
-        [then]
-            [set_variable]
-                name=count
-                {QUANTITY value 6 7 9}
-            [/set_variable]
-            [while]
-                [variable]
-                    name=count
-                    greater_than=0
-                [/variable]
-                [do]
-                    {VARIABLE_OP type rand "Ghoul,Necrophage,Ghast,Walking Corpse,Soulless,Monstrosity,Ghost,Wraith,Spectre,Skeleton Archer,Bone Shooter,Banebow"}
-                    {GENERIC_UNIT 3 $type 11 21}
-                    {GENERIC_UNIT 3 $type 27 22}
-                    {VARIABLE_OP count sub 1}
-                [/do]
-            [/while]
-            {AE_SPAWN_UNITS 3 1.3 "Necrophage,Ghast,Soulless,Monstrosity,Wraith,Spectre,Bone Shooter,Banebow" 27 5 "Abomination" boss_1}
-            [event]
-                name=new turn
-                first_time_only=no
-                {GENERIC_UNIT 3 Ghast 1 18}
-                {GENERIC_UNIT 3 Banebow 26 24}
-            [/event]
-            {GUARDIAN_UNIT 2 "Royal Guard" 24 7}
-            {GUARDIAN_UNIT 2 "Master Bowman" 27 10}
-            {GUARDIAN_UNIT 2 "Master at Arms" 24 19}
-            {GUARDIAN_UNIT 2 "Knight of Magic" 19 20}
-            {GUARDIAN_UNIT 2 "Mage of Light" 18 19}
-            {GUARDIAN_UNIT 2 "Iron Mauler" 15 18}
-            {GUARDIAN_UNIT 2 "Arch Mage" 24 19}
-            [+unit]
-                id=ally_talker
-            [/unit]
-        [/then]
-    [/if]
-    {CLEAR_RECALLS}
-    [/event]
-
-    [event]
-    name=start
-    [remove_shroud]
-        side=1
-    [/remove_shroud]
-    [place_shroud]
-        side=1
-        terrain=Mm^Xm,X*
-    [/place_shroud]
-    {AE_GET_GOLD}
-    [if]
-        [variable]
-            name=quests.first_in_strych
-            equals=yes
-        [/variable]
-        [else]
-            [message]
-                speaker=Krux
-                message=_"Back home, back where I want to be, back home, no better place for me."
-            [/message]
-            [message]
-                speaker=Acanthamoeba
-                message=_"That attempt at poetry was not bad."
-            [/message]
-            [message]
-                speaker=Krux
-                message=_"I have just read those verses somewhere. They must have been written by a great poet."
-            [/message] # It's a short excerpt from Ronnie König's works
-            [message]
-                speaker=Acanthamoeba
-                message=_"To be honest, I was amazed how you could write <i>poetry</i>. You are usually so <i>rational</i> that something like this looks so unusual for you."
-            [/message]
-            [message]
-                speaker=Antipos
-                message=_"I have heard of a great researcher who had enough research at some age and became a master of pen. I cannot quite remember his name. It was... ehm... how was it... Ernie Sabaton? No, his name did not sound military. I will have to check it out. He is told to have lived for a hundred years, maybe some healers studied how could he live for so long."
-            [/message] # Reference to a real MIT physicist and later surrealist prose writer, Ernesto Sabato.
-            [message]
-                speaker=Acanthamoeba
-                message=_"Well, enough talking about literature, it is time to see our father."
-            [/message]
-            [message]
-                speaker=Hare
-                message=_"I always wondered how he looks."
-            [/message]
-            {VARIABLE quests.first_in_strych yes}
-        [/else]
-    [/if]
-    [if]
-        [variable]
-            name=quests.overall
-            equals=12
-        [/variable]
-        [then]
-            [if]
-                [variable]
-                    name=quests.first_in_strych_when_undead_attack
-                    equals=yes
-                [/variable]
-                [else]
-                    [message]
-                        speaker=Krux
-                        message=_"It is good to see that Strych has not fallen yet. But these enemies are disturbing."
-                    [/message]
-                    [message]
-                        speaker=Acanthamoeba
-                        message=_"I think that instead of defending the town like Ogira, we should rush to our parents to ask what to do."
-                    [/message]
-                    [message]
-                        speaker=Antipos
-                        message=_"I think that it would be the best. But there are many undead between us and Strych."
-                    [/message]
-                    [message]
-                        speaker=ally_talker
-                        message=_"Help us! We are barely capable of facing these monsters! Sooner or later, we will fall if we are not sent reinforcements or they stop coming!"
-                    [/message]
-                    [message]
-                        speaker=boss_1
-                        message=_"You shall fall and you shall be eaten. No reinforcements will ever come, no retreat will ever occur."
-                    [/message]
-                    [message]
-                        speaker=Krux
-                        message=_"We will kill the group standing in our way and consult with our parents, maybe they are held captive and unable to send reinforcements."
-                    [/message]
-                    [message]
-                        speaker=Acanthamoeba
-                        message=_"I hope they are not dead already."
-                    [/message]
-                    [message]
-                        speaker=boss_1
-                        message=_"All shall fall."
-                    [/message]
-                    {VARIABLE quests.first_in_strych_when_undead_attack yes}
-                [/else]
-            [/if]
-        [/then]
-    [/if]
-    [/event]
-
-    [event]
-    name=moveto
-    first_time_only=no
-    [filter]
-        side=1
-        x,y=7-17,4-11
-        [or]
-            side=1
-            x,y=1-8,1-4
-        [/or]
-    [/filter]
-    [message]
-        speaker=Acanthamoeba
-        message=_"Please stay in the antechamber, our family discussions are secret."
-    [/message]
-    [move_unit]
-        side=1
-        [not]
-            id=Krux
-        [/not]
-        [not]
-            id=Acanthamoeba
-        [/not]
-        to_x=10
-        to_y=9
-    [/move_unit]
-    [move_unit]
-        id=Krux
-        [or]
-            id=Acanthamoeba
-        [/or]
-        to_x=5
-        to_y=3
-    [/move_unit]
-    [unit]
-        id=Prion
-        name=_"Prion the Shiverbringer"
-        x,y=3,1
-        side=1
-        type=General
-        canrecruit=yes
-        [modifications]
-            [object]
-            [effect]
-                apply_to=profile
-                portrait=portraits/Prion.png
-            [/effect]
-            [/object]
-            {TRAIT_INTELLIGENT}
-            {TRAIT_INTELLIGENT}
-        [/modifications]
-    [/unit]
-    {MOVE_UNIT id=Prion 4 1}
-    [unit]
-        id=Bala
-        name=_"Bala"
-        x,y=1,3
-        side=1
-        type=Red Mage
-        gender=female
-        canrecruit=yes
-        [modifications]
-            {TRAIT_INTELLIGENT}
-            {TRAIT_INTELLIGENT}
-        [/modifications]
-    [/unit]
-    {MOVE_UNIT id=Bala 2 2}
-    [if]
-        [variable]
-            name=quests.overall
-            less_than=11
-        [/variable]
-        [then]
-            [unit]
-                id=Agrippa
-                name=_"Agrippa the Wise"
-                x,y=7,1
-                side=1
-                gender=male
-                type=Dark Sorcerer
-                canrecruit=yes
-                [modifications]
-                    {TRAIT_INTELLIGENT}
-                    {TRAIT_RESILIENT}
-                [/modifications]
-            [/unit]
-            {MOVE_UNIT id=Agrippa 6 1}
-        [/then]
-    [/if]
-    [message]
-        speaker=Bala
-        message=_"What do you want, my children?"
-    [/message]
-    [repeating_message]
-        speaker=Prion
-        first=_"Is there something you want to tell us or to learn from us?"
-        message=_"Is there something else?"
-        [option]
-        message=_"We have dealt with the bandit uprising. Most of them are imprisoned in the town and waiting for escort."
-        [show_if]
+        name=prestart
+        [label]
+            x,y=23,16
+            text=_"Gear shop"
+            color=255,255,255
+        [/label]
+        [label]
+            x,y=24,13
+            text=_"Gems shop"
+            color=255,255,255
+        [/label]
+        {VARIABLE current_scenario strych}
+        {AE_ORIGIN menacing_hills 3 20}
+        {AE_ORIGIN southern_estates 24 22}
+        {AE_ORIGIN lorendas_forest 24 2}
+        {AE_TRANSITION 0-3 5-25 Menacing_Hills _"Menacing Hills" 2 18}
+        [if]
             [variable]
                 name=quests.overall
-                equals=1
+                greater_than_equal_to=2
             [/variable]
-        [/show_if]
-        [command]
-            [message]
-                speaker=Agrippa
-                message=_"Excellent work."
-            [/message]
-            [message]
-                speaker=Bala
-                message=_"Congratulations. I am so proud of you."
-            [/message]
-            [message]
-                speaker=Prion
-                message=_"You have shown great skill, my son. And also you, Acantha."
-            [/message]
-            [message]
-                speaker=Krux
-                message=_"It was an honour."
-            [/message]
-            [message]
-                speaker=Prion
-                message=_"Now, I am sorry for jumping into it too quickly, but I have some pressing matters that you should be able to solve."
-            [/message]
-            [message]
-                speaker=Acanthamoeba
-                message=_"What is it?"
-            [/message]
-            [message]
-                speaker=Prion
-                message=_"We have some trouble with House Mansion. They are trying to expand their political influence."
-            [/message]
-            [message]
-                speaker=Agrippa
-                message=_"Just like us. They are our rivals in the game."
-            [/message]
-            [message]
-                speaker=Prion
-                message=_"However, although they are more popular among the usual folk as we are, they are not very good at governing. They tend to be honest and keep their word. Also, they always follow the rules. To the extent when it becomes harmful for everyone. Many people appreciate that, but it has many bad consequences. So we need to push them away or just stop them from spreading over our land."
-            [/message]
-            [repeating_message]
-                speaker=Bala
-                first=_"They have recently appointed a new mayor in the small town known as Boonies. It used to be somewhere between our influence and theirs. Now it is clearly under their influence. It is not an important town, we might live on without problems without it, but we fear what would be next. They must be stopped. Do you want to ask something more about the situation?"
-                message=_"Is there something else you want to ask?"
-                [option]
-                message=_"Do I really have to deal with that? Brother Gilles is a more skilled warrior than I am."
-                [command]
-                    [message]
-                        speaker=Prion
-                        message=_"He is occupied elsewhere. You will have Acantha with you. Gilles' mission is important we cannot recall him. And having you replace him would take too much time."
-                    [/message]
-                [/command]
-                [/option]
-                [option]
-                message=_"How large is that Boonies?"
-                [command]
-                    [message]
-                        speaker=Prion
-                        message=_"It has about two hundreds inhabitants. It has a small fortress with a crew of several men, but they were mostly to protect the people from bandits. When the enemies came, they could do nothing but to surrender."
-                    [/message]
-                    [message]
-                        speaker=Agrippa
-                        message=_"Remember that we do not need Boonies necessarily, we would not mind trading it for something. But now it is Boonies, then it might be Ogira. And we cannot let them have our towns."
-                    [/message]
-                [/command]
-                [/option]
-                [option]
-                message=_"How about a full scale confrontation with the Mansions to teach them that they should be our vassals and not our rivals?"
-                [command]
-                    [message]
-                        speaker=Prion
-                        message=_"That is not as easy as it sounds. They have a large army. They might be weaker than us, but their soldiers will fight bravely for their so popular masters. Large numbers of our soldiers would die in a bloodbath like that and leave us vulnerable for a few years."
-                    [/message]
-                    [message]
-                        speaker=Bala
-                        message=_"They are currently facing an undead threat and it is weakening them, but the overall effect is small. We hope that the mysterious necromancer causes heavy damage to them before he dies. We do not want to face the necromancer ourselves when the Mansions fall."
-                    [/message]
-                    [message]
-                        speaker=Agrippa
-                        message=_"We might attack when the situation gets better, but we cannot know when the situation gets better."
-                    [/message]
-                [/command]
-                [/option]
-                [option]
-                message=_"How many enemies are there?"
-                [command]
-                    [message]
-                        speaker=Prion
-                        message=_"Quite a lot, it is possible that they plan to continue occupying our villages."
-                    [/message]
-                    [message]
-                        speaker=Agrippa
-                        message=_"They are not so numerous that they could handle a whole regiment of our army. Furthermore, we want you to try some diplomacy first."
-                    [/message]
-                [/command]
-                [/option]
-                [option]
-                message=_"Nothing else. What exactly what do you want me to do?"
-                [show_if]
-                    [not]
-                        [variable]
-                            name=first_view
-                            equals=true
-                        [/variable]
-                    [/not]
-                [/show_if]
-                [command]
-                    [break]
-                    [/break]
-                [/command]
-                [/option]
-            [/repeating_message]
-            [message]
-                speaker=Bala
-                message=_"The appointed mayor is the only child of their house, Marilyn. As far as I known, Marilyn is a reasonable person. You may threaten with a full confrontation of our armies that would probably end up badly for them. You may sneak into their base and take a very good hostage. You may also try some persuation, you will surely figure out something."
-            [/message]
-            [message]
-                speaker=Krux
-                message=_"Marilyn, you say. Is their heir a woman?"
-            [/message]
-            [message]
-                speaker=Prion
-                message=_"I am not certain about that. People always speak about Marilyn of House Mansion, the offspring of Charles, but they rarely tell if it is a daughter or son. I believe that they are doing it to conceal that their great heir is a woman. Most likely a warrior, but a woman."
-            [/message]
-            [message]
-                speaker=Krux
-                message=_"So somebody like Acantha could be if me and all of my siblings except her died."
-            [/message]
-            [message]
-                speaker=Prion
-                message=_"You know well that not any woman is like Acanthamoeba. This Marilyn certainly has some similarities, but remember that she might be different. Cold, ill-tempered, ugly. And just to see the expression of your face, I am telling you that Marilyn might also be manly or a man."
-            [/message]
-            [message]
-                speaker=Krux
-                message=_"You know that I often wish that Acantha was not my sister... She is great."
-            [/message]
-            [message]
-                speaker=Bala
-                message=_"Stop that."
-            [/message]
-            [message]
-                speaker=Krux
-                message=_"Okay, so, if this Marilyn happens to be like Acantha, may I marry her? It might nicely fuse our two Houses together. Under our control."
-            [/message]
-            [message]
-                speaker=Prion
-                message=_"If it is a woman, you must try to befriend her and marry her. We cannot risk that opportunity because of your aesthetic preferences."
-            [/message]
-            [message]
-                speaker=Acanthamoeba
-                message=_"Hehe, Krux, why was it <i>you</i> who mocked <i>me</i> about arranged marriages?"
-            [/message]
-            [message]
-                speaker=Prion
-                message=_"Of course, if it is a man, you will have to try hard to marry him, Acantha. And take dominance in commanding and organising."
-            [/message]
-            [message]
-                speaker=Acanthamoeba
-                message=_"It will be a manly woman, I can see that."
-            [/message]
-            [message]
-                speaker=Bala
-                message=_"I know that both of your are afraid of having to marry an ugly person. But being married to an ugly person is not that bad, you can always cheat."
-            [/message]
-            [message]
-                speaker=Prion
-                message=_"Bala, it was only once! And you are not ugly, you are just... not so young anymore."
-            [/message]
-            [message]
-                speaker=Bala
-                message=_"I have caught you once, I might have failed to catch you a hundred times. I have forgiven you... but you should not be sure that I will forgive you next time."
-            [/message]
-            [message]
-                speaker=Agrippa
-                message=_"Brother, sister-in-law, do you realise that your children are here?"
-            [/message]
-            [message]
-                speaker=Prion
-                message=_"So embarassing... well, you were told everything you need to know, head south and deal with that problem. Remember that simply persuade Marilyn to stop that expansion north is enough."
-            [/message]
-            [message]
-                speaker=Bala
-                message=_"Boonies is south from here, you need to pass through Southern Estates. There might be a few bandits there, maybe some Mansion soldiers, but it should be relatively safe. Some soldiers should be waiting for you in its vincinity, I have sent them already."
-            [/message]
-            [message]
-                speaker=Krux
-                message=_"I will be on my way."
-            [/message]
-            {AE_TRANSITION 14-30 23-25 Southern_Estates _"Southern Estates" 24 23}
-            {VARIABLE quests.overall 2}
-            {VARIABLE quests.do_talk_about_mansions yes}
-        [/command]
-        [/option]
-        [option]
-        message=_"We have taken control of Boonies. Marilyn had to run."
-        [show_if]
+            [then]
+                {AE_TRANSITION 14-30 23-25 Southern_Estates _"Southern Estates" 24 23}
+            [/then]
+        [/if]
+        [if]
             [variable]
                 name=quests.overall
-                equals=3
+                equals=5
             [/variable]
-        [/show_if]
-        [command]
-            [message]
-                speaker=Bala
-                message=_"That is a great victory, my children."
-            [/message]
-            [message]
-                speaker=Prion
-                message=_"Was she strong?"
-            [/message]
-            [message]
-                speaker=Krux
-                message=_"Marilyn is a man."
-            [/message]
-            [message]
-                speaker=Acanthamoeba
-                message=_"A man who refused a prospective marriage offer from me. Like if he was suspecting me of planning to manipulate him."
-            [/message]
-            [message]
-                speaker=Prion
-                message=_"He did not want peace neither, I assume, so you had to fight. Was he strong?"
-            [/message]
-            [if]
-                [variable]
-                    name=quests.marilyn_undead_exploit
-                    equals=yes
-                [/variable]
-                [then]
-                    [message]
-                        speaker=Acanthamoeba
-                        message=_"Yes. Initially he was not sending much of his forces at us, but when we approached, he realised that he overestimated us. We could not face him, but undead suddenly appeared and attacked him."
-                    [/message]
-                    [message]
-                        speaker=Prion
-                        message=_"Undead? Again?"
-                    [/message]
-                    [message]
-                        speaker=Acanthamoeba
-                        message=_"Yes. We are encountering undead everywhere. I think that there is some serious trouble going on somewhere."
-                    [/message]
-                    [message]
-                        speaker=Agrippa
-                        message=_"Would you prefer if the undead were attacking only our enemies and not us? Everybody would suspect us!"
-                        [option]
-                        message=_"No. Serious arguments claiming a link between us and undead would have damaged us badly."
-                        [command]
-                            [message]
-                                speaker=Prion
-                                message=_"I wonder who the necromancer is..."
-                            [/message]
-                        [/command]
-                        [/option]
-                        [option]
-                        message=_"Actually, the undead caused damage to both sides, but they never directly attacked us. But they did retaliate."
-                        [command]
-                            [message]
-                                speaker=Acanthamoeba
-                                message=_"Do they held some grudge on the Mansions or something? Maybe one of them, in one of their outbursts of raging violence, killed somebody and that person returned as a Death Knight, seeking revenge. With no Mansions in sight, they attack at random, with Mansions in sight, they focus on Mansions."
-                            [/message]
-                            [message]
-                                speaker=Agrippa
-                                message=_"That is possible. I would like to send the Death Knight a pack of gold, but I do not know where he lives."
-                            [/message]
-                        [/command]
-                        [/option]
-                        [option]
-                        message=_"Ah, that is why <i>your</i> undead are attacking us."
-                        [command]
-                            [message]
-                                speaker=Agrippa
-                                message=_"<i>My</i> undead? No, please no. I am not a necromancer."
-                            [/message]
-                            [message]
-                                speaker=Prion
-                                message=_"That is not possible. I can assure you that my brother Agrippa is not a necromancer."
-                            [/message]
-                        [/command]
-                        [/option]
-                    [/message]
-                [/then]
-            [/if]
-            [message]
-                speaker=Bala
-                message=_"Is there anything else that you can tell us about the fight?"
-            [/message]
-            [message]
-                speaker=Krux
-                message=_"Well, Marilyn complained that undead had caused them a lot of damage and that is why he had lost. However, he accepted his defeat."
-            [/message]
-            [message]
-                speaker=Prion
-                message=_"Their war with that necromancer is so bad? I did not know. They owe us a lot of gold. Their expenses are greater than their income for decades. Maybe we could declare them unreliable debtors and start confiscating?"
-            [/message]
-            [message]
-                speaker=Bala
-                message=_"We shall discuss that later."
-            [/message]
-            {VARIABLE quests.overall 4}
-        [/command]
-        [/option]
-        [option]
-        message=_"Is there something you would like us to do?"
-        [show_if]
+            [then]
+                [label]
+                    x,y=24,1
+                    text=_"Lorendas' Forest"
+                    color=255,255,255
+                [/label]
+            [/then]
+        [/if]
+        [if]
             [variable]
                 name=quests.overall
-                equals=4
+                greater_than_equal_to=6
             [/variable]
-        [/show_if]
-        [command]
-            [message]
-                speaker=Bala
-                message=_"Actually, yes. We were preparing this plan for long. It is about further expansion. Do you know why we cannot push to the south now?"
-            [/message]
-            [message]
-                speaker=Acanthamoeba
-                message=_"The Mansions. If we attacked them, we might risk a full confrontation. As you suggested before, it might work a few years after we cease to lend them gold. Or if their war with undead damages them too badly. We cannot go south at the moment. But we can wait and prepare forces."
-            [/message]
-            [message]
-                speaker=Bala
-                message=_"Yes. Do you know why we cannot push to the north now?"
-            [/message]
-            [message]
-                speaker=Krux
-                message=_"There are mountains. They are hard to pass, if we attacked there we would need great amounts of supplies to bring and fighting there would be very disadvantageous."
-            [/message]
-            [message]
-                speaker=Prion
-                message=_"Also, orcs attack from the north. House Thule holds them, but if we defeated the Thule, we would have to face the orcs ourselves. Furthermore, the Thule are quite stark and I do not want to mess with them."
-            [/message]
-            [message]
-                speaker=Bala
-                message=_"Do you know why we cannot push to the east now?"
-            [/message]
-            [message]
-                speaker=Acanthamoeba
-                message=_"There are some lands we had recently taken over and they are not tamed properly yet. We need to have full loyalty of the people living there."
-            [/message]
-            [message]
-                speaker=Krux
-                message=_"Are you trying to say that we should push to the west? There are thick forest and elves live there. It is unwise to mess with elves."
-            [/message]
-            [message]
-                speaker=Prion
-                message=_"I do not want to fight them. Kill an elf murderer, his friends will murder the judge or executioner. Enter their forest accidentally, they will capture you and complain about it to the king and they have to be paid gold for their release. About a century ago, one lord attacked the elves after a long argument over a forest and soon they retaliated with a huge army of elves that came from all forests of the continent. They destroyed their fields, sacked their castles, stole their children and drove all humans away. Now it is a thick forest full of unfriendly elves."
-            [/message]
-            [message]
-                speaker=Acanthamoeba
-                message=_"So what? Do you want us to mess with them or not?"
-            [/message]
-            [message]
-                speaker=Prion
-                message=_"We have a plan."
-            [/message]
-            [message]
-                speaker=Bala
-                message=_"Krux, a marriage awaits you."
-            [/message]
-            [message]
-                speaker=Krux
-                message=_"Are you serious? Why would I do that? Elves look good, are intelligent and nice, but they do not interact with us! How could I possibly persuade one to marry me?"
-            [/message]
-            [message]
-                speaker=Bala
-                message=_"You have been very successful with using your charm in the past, maybe you take a greater challenge."
-            [/message]
-            [message]
-                speaker=Krux
-                message=_"What would it be good for? Half-elves do not differ much from humans as far as I know. And those usually come from... unwanted mating."
-            [/message]
-            [message]
-                speaker=Bala
-                message=_"It would allow you to join the elvish community. It would open them for manipulation and a strong alliance with us."
-            [/message]
-            [message]
-                speaker=Krux
-                message=_"Where can I find an elf? Should I rush into a forest and yell <i>are there some pretty maidens around here</i>?"
-            [/message]
-            [message]
-                speaker=Prion
-                message=_"There are elves who live with humans. The reasons vary, it can be exile, fleeing from justice, healing for gold, espionage, strange habits,..."
-            [/message]
-            [repeating_message]
-                speaker=Bala
-                message=_"Is there something else you want to ask?"
-                [option]
-                message=_"Where do I find one?"
-                [command]
-                    [message]
-                        speaker=Bala
-                        message=_"I have heard of one living somewhere north from here, maybe in Ogira. She is some sort of ambassador, sometimes she comes to us with some affairs from the high lords. What was her name?"
-                    [/message]
-                    [message]
-                        speaker=Prion
-                        message=_"I cannot remember, it was a strange name, even by elvish standards."
-                    [/message]
-                [/command]
-                [/option]
-                [option]
-                message=_"What should I tell her? Asking her something like <i>why so lonely</i> certainly is not a good idea."
-                [command]
-                    [message]
-                        speaker=Bala
-                        message=_"It should be something that would keep you near her for a longer time. We discussed various possibilities, here is the one that looks the most likely: Elves see us inferior to them and tend to tell us over and over how we should live to be like them. Maybe you could ask her to show you how the elves live and that our family wants to be their friends. They most likely have no idea about our foul reputation among the nobles."
-                    [/message]
-                    [message]
-                        speaker=Prion
-                        message=_"Let us hope so."
-                    [/message]
-                [/command]
-                [/option]
-                [option]
-                message=_"Are the undead damaging also the elves? Maybe we could offer them help."
-                [command]
-                    [message]
-                        speaker=Agrippa
-                        message=_"Unfortunately, no. The elves are most likely better at locating the source of undead and the necromancer behind the whole thing."
-                    [/message]
-                [/command]
-                [/option]
-                [option]
-                message=_"Nothing else."
-                [show_if]
-                    [not]
-                        [variable]
-                            name=first_view
-                            equals=true
-                        [/variable]
-                    [/not]
-                [/show_if]
-                [command]
-                    [break]
-                    [/break]
-                [/command]
-                [/option]
-            [/repeating_message]
-            [message]
-                speaker=Prion
-                message=_"And there is a little problem. The road north from here was blocked and some undead are reported to wander there."
-            [/message]
-            [message]
-                speaker=Krux
-                message=_"So we need to secure the road in order to get there."
-            [/message]
-            [message]
-                speaker=Prion
-                message=_"Yes. An army will be waiting for you near the place where the undead dwell."
-            [/message]
-            [label]
-                x,y=24,1
-                text=_"Lorendas' Forest"
-                color=255,255,255
-            [/label]
-            {VARIABLE quests.overall 5}
-            {VARIABLE quests.do_talk_about_elf yes}
-        [/command]
-        [/option]
-        [option]
-        message=_"We had some difficulties with the elvish plan, we currently need a few years until we return to it."
-        [show_if]
-            [variable]
-                name=quests.overall
-                equals=10
-            [/variable]
-        [/show_if]
-        [command]
-            [message]
-                speaker=Bala
-                message=_"What happened?"
-            [/message]
-            [message]
-                speaker=Acanthamoeba
-                message=_"It is a long story. Krux successfully made that elf, Fowleri, fall in love with him. He seems to have fallen in love with her too, unusually. But other elves were not so welcoming. We have saved them from an orcish incursion, but they only said their thanks but did absolutely nothing to return our favour. Many of those elves behaved like if they were gods among men."
-            [/message]
-            [if]
-                [variable]
-                    name=quests.gruzgobs_path_visited_settlement
-                    equals=yes
-                [/variable]
-                [then]
-                    [message]
-                        speaker=Krux
-                        message=_"Later, we have learned that they have informers among common folk and they inform them about anything they know. When I asked more about the system, it appeared to me that some of them picked up the vicious rumours that are spread about us and they believed them. They considered us dangerous."
-                    [/message]
-                [/then]
-            [/if]
-            [message]
-                speaker=Prion
-                message=_"What have you done then?"
-            [/message]
-            [message]
-                speaker=Krux
-                message=_"It was a wicked plan. An unforgivable abomination. Antipos learned that Fowleri was pregnant. With me. So we snatched the child from her insides."
-            [/message]
-            [message]
-                speaker=Bala
-                message=_"Is she..."
-            [/message]
-            [message]
-                speaker=Acanthamoeba
-                message=_"No, she knows nothing. We have organised a false flag orcish assault on her outpost and when she was injured by orcs, we have only added a new wound. Then we healed her and pretended that we saved her from the orcs. As far as we know, no elf knows about our actions."
-            [/message]
-            [message]
-                speaker=Prion
-                message=_"Where is the child now?"
-            [/message]
-            [message]
-                speaker=Acanthamoeba
-                message=_"He was placed into me initially, then transferred into a suitable mother."
-            [/message]
-            [message]
-                speaker=Prion
-                message=_"Who? Who is carrying my grandson?"
-            [/message]
-            [message]
-                speaker=Krux
-                message=_"We initially intended Legionella de Ceise to carry her. I do not know if you know her, but I found her to be suitable for this purpose. She wanted to have a child so badly. Without even looking for a proper husband. But unfortunately, I impregnated her when trying to pretend to impregnate her. So she is carrying your grandson, but not the elvish child. That one is carried by her friend. I assumed that she would help her care about her."
-            [/message]
-            [message]
-                speaker=Prion
-                message=_"So it is a girl? That might be a problem, women get into ruling positions harder."
-            [/message]
-            [message]
-                speaker=Acanthamoeba
-                message=_"That is not the case of elves. For example, Fowleri used to be a great elvish warlord."
-            [/message]
-            [message]
-                speaker=Agrippa
-                message=_"What if she likes eating babies?"
-            [/message]
-            [message]
-                speaker=Bala
-                message=_"Screw you with your sick jokes, Agrippa."
-            [/message]
-            [message]
-                speaker=Agrippa
-                message=_"Pardon, mylady, I thought the rumours that you eat children were true."
-            [/message]
-            [message]
-                speaker=Krux
-                message=_"Please leave these arguments for later. I think that Uncle Agrippa should spend less time with his prisoners."
-            [/message]
-            [message]
-                speaker=Bala
-                message=_"Or spend all time with his prisoners so that I would not have to listen to him."
-            [/message]
-            [message]
-                speaker=Prion
-                message=_"Enough."
-            [/message]
-            [message]
-                speaker=Krux
-                message=_"Is there anything else you want us to do?"
-            [/message]
-            [message]
-                speaker=Prion
-                message=_"I know this will surprise you, but there is not. You have done a lot of good work recently. Our plan to control the western lands is advancing slowly, we cannot go north, your brother Gilles has gone far enough to the east, south is a matter of diplomacy at the moment, undead are not very annoying currently... There are some rough ideas what we could do, but we should wait for things to evolve."
-            [/message]
-            [message]
-                speaker=Bala
-                message=_"But you might want to see Legionella and especially her friend ocasionally, it should certainly help our cause and your budding family."
-            [/message]
-            {VARIABLE quests.overall 11}
-            {VARIABLE previous_scenario $current_scenario}
-            {AE_SAVE_GOLD}
-            [endlevel]
-                result=victory
-                bonus=no
-                next_scenario=Ogira
-                {NEW_GOLD_CARRYOVER 100}
-                linger_mode=no
-                carryover_report=no
-            [/endlevel]
-            [break]
-            [/break]
-        [/command]
-        [/option]
-        [option]
-        message=_"What is going on with all those undead attacking our towns?"
-        [show_if]
+            [then]
+                {AE_TRANSITION 11-30 1-2 Lorendas_Forest _"Lorendas' Forest" 24 1}
+            [/then]
+        [/if]
+        [if]
             [variable]
                 name=quests.overall
                 equals=12
             [/variable]
-        [/show_if]
-        [command]
-            [message]
-                speaker=Bala
-                message=_"It is a disaster. Our plan backfired, and really badly."
-            [/message]
-            [message]
-                speaker=Prion
-                message=_"It is time to tell you the full truth, children. It will not be pleasant, but you will know that it is true because you were suspecting it."
-            [/message]
-            [message]
-                speaker=Bala
-                message=_"If we found a prisoner guilty, we sent him for execution. But the executor was Agrippa and he was making undead out of them. He has made a lot of discoveries and made stronger and hardier monsters. He used them as some sort of slaves, built tunnels under our lands and many others, built underground fortresses and castles for us to hide in if times get bad. It allowed him to approach the discovery of a way to extend lives without any significant drawbacks, also the slave work required no food."
-            [/message]
-            [message]
-                speaker=Prion
-                message=_"At some point, we decided that we might use those undead to attack our enemies while pretending that it was a third party. Suspicion quickly fell on us, probably as an attempt to destroy us rather than because of evidence. As the undead killed many people who rose as undead, the undead army grew and Agrippa had difficulties to control them, causing some undead attacks on our land."
-            [/message]
-            [if]
-                [variable]
-                    name=quests.dead_menace_seen_peasants
-                    equals=yes
-                [/variable]
-                [then]
-                    [message]
-                        speaker=Krux
-                        message=_"These undead were not attacking the locals, only us. I believe it was rather a false flag attack to misdirect suspicion than a loss of control."
-                    [/message]
-                    [message]
-                        speaker=Prion
-                        message=_"Some of those undead attacked only if threatened. Many of them remained partially under Agrippa's control and only moved where they were not supposed to go."
-                    [/message]
-                [/then]
-            [/if]
-            [message]
-                speaker=Krux
-                message=_"And what happened now?"
-            [/message]
-            [message]
-                speaker=Prion
-                message=_"He lost control over the undead completely. There was too many of them and they possibly pretended for some time that they are controlled so that they would revolt only if it is too late for him to stop them. It is also possible that he betrayed us entirely. In any way, he got us into a great trouble."
-            [/message]
-            [message]
-                speaker=Bala
-                message=_"A trouble that can cause our family to fall. The Mansions will certainly use it to build an alliance against us. While we are ravaged by undead of our own creation."
-            [/message]
-            [message]
-                speaker=Acanthamoeba
-                message=_"What can we do now? Prepare to run?"
-            [/message]
-            [message]
-                speaker=Prion
-                message=_"I believe it is not <i>so</i> bad. They have no evidence that we are responsible for the undead. What we fear is that they ignore the lack of evidence and attack us anyway. Some of those Paladins can be quite blind and attack whatever they consider evil without questioning if the evil they see is really evil."
-            [/message]
-            [message]
-                speaker=Bala
-                message=_"We are sending messages to everyone around that we are going to pay them great amounts of gold for helping us defeat the undead. We shall see how will it work out."
-            [/message]
-            [message]
-                speaker=Krux
-                message=_"What do you want us to do?"
-            [/message]
-            [message]
-                speaker=Bala
-                message=_"The most important thing you could do. To enter Agrippa's dungeon."
-            [/message]
-            [message]
-                speaker=Prion
-                message=_"The mastermind of the undead attack is most likely there. It might be Agrippa. It might be something else. Anyway, if we destroy whoever coordinates them, they will be much weaker without him. If it is Agrippa and he had betrayed us, ask him how he plans to survive it and force him to change the plan to suit our needs."
-            [/message]
-            [repeating_message]
-                speaker=Bala
-                first=_"Any questions?"
-                message=_"Anything else?"
-                [option]
-                message=_"Will we have soldiers with us?"
-                [command]
-                    [message]
-                        speaker=Prion
-                        message=_"Certainly. That is why we are leaving most soldiers inside the keep. If we lose the town, the walls of this fortress can still stand. If their mastermind is dead, they will disperse and we well retake it easily. We are preparing an evacuation."
-                    [/message]
-                    [message]
-                        speaker=Acanthamoeba
-                        message=_"Good to know."
-                    [/message]
-                [/command]
-                [/option]
-                [option]
-                message=_"Where do we find him?"
-                [command]
-                    [message]
-                        speaker=Prion
-                        message=_"I have no idea. If it is Agrippa, he is probably somewhere under this town, he wants to use this town as his capital even after the putsch. If it is something else, I would also expect it to be nearby, in the centre of action. Start searching in the dungeons under the castle, go deeper and deeper, but try not to get lost. Try to look for some clues."
-                    [/message]
-                    [message]
-                        speaker=Acanthamoeba
-                        message=_"That is not very much information."
-                    [/message]
-                    [message]
-                        speaker=Prion
-                        message=_"It is all we have."
-                    [/message]
-                [/command]
-                [/option]
-                [option]
-                message=_"Can you two help us directly?"
-                [command]
-                    [message]
-                        speaker=Prion
-                        message=_"No, we have duties here. If we plunged into the dungeon with you, it might seem that we are allied with them. If we are seen actively fighting them, it is much more persuasive. And we are not so powerful in battle after all."
-                    [/message]
-                    [message]
-                        speaker=Bala
-                        message=_"My skill with combat magic has faded over time."
-                    [/message]
-                    [message]
-                        speaker=Prion
-                        message=_"And I have not practised sword fighting for long."
-                    [/message]
-                [/command]
-                [/option]
-                [option]
-                message=_"Nothing else."
-                [command]
-                    [break]
-                    [/break]
-                [/command]
-                [/option]
-            [/repeating_message]
-            [message]
-                speaker=Prion
-                message=_"Okay, go to the dungeon and ensure our survival."
-            [/message]
-            {VARIABLE quests.overall 13}
-            {VARIABLE previous_scenario $current_scenario}
-            {AE_SAVE_GOLD}
-            [endlevel]
-                result=victory
-                bonus=no
-                next_scenario=08_The_Reckoning
-                {NEW_GOLD_CARRYOVER 0}
-                linger_mode=no
-                carryover_report=no
-            [/endlevel]
-            [break]
-            [/break]
-        [/command]
-        [/option]
-        [option]
-        message=_"We have found some undead on our way back."
-        [show_if]
+            [then]
+                [set_variable]
+                    name=count
+                    {QUANTITY value 6 7 9}
+                [/set_variable]
+                [while]
+                    [variable]
+                        name=count
+                        greater_than=0
+                    [/variable]
+                    [do]
+                        {VARIABLE_OP type rand "Ghoul,Necrophage,Ghast,Walking Corpse,Soulless,Monstrosity,Ghost,Wraith,Spectre,Skeleton Archer,Bone Shooter,Banebow"}
+                        {GENERIC_UNIT 3 $type 11 21}
+                        {GENERIC_UNIT 3 $type 27 22}
+                        {VARIABLE_OP count sub 1}
+                    [/do]
+                [/while]
+                {AE_SPAWN_UNITS 3 1.3 "Necrophage,Ghast,Soulless,Monstrosity,Wraith,Spectre,Bone Shooter,Banebow" 27 5 "Abomination" boss_1}
+                [event]
+                    name=new turn
+                    first_time_only=no
+                    {GENERIC_UNIT 3 Ghast 1 18}
+                    {GENERIC_UNIT 3 Banebow 26 24}
+                [/event]
+                {GUARDIAN_UNIT 2 "Royal Guard" 24 7}
+                {GUARDIAN_UNIT 2 "Master Bowman" 27 10}
+                {GUARDIAN_UNIT 2 "Master at Arms" 24 19}
+                {GUARDIAN_UNIT 2 "Knight of Magic" 19 20}
+                {GUARDIAN_UNIT 2 "Mage of Light" 18 19}
+                {GUARDIAN_UNIT 2 "Iron Mauler" 15 18}
+                {GUARDIAN_UNIT 2 "Arch Mage" 24 19}
+                [+unit]
+                    id=ally_talker
+                [/unit]
+            [/then]
+        [/if]
+        {CLEAR_RECALLS}
+    [/event]
+
+    [event]
+        name=start
+        [remove_shroud]
+            side=1
+        [/remove_shroud]
+        [place_shroud]
+            side=1
+            terrain=Mm^Xm,X*
+        [/place_shroud]
+        {AE_GET_GOLD}
+        [if]
             [variable]
-                name=quests.menacing_hills_undead_house
+                name=quests.first_in_strych
                 equals=yes
             [/variable]
-            [or]
-                [variable]
-                    name=quests.menacing_hills_undead_cave
-                    equals=yes
-                [/variable]
-            [/or]
-            [not]
-                [variable]
-                    name=quests.menacing_hills_undead_house_announced
-                    equals=yes
-                [/variable]
-            [/not]
-            [not]
-                [variable]
-                    name=quests.overall
-                    greater_than=4
-                [/variable]
-            [/not]
-        [/show_if]
-        [command]
-            [if]
-                [variable]
-                    name=quests.menacing_hills_undead_cave
-                    equals=yes
-                [/variable]
-                [then]
-                    [message]
-                        speaker=Acanthamoeba
-                        message=_"What is worse, there was an undead-infested cave nearby. We have investigated it, they were climbing from a deep hole. We could not investigate further."
-                    [/message]
-                [/then]
-            [/if]
-            [message]
-                speaker=Bala
-                message=_"Undead? Maybe some of them have reached also our region. House Mansion has trouble with them."
-            [/message]
-            [message]
-                speaker=Agrippa
-                message=_"As far as I know, undead, when not properly kept, either because the necromancer is incapable or controls too many of them, might attack unintended targets, possibly far away. They might wander somewhere where they were not sent and attack whatever they encounter."
-            [/message]
-            [message]
-                speaker=Prion
-                message=_"Where was it, exactly?"
-            [/message]
-            [message]
-                speaker=Krux
-                message=_"South from the road. The road was altered by somebody or something, redirected to a swamp where undead lurked."
-            [/message]
-            [message]
-                speaker=Agrippa
-                message=_"I will deal with that issue."
-            [/message]
-            {VARIABLE quests.menacing_hills_undead_house_announced yes}
-        [/command]
-        [/option]
-        [option]
-        message=_"What is done to the prisoners we capture?"
-        [show_if]
-            [variable]
-                name=quests.overall
-                not_equals=12
-            [/variable]
-            [not]
-                [variable]
-                    name=quests.asked_about_prison
-                    equals=yes
-                [/variable]
-            [/not]
-        [/show_if]
-        [command]
-            [message]
-                speaker=Agrippa
-                message=_"They are killed."
-            [/message]
-            [message]
-                speaker=Prion
-                message=_"What do you think we are doing to them, Krux?"
-            [/message]
-            [message]
-                speaker=Krux
-                message=_"I believe that they are used for slave labour to build a system of underground tunnels and fortresses."
-            [/message]
-            [message]
-                speaker=Agrippa
-                message=_"Correct. Exhaustation and death from overworking is the way they are killed. It helps our family much more than mere hanging. But let us keep the lie that they are simply hanged, fine?"
-            [/message]
-            [message]
-                speaker=Krux
-                message=_"People have suspicions."
-            [/message]
-            [message]
-                speaker=Bala
-                message=_"They are spread by evil tongues... ehm, hostile tongues. They are making up stories just to have people listen to them and maybe pay them a beer. They always existed and it is hard to get rid of them, they know how to hide themselves. Some of them are really ridiculous, he told to our agent that he was an escaped prisoner and he had to wash the blood-drenched floor of an occult room where we killed and ate small children every day in the name of Baphomet."
-            [/message]
-            [message]
-                speaker=Acanthamoeba
-                message=_"Ridiculous. We are not worshipping any Baphomet. Who is that Baphomet anyway?"
-            [/message]
-            [message]
-                speaker=Agrippa
-                message=_"There are many dangerous demons that let themselves be worshipped with some gruesome rituals in order to gain power. Their identities are kept secret from most people because worshipping them might be rewarding for the worshipper as the demons usually give rewards. It is unwise from the side of worshippers because it usually means that they have to serve the demon until they die and their descendants will have to worship them too. Otherwise they will be killed by the demon. So their worship is like an eternal curse, a huge limitation to freedom."
-            [/message]
-            [message]
-                speaker=Agrippa
-                message=_"It can make someone powerful, but chained by obligations and other people are harmed. Lilith is the most known of these demons, but I had to go to great depths of forbidden literature to find mentions even of that one. Supposed to be the most known. Interestingly, people sometimes talk about Baphomet. There is no such demon, it is just a tale to scare people. Every accusation of worshipping Baphomet has been false so far."
-            [/message]
-            [message]
-                speaker=Acanthamoeba
-                message=_"Do you believe what they say?"
-            [/message]
-            [message]
-                speaker=Krux
-                message=_"I am not completely without doubts..."
-            [/message]
-            {VARIABLE quests.asked_about_prison yes}
-        [/command]
-        [/option]
-        [option]
-        message=_"I have learned something interesting about the necromancers. From one of their victims."
-        [show_if]
-            [variable]
-                name=quests.overall
-                greater_than=8
-            [/variable]
-            [and]
-                [have_unit]
-                    id=Lucretia
-                [/have_unit]
-            [/and]
-            [not]
-                [variable]
-                    name=quests.asked_about_lucretia
-                    equals=yes
-                [/variable]
-            [/not]
-        [/show_if]
-        [command]
-            [message]
-                speaker=Bala
-                message=_"What have you learned? How? Have you interrogated a ghoul?"
-            [/message]
-            [message]
-                speaker=Krux
-                message=_"No. One of them made it out relatively untouched. A ghost of a poisoner noblewoman. She behaves perfectly rationally, looks human, although she is a bit transparent. She has great issues to remember what happened before we met her, but over time, we have figured a few things out."
-            [/message]
-            [message]
-                speaker=Prion
-                message=_"It might be very interesting what have you figured out."
-            [/message]
-            [message]
-                speaker=Acanthamoeba
-                message=_"There is at least one necromancer underground and he investigates a poison named Lethe. It makes people forget. It is often used to take control over places and persuade the people that it was always like that. It might be a key that would allow a necromancer to rule an area without the obvious problems of rejection."
-            [/message]
-            [message]
-                speaker=Bala
-                message=_"That sounds scary."
-            [/message]
-            [message]
-                speaker=Prion
-                message=_"That means that the necromancers are planning to take over the land. Probably not only ours, but also the nearby ones."
-            [/message]
-            [message]
-                speaker=Acanthamoeba
-                message=_"We came to that conclusion too."
-            [/message]
-            [message]
-                speaker=Krux
-                message=_"It also seems that the dungeons are not far away from here."
-            [/message]
-            [if]
-                [variable]
-                    name=quests.overall
-                    not_equals=12
-                [/variable]
-                [then]
-                    [message]
-                        speaker=Agrippa
-                        message=_"I will have to investigate who tunelled near our town. It will take some time."
-                    [/message]
-                    [message]
-                        speaker=Acanthamoeba
-                        message=_"Actually, I know of a shady man who owns a dungeon nearby and has good access to bodies."
-                    [/message]
-                    [message]
-                        speaker=Agrippa
-                        message=_"Who is it?"
-                    [/message]
-                    [message]
-                        speaker=Krux
-                        message=_"You! Grab him."
-                    [/message]
-                    [message]
-                        speaker=Prion
-                        message=_"No, it is not your uncle. I know very well what he is doing and I can assure you, he is not doing anything with undead."
-                    [/message]
-                    [message]
-                        speaker=Krux
-                        message=_"Lucretia was taken into his dungeon and then we found her wandering around as an unusual ghost who had been created apparently by a necromancer! If you have not found it, it is clearly because you have not checked all the extensions of his dungeon."
-                    [/message]
-                    [message]
-                        speaker=Bala
-                        message=_"There is something that assures us of full reliability of your uncle. Unfortunately, it is not something we want to tell you at this time."
-                    [/message]
-                    [message]
-                        speaker=Acanthamoeba
-                        message=_"I do not trust him. You should not trust him neither."
-                    [/message]
-                    [message]
-                        speaker=Bala
-                        message=_"You do not have to trust him."
-                    [/message]
-                [/then]
-                [else]
-                    [message]
-                        speaker=Acanthamoeba
-                        message=_"I know of a shady man who owns a dungeon nearby and has good access to bodies. Uncle Agrippa. Who is suspiciously absent at this moment."
-                    [/message]
-                    [message]
-                        speaker=Prion
-                        message=_"I am quite convinced that he is behind all of this too. I know you suspected him before and I should have listened to you."
-                    [/message]
-                [/else]
-            [/if]
-            {VARIABLE quests.asked_about_lucretia yes}
-        [/command]
-        [/option]
-        [option]
-        message=_"I wonder, do you think that I have some ancient legacy in my blood?"
-        [show_if]
-            [not]
-                [variable]
-                    name=quests.asked_about_legacy
-                    equals=yes
-                [/variable]
-            [/not]
-        [/show_if]
-        [command]
-            [message]
-                speaker=Bala
-                message=_"Everybody has some legacy. You have not discovered yours, it seems."
-            [/message]
-            [message]
-                speaker=Prion
-                message=_"Try to guess."
-                    {LEGACY_MESSAGE_OPTIONS legacy} # This one is defined in LotI, but it's just for this case - so that adding legacies would not require updating this campaign
-            [/message]
-            [store_unit]
-                [filter]
-                    id=Krux
-                [/filter]
-                variable=krux_store
-                kill=no
-            [/store_unit]
-            {FOREACH krux_store.modifications.advancement i}
-                [if]
-                    [variable]
-                        name=krux_store.modifications.advancement[$i].id
-                        equals=disabled_legacy
-                    [/variable]
-                    [then]
-                        {VARIABLE krux_store.modifications.advancement[$i].id $legacy}
-                    [/then]
-                [/if]
-            {NEXT i}
-            [unstore_unit]
-                variable=krux_store
-                find_vacant=no
-            [/unstore_unit]
-            {CLEAR_VARIABLE legacy}
-            [message]
-                speaker=Prion
-                message=_"Correct."
-            [/message]
-            [message]
-                speaker=Krux
-                message=_"I always knew it. My intuition was right. Acantha has the same...?"
-            [/message]
-            [message]
-                speaker=Bala
-                message=_"She might not have the same legacy."
-            [/message]
-            {VARIABLE quests.asked_about_legacy yes}
-        [/command]
-        [/option]
-        [option]
-        message=_"That is all that I wanted to ask."
-        [command]
-            [break]
+            [else]
                 [message]
-                    speaker=Prion
-                    message=_"Fine. Goodbye, son."
+                    speaker=Krux
+                    message=_"Back home, back where I want to be, back home, no better place for me."
                 [/message]
                 [message]
                     speaker=Acanthamoeba
-                    message=_"Goodbye, dad."
+                    message=_"That attempt at poetry was not bad."
                 [/message]
-            [/break]
-        [/command]
-        [/option]
-    [/repeating_message]
-    [if]
-        [variable]
-            name=quests.overall
-            not_equals=11
-        [/variable]
-        [and]
+                [message]
+                    speaker=Krux
+                    message=_"I have just read those verses somewhere. They must have been written by a great poet."
+                [/message] # It's a short excerpt from Ronnie König's works
+                [message]
+                    speaker=Acanthamoeba
+                    message=_"To be honest, I was amazed how you could write <i>poetry</i>. You are usually so <i>rational</i> that something like this looks so unusual for you."
+                [/message]
+                [message]
+                    speaker=Antipos
+                    message=_"I have heard of a great researcher who had enough research at some age and became a master of pen. I cannot quite remember his name. It was... ehm... how was it... Ernie Sabaton? No, his name did not sound military. I will have to check it out. He is told to have lived for a hundred years, maybe some healers studied how could he live for so long."
+                [/message] # Reference to a real MIT physicist and later surrealist prose writer, Ernesto Sabato.
+                [message]
+                    speaker=Acanthamoeba
+                    message=_"Well, enough talking about literature, it is time to see our father."
+                [/message]
+                [message]
+                    speaker=Hare
+                    message=_"I always wondered how he looks."
+                [/message]
+                {VARIABLE quests.first_in_strych yes}
+            [/else]
+        [/if]
+        [if]
             [variable]
                 name=quests.overall
-                not_equals=13
+                equals=12
             [/variable]
-        [/and]
-        [then]
-            [if]
+            [then]
+                [if]
+                    [variable]
+                        name=quests.first_in_strych_when_undead_attack
+                        equals=yes
+                    [/variable]
+                    [else]
+                        [message]
+                            speaker=Krux
+                            message=_"It is good to see that Strych has not fallen yet. But these enemies are disturbing."
+                        [/message]
+                        [message]
+                            speaker=Acanthamoeba
+                            message=_"I think that instead of defending the town like Ogira, we should rush to our parents to ask what to do."
+                        [/message]
+                        [message]
+                            speaker=Antipos
+                            message=_"I think that it would be the best. But there are many undead between us and Strych."
+                        [/message]
+                        [message]
+                            speaker=ally_talker
+                            message=_"Help us! We are barely capable of facing these monsters! Sooner or later, we will fall if we are not sent reinforcements or they stop coming!"
+                        [/message]
+                        [message]
+                            speaker=boss_1
+                            message=_"You shall fall and you shall be eaten. No reinforcements will ever come, no retreat will ever occur."
+                        [/message]
+                        [message]
+                            speaker=Krux
+                            message=_"We will kill the group standing in our way and consult with our parents, maybe they are held captive and unable to send reinforcements."
+                        [/message]
+                        [message]
+                            speaker=Acanthamoeba
+                            message=_"I hope they are not dead already."
+                        [/message]
+                        [message]
+                            speaker=boss_1
+                            message=_"All shall fall."
+                        [/message]
+                        {VARIABLE quests.first_in_strych_when_undead_attack yes}
+                    [/else]
+                [/if]
+            [/then]
+        [/if]
+    [/event]
+
+    [event]
+        name=moveto
+        first_time_only=no
+        [filter]
+            side=1
+            x,y=7-17,4-11
+            [or]
+                side=1
+                x,y=1-8,1-4
+            [/or]
+        [/filter]
+        [message]
+            speaker=Acanthamoeba
+            message=_"Please stay in the antechamber, our family discussions are secret."
+        [/message]
+        [move_unit]
+            side=1
+            [not]
+                id=Krux
+            [/not]
+            [not]
+                id=Acanthamoeba
+            [/not]
+            to_x=10
+            to_y=9
+        [/move_unit]
+        [move_unit]
+            id=Krux
+            [or]
+                id=Acanthamoeba
+            [/or]
+            to_x=5
+            to_y=3
+        [/move_unit]
+        [unit]
+            id=Prion
+            name=_"Prion the Shiverbringer"
+            x,y=3,1
+            side=1
+            type=General
+            canrecruit=yes
+            [modifications]
+                [object]
+                    [effect]
+                        apply_to=profile
+                        portrait=portraits/Prion.png
+                    [/effect]
+                [/object]
+                {TRAIT_INTELLIGENT}
+                {TRAIT_INTELLIGENT}
+            [/modifications]
+        [/unit]
+        {MOVE_UNIT id=Prion 4 1}
+        [unit]
+            id=Bala
+            name=_"Bala"
+            x,y=1,3
+            side=1
+            type=Red Mage
+            gender=female
+            canrecruit=yes
+            [modifications]
+                {TRAIT_INTELLIGENT}
+                {TRAIT_INTELLIGENT}
+            [/modifications]
+        [/unit]
+        {MOVE_UNIT id=Bala 2 2}
+        [if]
+            [variable]
+                name=quests.overall
+                less_than=11
+            [/variable]
+            [then]
+                [unit]
+                    id=Agrippa
+                    name=_"Agrippa the Wise"
+                    x,y=7,1
+                    side=1
+                    gender=male
+                    type=Dark Sorcerer
+                    canrecruit=yes
+                    [modifications]
+                        {TRAIT_INTELLIGENT}
+                        {TRAIT_RESILIENT}
+                    [/modifications]
+                [/unit]
+                {MOVE_UNIT id=Agrippa 6 1}
+            [/then]
+        [/if]
+        [message]
+            speaker=Bala
+            message=_"What do you want, my children?"
+        [/message]
+        [repeating_message]
+            speaker=Prion
+            first=_"Is there something you want to tell us or to learn from us?"
+            message=_"Is there something else?"
+            [option]
+                message=_"We have dealt with the bandit uprising. Most of them are imprisoned in the town and waiting for escort."
+                [show_if]
+                    [variable]
+                        name=quests.overall
+                        equals=1
+                    [/variable]
+                [/show_if]
+                [command]
+                    [message]
+                        speaker=Agrippa
+                        message=_"Excellent work."
+                    [/message]
+                    [message]
+                        speaker=Bala
+                        message=_"Congratulations. I am so proud of you."
+                    [/message]
+                    [message]
+                        speaker=Prion
+                        message=_"You have shown great skill, my son. And also you, Acantha."
+                    [/message]
+                    [message]
+                        speaker=Krux
+                        message=_"It was an honour."
+                    [/message]
+                    [message]
+                        speaker=Prion
+                        message=_"Now, I am sorry for jumping into it too quickly, but I have some pressing matters that you should be able to solve."
+                    [/message]
+                    [message]
+                        speaker=Acanthamoeba
+                        message=_"What is it?"
+                    [/message]
+                    [message]
+                        speaker=Prion
+                        message=_"We have some trouble with House Mansion. They are trying to expand their political influence."
+                    [/message]
+                    [message]
+                        speaker=Agrippa
+                        message=_"Just like us. They are our rivals in the game."
+                    [/message]
+                    [message]
+                        speaker=Prion
+                        message=_"However, although they are more popular among the usual folk as we are, they are not very good at governing. They tend to be honest and keep their word. Also, they always follow the rules. To the extent when it becomes harmful for everyone. Many people appreciate that, but it has many bad consequences. So we need to push them away or just stop them from spreading over our land."
+                    [/message]
+                    [repeating_message]
+                        speaker=Bala
+                        first=_"They have recently appointed a new mayor in the small town known as Boonies. It used to be somewhere between our influence and theirs. Now it is clearly under their influence. It is not an important town, we might live on without problems without it, but we fear what would be next. They must be stopped. Do you want to ask something more about the situation?"
+                        message=_"Is there something else you want to ask?"
+                        [option]
+                            message=_"Do I really have to deal with that? Brother Gilles is a more skilled warrior than I am."
+                            [command]
+                                [message]
+                                    speaker=Prion
+                                    message=_"He is occupied elsewhere. You will have Acantha with you. Gilles' mission is important we cannot recall him. And having you replace him would take too much time."
+                                [/message]
+                            [/command]
+                        [/option]
+                        [option]
+                            message=_"How large is that Boonies?"
+                            [command]
+                                [message]
+                                    speaker=Prion
+                                    message=_"It has about two hundreds inhabitants. It has a small fortress with a crew of several men, but they were mostly to protect the people from bandits. When the enemies came, they could do nothing but to surrender."
+                                [/message]
+                                [message]
+                                    speaker=Agrippa
+                                    message=_"Remember that we do not need Boonies necessarily, we would not mind trading it for something. But now it is Boonies, then it might be Ogira. And we cannot let them have our towns."
+                                [/message]
+                            [/command]
+                        [/option]
+                        [option]
+                            message=_"How about a full scale confrontation with the Mansions to teach them that they should be our vassals and not our rivals?"
+                            [command]
+                                [message]
+                                    speaker=Prion
+                                    message=_"That is not as easy as it sounds. They have a large army. They might be weaker than us, but their soldiers will fight bravely for their so popular masters. Large numbers of our soldiers would die in a bloodbath like that and leave us vulnerable for a few years."
+                                [/message]
+                                [message]
+                                    speaker=Bala
+                                    message=_"They are currently facing an undead threat and it is weakening them, but the overall effect is small. We hope that the mysterious necromancer causes heavy damage to them before he dies. We do not want to face the necromancer ourselves when the Mansions fall."
+                                [/message]
+                                [message]
+                                    speaker=Agrippa
+                                    message=_"We might attack when the situation gets better, but we cannot know when the situation gets better."
+                                [/message]
+                            [/command]
+                        [/option]
+                        [option]
+                            message=_"How many enemies are there?"
+                            [command]
+                                [message]
+                                    speaker=Prion
+                                    message=_"Quite a lot, it is possible that they plan to continue occupying our villages."
+                                [/message]
+                                [message]
+                                    speaker=Agrippa
+                                    message=_"They are not so numerous that they could handle a whole regiment of our army. Furthermore, we want you to try some diplomacy first."
+                                [/message]
+                            [/command]
+                        [/option]
+                        [option]
+                            message=_"Nothing else. What exactly what do you want me to do?"
+                            [show_if]
+                                [not]
+                                    [variable]
+                                        name=first_view
+                                        equals=true
+                                    [/variable]
+                                [/not]
+                            [/show_if]
+                            [command]
+                                [break]
+                                [/break]
+                            [/command]
+                        [/option]
+                    [/repeating_message]
+                    [message]
+                        speaker=Bala
+                        message=_"The appointed mayor is the only child of their house, Marilyn. As far as I known, Marilyn is a reasonable person. You may threaten with a full confrontation of our armies that would probably end up badly for them. You may sneak into their base and take a very good hostage. You may also try some persuation, you will surely figure out something."
+                    [/message]
+                    [message]
+                        speaker=Krux
+                        message=_"Marilyn, you say. Is their heir a woman?"
+                    [/message]
+                    [message]
+                        speaker=Prion
+                        message=_"I am not certain about that. People always speak about Marilyn of House Mansion, the offspring of Charles, but they rarely tell if it is a daughter or son. I believe that they are doing it to conceal that their great heir is a woman. Most likely a warrior, but a woman."
+                    [/message]
+                    [message]
+                        speaker=Krux
+                        message=_"So somebody like Acantha could be if me and all of my siblings except her died."
+                    [/message]
+                    [message]
+                        speaker=Prion
+                        message=_"You know well that not any woman is like Acanthamoeba. This Marilyn certainly has some similarities, but remember that she might be different. Cold, ill-tempered, ugly. And just to see the expression of your face, I am telling you that Marilyn might also be manly or a man."
+                    [/message]
+                    [message]
+                        speaker=Krux
+                        message=_"You know that I often wish that Acantha was not my sister... She is great."
+                    [/message]
+                    [message]
+                        speaker=Bala
+                        message=_"Stop that."
+                    [/message]
+                    [message]
+                        speaker=Krux
+                        message=_"Okay, so, if this Marilyn happens to be like Acantha, may I marry her? It might nicely fuse our two Houses together. Under our control."
+                    [/message]
+                    [message]
+                        speaker=Prion
+                        message=_"If it is a woman, you must try to befriend her and marry her. We cannot risk that opportunity because of your aesthetic preferences."
+                    [/message]
+                    [message]
+                        speaker=Acanthamoeba
+                        message=_"Hehe, Krux, why was it <i>you</i> who mocked <i>me</i> about arranged marriages?"
+                    [/message]
+                    [message]
+                        speaker=Prion
+                        message=_"Of course, if it is a man, you will have to try hard to marry him, Acantha. And take dominance in commanding and organising."
+                    [/message]
+                    [message]
+                        speaker=Acanthamoeba
+                        message=_"It will be a manly woman, I can see that."
+                    [/message]
+                    [message]
+                        speaker=Bala
+                        message=_"I know that both of your are afraid of having to marry an ugly person. But being married to an ugly person is not that bad, you can always cheat."
+                    [/message]
+                    [message]
+                        speaker=Prion
+                        message=_"Bala, it was only once! And you are not ugly, you are just... not so young anymore."
+                    [/message]
+                    [message]
+                        speaker=Bala
+                        message=_"I have caught you once, I might have failed to catch you a hundred times. I have forgiven you... but you should not be sure that I will forgive you next time."
+                    [/message]
+                    [message]
+                        speaker=Agrippa
+                        message=_"Brother, sister-in-law, do you realise that your children are here?"
+                    [/message]
+                    [message]
+                        speaker=Prion
+                        message=_"So embarassing... well, you were told everything you need to know, head south and deal with that problem. Remember that simply persuade Marilyn to stop that expansion north is enough."
+                    [/message]
+                    [message]
+                        speaker=Bala
+                        message=_"Boonies is south from here, you need to pass through Southern Estates. There might be a few bandits there, maybe some Mansion soldiers, but it should be relatively safe. Some soldiers should be waiting for you in its vincinity, I have sent them already."
+                    [/message]
+                    [message]
+                        speaker=Krux
+                        message=_"I will be on my way."
+                    [/message]
+                    {AE_TRANSITION 14-30 23-25 Southern_Estates _"Southern Estates" 24 23}
+                    {VARIABLE quests.overall 2}
+                    {VARIABLE quests.do_talk_about_mansions yes}
+                [/command]
+            [/option]
+            [option]
+                message=_"We have taken control of Boonies. Marilyn had to run."
+                [show_if]
+                    [variable]
+                        name=quests.overall
+                        equals=3
+                    [/variable]
+                [/show_if]
+                [command]
+                    [message]
+                        speaker=Bala
+                        message=_"That is a great victory, my children."
+                    [/message]
+                    [message]
+                        speaker=Prion
+                        message=_"Was she strong?"
+                    [/message]
+                    [message]
+                        speaker=Krux
+                        message=_"Marilyn is a man."
+                    [/message]
+                    [message]
+                        speaker=Acanthamoeba
+                        message=_"A man who refused a prospective marriage offer from me. Like if he was suspecting me of planning to manipulate him."
+                    [/message]
+                    [message]
+                        speaker=Prion
+                        message=_"He did not want peace neither, I assume, so you had to fight. Was he strong?"
+                    [/message]
+                    [if]
+                        [variable]
+                            name=quests.marilyn_undead_exploit
+                            equals=yes
+                        [/variable]
+                        [then]
+                            [message]
+                                speaker=Acanthamoeba
+                                message=_"Yes. Initially he was not sending much of his forces at us, but when we approached, he realised that he overestimated us. We could not face him, but undead suddenly appeared and attacked him."
+                            [/message]
+                            [message]
+                                speaker=Prion
+                                message=_"Undead? Again?"
+                            [/message]
+                            [message]
+                                speaker=Acanthamoeba
+                                message=_"Yes. We are encountering undead everywhere. I think that there is some serious trouble going on somewhere."
+                            [/message]
+                            [message]
+                                speaker=Agrippa
+                                message=_"Would you prefer if the undead were attacking only our enemies and not us? Everybody would suspect us!"
+                                [option]
+                                    message=_"No. Serious arguments claiming a link between us and undead would have damaged us badly."
+                                    [command]
+                                        [message]
+                                            speaker=Prion
+                                            message=_"I wonder who the necromancer is..."
+                                        [/message]
+                                    [/command]
+                                [/option]
+                                [option]
+                                    message=_"Actually, the undead caused damage to both sides, but they never directly attacked us. But they did retaliate."
+                                    [command]
+                                        [message]
+                                            speaker=Acanthamoeba
+                                            message=_"Do they held some grudge on the Mansions or something? Maybe one of them, in one of their outbursts of raging violence, killed somebody and that person returned as a Death Knight, seeking revenge. With no Mansions in sight, they attack at random, with Mansions in sight, they focus on Mansions."
+                                        [/message]
+                                        [message]
+                                            speaker=Agrippa
+                                            message=_"That is possible. I would like to send the Death Knight a pack of gold, but I do not know where he lives."
+                                        [/message]
+                                    [/command]
+                                [/option]
+                                [option]
+                                    message=_"Ah, that is why <i>your</i> undead are attacking us."
+                                    [command]
+                                        [message]
+                                            speaker=Agrippa
+                                            message=_"<i>My</i> undead? No, please no. I am not a necromancer."
+                                        [/message]
+                                        [message]
+                                            speaker=Prion
+                                            message=_"That is not possible. I can assure you that my brother Agrippa is not a necromancer."
+                                        [/message]
+                                    [/command]
+                                [/option]
+                            [/message]
+                        [/then]
+                    [/if]
+                    [message]
+                        speaker=Bala
+                        message=_"Is there anything else that you can tell us about the fight?"
+                    [/message]
+                    [message]
+                        speaker=Krux
+                        message=_"Well, Marilyn complained that undead had caused them a lot of damage and that is why he had lost. However, he accepted his defeat."
+                    [/message]
+                    [message]
+                        speaker=Prion
+                        message=_"Their war with that necromancer is so bad? I did not know. They owe us a lot of gold. Their expenses are greater than their income for decades. Maybe we could declare them unreliable debtors and start confiscating?"
+                    [/message]
+                    [message]
+                        speaker=Bala
+                        message=_"We shall discuss that later."
+                    [/message]
+                    {VARIABLE quests.overall 4}
+                [/command]
+            [/option]
+            [option]
+                message=_"Is there something you would like us to do?"
+                [show_if]
+                    [variable]
+                        name=quests.overall
+                        equals=4
+                    [/variable]
+                [/show_if]
+                [command]
+                    [message]
+                        speaker=Bala
+                        message=_"Actually, yes. We were preparing this plan for long. It is about further expansion. Do you know why we cannot push to the south now?"
+                    [/message]
+                    [message]
+                        speaker=Acanthamoeba
+                        message=_"The Mansions. If we attacked them, we might risk a full confrontation. As you suggested before, it might work a few years after we cease to lend them gold. Or if their war with undead damages them too badly. We cannot go south at the moment. But we can wait and prepare forces."
+                    [/message]
+                    [message]
+                        speaker=Bala
+                        message=_"Yes. Do you know why we cannot push to the north now?"
+                    [/message]
+                    [message]
+                        speaker=Krux
+                        message=_"There are mountains. They are hard to pass, if we attacked there we would need great amounts of supplies to bring and fighting there would be very disadvantageous."
+                    [/message]
+                    [message]
+                        speaker=Prion
+                        message=_"Also, orcs attack from the north. House Thule holds them, but if we defeated the Thule, we would have to face the orcs ourselves. Furthermore, the Thule are quite stark and I do not want to mess with them."
+                    [/message]
+                    [message]
+                        speaker=Bala
+                        message=_"Do you know why we cannot push to the east now?"
+                    [/message]
+                    [message]
+                        speaker=Acanthamoeba
+                        message=_"There are some lands we had recently taken over and they are not tamed properly yet. We need to have full loyalty of the people living there."
+                    [/message]
+                    [message]
+                        speaker=Krux
+                        message=_"Are you trying to say that we should push to the west? There are thick forest and elves live there. It is unwise to mess with elves."
+                    [/message]
+                    [message]
+                        speaker=Prion
+                        message=_"I do not want to fight them. Kill an elf murderer, his friends will murder the judge or executioner. Enter their forest accidentally, they will capture you and complain about it to the king and they have to be paid gold for their release. About a century ago, one lord attacked the elves after a long argument over a forest and soon they retaliated with a huge army of elves that came from all forests of the continent. They destroyed their fields, sacked their castles, stole their children and drove all humans away. Now it is a thick forest full of unfriendly elves."
+                    [/message]
+                    [message]
+                        speaker=Acanthamoeba
+                        message=_"So what? Do you want us to mess with them or not?"
+                    [/message]
+                    [message]
+                        speaker=Prion
+                        message=_"We have a plan."
+                    [/message]
+                    [message]
+                        speaker=Bala
+                        message=_"Krux, a marriage awaits you."
+                    [/message]
+                    [message]
+                        speaker=Krux
+                        message=_"Are you serious? Why would I do that? Elves look good, are intelligent and nice, but they do not interact with us! How could I possibly persuade one to marry me?"
+                    [/message]
+                    [message]
+                        speaker=Bala
+                        message=_"You have been very successful with using your charm in the past, maybe you take a greater challenge."
+                    [/message]
+                    [message]
+                        speaker=Krux
+                        message=_"What would it be good for? Half-elves do not differ much from humans as far as I know. And those usually come from... unwanted mating."
+                    [/message]
+                    [message]
+                        speaker=Bala
+                        message=_"It would allow you to join the elvish community. It would open them for manipulation and a strong alliance with us."
+                    [/message]
+                    [message]
+                        speaker=Krux
+                        message=_"Where can I find an elf? Should I rush into a forest and yell <i>are there some pretty maidens around here</i>?"
+                    [/message]
+                    [message]
+                        speaker=Prion
+                        message=_"There are elves who live with humans. The reasons vary, it can be exile, fleeing from justice, healing for gold, espionage, strange habits,..."
+                    [/message]
+                    [repeating_message]
+                        speaker=Bala
+                        message=_"Is there something else you want to ask?"
+                        [option]
+                            message=_"Where do I find one?"
+                            [command]
+                                [message]
+                                    speaker=Bala
+                                    message=_"I have heard of one living somewhere north from here, maybe in Ogira. She is some sort of ambassador, sometimes she comes to us with some affairs from the high lords. What was her name?"
+                                [/message]
+                                [message]
+                                    speaker=Prion
+                                    message=_"I cannot remember, it was a strange name, even by elvish standards."
+                                [/message]
+                            [/command]
+                        [/option]
+                        [option]
+                            message=_"What should I tell her? Asking her something like <i>why so lonely</i> certainly is not a good idea."
+                            [command]
+                                [message]
+                                    speaker=Bala
+                                    message=_"It should be something that would keep you near her for a longer time. We discussed various possibilities, here is the one that looks the most likely: Elves see us inferior to them and tend to tell us over and over how we should live to be like them. Maybe you could ask her to show you how the elves live and that our family wants to be their friends. They most likely have no idea about our foul reputation among the nobles."
+                                [/message]
+                                [message]
+                                    speaker=Prion
+                                    message=_"Let us hope so."
+                                [/message]
+                            [/command]
+                        [/option]
+                        [option]
+                            message=_"Are the undead damaging also the elves? Maybe we could offer them help."
+                            [command]
+                                [message]
+                                    speaker=Agrippa
+                                    message=_"Unfortunately, no. The elves are most likely better at locating the source of undead and the necromancer behind the whole thing."
+                                [/message]
+                            [/command]
+                        [/option]
+                        [option]
+                            message=_"Nothing else."
+                            [show_if]
+                                [not]
+                                    [variable]
+                                        name=first_view
+                                        equals=true
+                                    [/variable]
+                                [/not]
+                            [/show_if]
+                            [command]
+                                [break]
+                                [/break]
+                            [/command]
+                        [/option]
+                    [/repeating_message]
+                    [message]
+                        speaker=Prion
+                        message=_"And there is a little problem. The road north from here was blocked and some undead are reported to wander there."
+                    [/message]
+                    [message]
+                        speaker=Krux
+                        message=_"So we need to secure the road in order to get there."
+                    [/message]
+                    [message]
+                        speaker=Prion
+                        message=_"Yes. An army will be waiting for you near the place where the undead dwell."
+                    [/message]
+                    [label]
+                        x,y=24,1
+                        text=_"Lorendas' Forest"
+                        color=255,255,255
+                    [/label]
+                    {VARIABLE quests.overall 5}
+                    {VARIABLE quests.do_talk_about_elf yes}
+                [/command]
+            [/option]
+            [option]
+                message=_"We had some difficulties with the elvish plan, we currently need a few years until we return to it."
+                [show_if]
+                    [variable]
+                        name=quests.overall
+                        equals=10
+                    [/variable]
+                [/show_if]
+                [command]
+                    [message]
+                        speaker=Bala
+                        message=_"What happened?"
+                    [/message]
+                    [message]
+                        speaker=Acanthamoeba
+                        message=_"It is a long story. Krux successfully made that elf, Fowleri, fall in love with him. He seems to have fallen in love with her too, unusually. But other elves were not so welcoming. We have saved them from an orcish incursion, but they only said their thanks but did absolutely nothing to return our favour. Many of those elves behaved like if they were gods among men."
+                    [/message]
+                    [if]
+                        [variable]
+                            name=quests.gruzgobs_path_visited_settlement
+                            equals=yes
+                        [/variable]
+                        [then]
+                            [message]
+                                speaker=Krux
+                                message=_"Later, we have learned that they have informers among common folk and they inform them about anything they know. When I asked more about the system, it appeared to me that some of them picked up the vicious rumours that are spread about us and they believed them. They considered us dangerous."
+                            [/message]
+                        [/then]
+                    [/if]
+                    [message]
+                        speaker=Prion
+                        message=_"What have you done then?"
+                    [/message]
+                    [message]
+                        speaker=Krux
+                        message=_"It was a wicked plan. An unforgivable abomination. Antipos learned that Fowleri was pregnant. With me. So we snatched the child from her insides."
+                    [/message]
+                    [message]
+                        speaker=Bala
+                        message=_"Is she..."
+                    [/message]
+                    [message]
+                        speaker=Acanthamoeba
+                        message=_"No, she knows nothing. We have organised a false flag orcish assault on her outpost and when she was injured by orcs, we have only added a new wound. Then we healed her and pretended that we saved her from the orcs. As far as we know, no elf knows about our actions."
+                    [/message]
+                    [message]
+                        speaker=Prion
+                        message=_"Where is the child now?"
+                    [/message]
+                    [message]
+                        speaker=Acanthamoeba
+                        message=_"He was placed into me initially, then transferred into a suitable mother."
+                    [/message]
+                    [message]
+                        speaker=Prion
+                        message=_"Who? Who is carrying my grandson?"
+                    [/message]
+                    [message]
+                        speaker=Krux
+                        message=_"We initially intended Legionella de Ceise to carry her. I do not know if you know her, but I found her to be suitable for this purpose. She wanted to have a child so badly. Without even looking for a proper husband. But unfortunately, I impregnated her when trying to pretend to impregnate her. So she is carrying your grandson, but not the elvish child. That one is carried by her friend. I assumed that she would help her care about her."
+                    [/message]
+                    [message]
+                        speaker=Prion
+                        message=_"So it is a girl? That might be a problem, women get into ruling positions harder."
+                    [/message]
+                    [message]
+                        speaker=Acanthamoeba
+                        message=_"That is not the case of elves. For example, Fowleri used to be a great elvish warlord."
+                    [/message]
+                    [message]
+                        speaker=Agrippa
+                        message=_"What if she likes eating babies?"
+                    [/message]
+                    [message]
+                        speaker=Bala
+                        message=_"Screw you with your sick jokes, Agrippa."
+                    [/message]
+                    [message]
+                        speaker=Agrippa
+                        message=_"Pardon, mylady, I thought the rumours that you eat children were true."
+                    [/message]
+                    [message]
+                        speaker=Krux
+                        message=_"Please leave these arguments for later. I think that Uncle Agrippa should spend less time with his prisoners."
+                    [/message]
+                    [message]
+                        speaker=Bala
+                        message=_"Or spend all time with his prisoners so that I would not have to listen to him."
+                    [/message]
+                    [message]
+                        speaker=Prion
+                        message=_"Enough."
+                    [/message]
+                    [message]
+                        speaker=Krux
+                        message=_"Is there anything else you want us to do?"
+                    [/message]
+                    [message]
+                        speaker=Prion
+                        message=_"I know this will surprise you, but there is not. You have done a lot of good work recently. Our plan to control the western lands is advancing slowly, we cannot go north, your brother Gilles has gone far enough to the east, south is a matter of diplomacy at the moment, undead are not very annoying currently... There are some rough ideas what we could do, but we should wait for things to evolve."
+                    [/message]
+                    [message]
+                        speaker=Bala
+                        message=_"But you might want to see Legionella and especially her friend ocasionally, it should certainly help our cause and your budding family."
+                    [/message]
+                    {VARIABLE quests.overall 11}
+                    {VARIABLE previous_scenario $current_scenario}
+                    {AE_SAVE_GOLD}
+                    [endlevel]
+                        result=victory
+                        bonus=no
+                        next_scenario=Ogira
+                        {NEW_GOLD_CARRYOVER 100}
+                        linger_mode=no
+                        carryover_report=no
+                    [/endlevel]
+                    [break]
+                    [/break]
+                [/command]
+            [/option]
+            [option]
+                message=_"What is going on with all those undead attacking our towns?"
+                [show_if]
+                    [variable]
+                        name=quests.overall
+                        equals=12
+                    [/variable]
+                [/show_if]
+                [command]
+                    [message]
+                        speaker=Bala
+                        message=_"It is a disaster. Our plan backfired, and really badly."
+                    [/message]
+                    [message]
+                        speaker=Prion
+                        message=_"It is time to tell you the full truth, children. It will not be pleasant, but you will know that it is true because you were suspecting it."
+                    [/message]
+                    [message]
+                        speaker=Bala
+                        message=_"If we found a prisoner guilty, we sent him for execution. But the executor was Agrippa and he was making undead out of them. He has made a lot of discoveries and made stronger and hardier monsters. He used them as some sort of slaves, built tunnels under our lands and many others, built underground fortresses and castles for us to hide in if times get bad. It allowed him to approach the discovery of a way to extend lives without any significant drawbacks, also the slave work required no food."
+                    [/message]
+                    [message]
+                        speaker=Prion
+                        message=_"At some point, we decided that we might use those undead to attack our enemies while pretending that it was a third party. Suspicion quickly fell on us, probably as an attempt to destroy us rather than because of evidence. As the undead killed many people who rose as undead, the undead army grew and Agrippa had difficulties to control them, causing some undead attacks on our land."
+                    [/message]
+                    [if]
+                        [variable]
+                            name=quests.dead_menace_seen_peasants
+                            equals=yes
+                        [/variable]
+                        [then]
+                            [message]
+                                speaker=Krux
+                                message=_"These undead were not attacking the locals, only us. I believe it was rather a false flag attack to misdirect suspicion than a loss of control."
+                            [/message]
+                            [message]
+                                speaker=Prion
+                                message=_"Some of those undead attacked only if threatened. Many of them remained partially under Agrippa's control and only moved where they were not supposed to go."
+                            [/message]
+                        [/then]
+                    [/if]
+                    [message]
+                        speaker=Krux
+                        message=_"And what happened now?"
+                    [/message]
+                    [message]
+                        speaker=Prion
+                        message=_"He lost control over the undead completely. There was too many of them and they possibly pretended for some time that they are controlled so that they would revolt only if it is too late for him to stop them. It is also possible that he betrayed us entirely. In any way, he got us into a great trouble."
+                    [/message]
+                    [message]
+                        speaker=Bala
+                        message=_"A trouble that can cause our family to fall. The Mansions will certainly use it to build an alliance against us. While we are ravaged by undead of our own creation."
+                    [/message]
+                    [message]
+                        speaker=Acanthamoeba
+                        message=_"What can we do now? Prepare to run?"
+                    [/message]
+                    [message]
+                        speaker=Prion
+                        message=_"I believe it is not <i>so</i> bad. They have no evidence that we are responsible for the undead. What we fear is that they ignore the lack of evidence and attack us anyway. Some of those Paladins can be quite blind and attack whatever they consider evil without questioning if the evil they see is really evil."
+                    [/message]
+                    [message]
+                        speaker=Bala
+                        message=_"We are sending messages to everyone around that we are going to pay them great amounts of gold for helping us defeat the undead. We shall see how will it work out."
+                    [/message]
+                    [message]
+                        speaker=Krux
+                        message=_"What do you want us to do?"
+                    [/message]
+                    [message]
+                        speaker=Bala
+                        message=_"The most important thing you could do. To enter Agrippa's dungeon."
+                    [/message]
+                    [message]
+                        speaker=Prion
+                        message=_"The mastermind of the undead attack is most likely there. It might be Agrippa. It might be something else. Anyway, if we destroy whoever coordinates them, they will be much weaker without him. If it is Agrippa and he had betrayed us, ask him how he plans to survive it and force him to change the plan to suit our needs."
+                    [/message]
+                    [repeating_message]
+                        speaker=Bala
+                        first=_"Any questions?"
+                        message=_"Anything else?"
+                        [option]
+                            message=_"Will we have soldiers with us?"
+                            [command]
+                                [message]
+                                    speaker=Prion
+                                    message=_"Certainly. That is why we are leaving most soldiers inside the keep. If we lose the town, the walls of this fortress can still stand. If their mastermind is dead, they will disperse and we well retake it easily. We are preparing an evacuation."
+                                [/message]
+                                [message]
+                                    speaker=Acanthamoeba
+                                    message=_"Good to know."
+                                [/message]
+                            [/command]
+                        [/option]
+                        [option]
+                            message=_"Where do we find him?"
+                            [command]
+                                [message]
+                                    speaker=Prion
+                                    message=_"I have no idea. If it is Agrippa, he is probably somewhere under this town, he wants to use this town as his capital even after the putsch. If it is something else, I would also expect it to be nearby, in the centre of action. Start searching in the dungeons under the castle, go deeper and deeper, but try not to get lost. Try to look for some clues."
+                                [/message]
+                                [message]
+                                    speaker=Acanthamoeba
+                                    message=_"That is not very much information."
+                                [/message]
+                                [message]
+                                    speaker=Prion
+                                    message=_"It is all we have."
+                                [/message]
+                            [/command]
+                        [/option]
+                        [option]
+                            message=_"Can you two help us directly?"
+                            [command]
+                                [message]
+                                    speaker=Prion
+                                    message=_"No, we have duties here. If we plunged into the dungeon with you, it might seem that we are allied with them. If we are seen actively fighting them, it is much more persuasive. And we are not so powerful in battle after all."
+                                [/message]
+                                [message]
+                                    speaker=Bala
+                                    message=_"My skill with combat magic has faded over time."
+                                [/message]
+                                [message]
+                                    speaker=Prion
+                                    message=_"And I have not practised sword fighting for long."
+                                [/message]
+                            [/command]
+                        [/option]
+                        [option]
+                            message=_"Nothing else."
+                            [command]
+                                [break]
+                                [/break]
+                            [/command]
+                        [/option]
+                    [/repeating_message]
+                    [message]
+                        speaker=Prion
+                        message=_"Okay, go to the dungeon and ensure our survival."
+                    [/message]
+                    {VARIABLE quests.overall 13}
+                    {VARIABLE previous_scenario $current_scenario}
+                    {AE_SAVE_GOLD}
+                    [endlevel]
+                        result=victory
+                        bonus=no
+                        next_scenario=08_The_Reckoning
+                        {NEW_GOLD_CARRYOVER 0}
+                        linger_mode=no
+                        carryover_report=no
+                    [/endlevel]
+                    [break]
+                    [/break]
+                [/command]
+            [/option]
+            [option]
+                message=_"We have found some undead on our way back."
+                [show_if]
+                    [variable]
+                        name=quests.menacing_hills_undead_house
+                        equals=yes
+                    [/variable]
+                    [or]
+                        [variable]
+                            name=quests.menacing_hills_undead_cave
+                            equals=yes
+                        [/variable]
+                    [/or]
+                    [not]
+                        [variable]
+                            name=quests.menacing_hills_undead_house_announced
+                            equals=yes
+                        [/variable]
+                    [/not]
+                    [not]
+                        [variable]
+                            name=quests.overall
+                            greater_than=4
+                        [/variable]
+                    [/not]
+                [/show_if]
+                [command]
+                    [if]
+                        [variable]
+                            name=quests.menacing_hills_undead_cave
+                            equals=yes
+                        [/variable]
+                        [then]
+                            [message]
+                                speaker=Acanthamoeba
+                                message=_"What is worse, there was an undead-infested cave nearby. We have investigated it, they were climbing from a deep hole. We could not investigate further."
+                            [/message]
+                        [/then]
+                    [/if]
+                    [message]
+                        speaker=Bala
+                        message=_"Undead? Maybe some of them have reached also our region. House Mansion has trouble with them."
+                    [/message]
+                    [message]
+                        speaker=Agrippa
+                        message=_"As far as I know, undead, when not properly kept, either because the necromancer is incapable or controls too many of them, might attack unintended targets, possibly far away. They might wander somewhere where they were not sent and attack whatever they encounter."
+                    [/message]
+                    [message]
+                        speaker=Prion
+                        message=_"Where was it, exactly?"
+                    [/message]
+                    [message]
+                        speaker=Krux
+                        message=_"South from the road. The road was altered by somebody or something, redirected to a swamp where undead lurked."
+                    [/message]
+                    [message]
+                        speaker=Agrippa
+                        message=_"I will deal with that issue."
+                    [/message]
+                    {VARIABLE quests.menacing_hills_undead_house_announced yes}
+                [/command]
+            [/option]
+            [option]
+                message=_"What is done to the prisoners we capture?"
+                [show_if]
+                    [variable]
+                        name=quests.overall
+                        not_equals=12
+                    [/variable]
+                    [not]
+                        [variable]
+                            name=quests.asked_about_prison
+                            equals=yes
+                        [/variable]
+                    [/not]
+                [/show_if]
+                [command]
+                    [message]
+                        speaker=Agrippa
+                        message=_"They are killed."
+                    [/message]
+                    [message]
+                        speaker=Prion
+                        message=_"What do you think we are doing to them, Krux?"
+                    [/message]
+                    [message]
+                        speaker=Krux
+                        message=_"I believe that they are used for slave labour to build a system of underground tunnels and fortresses."
+                    [/message]
+                    [message]
+                        speaker=Agrippa
+                        message=_"Correct. Exhaustation and death from overworking is the way they are killed. It helps our family much more than mere hanging. But let us keep the lie that they are simply hanged, fine?"
+                    [/message]
+                    [message]
+                        speaker=Krux
+                        message=_"People have suspicions."
+                    [/message]
+                    [message]
+                        speaker=Bala
+                        message=_"They are spread by evil tongues... ehm, hostile tongues. They are making up stories just to have people listen to them and maybe pay them a beer. They always existed and it is hard to get rid of them, they know how to hide themselves. Some of them are really ridiculous, he told to our agent that he was an escaped prisoner and he had to wash the blood-drenched floor of an occult room where we killed and ate small children every day in the name of Baphomet."
+                    [/message]
+                    [message]
+                        speaker=Acanthamoeba
+                        message=_"Ridiculous. We are not worshipping any Baphomet. Who is that Baphomet anyway?"
+                    [/message]
+                    [message]
+                        speaker=Agrippa
+                        message=_"There are many dangerous demons that let themselves be worshipped with some gruesome rituals in order to gain power. Their identities are kept secret from most people because worshipping them might be rewarding for the worshipper as the demons usually give rewards. It is unwise from the side of worshippers because it usually means that they have to serve the demon until they die and their descendants will have to worship them too. Otherwise they will be killed by the demon. So their worship is like an eternal curse, a huge limitation to freedom."
+                    [/message]
+                    [message]
+                        speaker=Agrippa
+                        message=_"It can make someone powerful, but chained by obligations and other people are harmed. Lilith is the most known of these demons, but I had to go to great depths of forbidden literature to find mentions even of that one. Supposed to be the most known. Interestingly, people sometimes talk about Baphomet. There is no such demon, it is just a tale to scare people. Every accusation of worshipping Baphomet has been false so far."
+                    [/message]
+                    [message]
+                        speaker=Acanthamoeba
+                        message=_"Do you believe what they say?"
+                    [/message]
+                    [message]
+                        speaker=Krux
+                        message=_"I am not completely without doubts..."
+                    [/message]
+                    {VARIABLE quests.asked_about_prison yes}
+                [/command]
+            [/option]
+            [option]
+                message=_"I have learned something interesting about the necromancers. From one of their victims."
+                [show_if]
+                    [variable]
+                        name=quests.overall
+                        greater_than=8
+                    [/variable]
+                    [and]
+                        [have_unit]
+                            id=Lucretia
+                        [/have_unit]
+                    [/and]
+                    [not]
+                        [variable]
+                            name=quests.asked_about_lucretia
+                            equals=yes
+                        [/variable]
+                    [/not]
+                [/show_if]
+                [command]
+                    [message]
+                        speaker=Bala
+                        message=_"What have you learned? How? Have you interrogated a ghoul?"
+                    [/message]
+                    [message]
+                        speaker=Krux
+                        message=_"No. One of them made it out relatively untouched. A ghost of a poisoner noblewoman. She behaves perfectly rationally, looks human, although she is a bit transparent. She has great issues to remember what happened before we met her, but over time, we have figured a few things out."
+                    [/message]
+                    [message]
+                        speaker=Prion
+                        message=_"It might be very interesting what have you figured out."
+                    [/message]
+                    [message]
+                        speaker=Acanthamoeba
+                        message=_"There is at least one necromancer underground and he investigates a poison named Lethe. It makes people forget. It is often used to take control over places and persuade the people that it was always like that. It might be a key that would allow a necromancer to rule an area without the obvious problems of rejection."
+                    [/message]
+                    [message]
+                        speaker=Bala
+                        message=_"That sounds scary."
+                    [/message]
+                    [message]
+                        speaker=Prion
+                        message=_"That means that the necromancers are planning to take over the land. Probably not only ours, but also the nearby ones."
+                    [/message]
+                    [message]
+                        speaker=Acanthamoeba
+                        message=_"We came to that conclusion too."
+                    [/message]
+                    [message]
+                        speaker=Krux
+                        message=_"It also seems that the dungeons are not far away from here."
+                    [/message]
+                    [if]
+                        [variable]
+                            name=quests.overall
+                            not_equals=12
+                        [/variable]
+                        [then]
+                            [message]
+                                speaker=Agrippa
+                                message=_"I will have to investigate who tunelled near our town. It will take some time."
+                            [/message]
+                            [message]
+                                speaker=Acanthamoeba
+                                message=_"Actually, I know of a shady man who owns a dungeon nearby and has good access to bodies."
+                            [/message]
+                            [message]
+                                speaker=Agrippa
+                                message=_"Who is it?"
+                            [/message]
+                            [message]
+                                speaker=Krux
+                                message=_"You! Grab him."
+                            [/message]
+                            [message]
+                                speaker=Prion
+                                message=_"No, it is not your uncle. I know very well what he is doing and I can assure you, he is not doing anything with undead."
+                            [/message]
+                            [message]
+                                speaker=Krux
+                                message=_"Lucretia was taken into his dungeon and then we found her wandering around as an unusual ghost who had been created apparently by a necromancer! If you have not found it, it is clearly because you have not checked all the extensions of his dungeon."
+                            [/message]
+                            [message]
+                                speaker=Bala
+                                message=_"There is something that assures us of full reliability of your uncle. Unfortunately, it is not something we want to tell you at this time."
+                            [/message]
+                            [message]
+                                speaker=Acanthamoeba
+                                message=_"I do not trust him. You should not trust him neither."
+                            [/message]
+                            [message]
+                                speaker=Bala
+                                message=_"You do not have to trust him."
+                            [/message]
+                        [/then]
+                        [else]
+                            [message]
+                                speaker=Acanthamoeba
+                                message=_"I know of a shady man who owns a dungeon nearby and has good access to bodies. Uncle Agrippa. Who is suspiciously absent at this moment."
+                            [/message]
+                            [message]
+                                speaker=Prion
+                                message=_"I am quite convinced that he is behind all of this too. I know you suspected him before and I should have listened to you."
+                            [/message]
+                        [/else]
+                    [/if]
+                    {VARIABLE quests.asked_about_lucretia yes}
+                [/command]
+            [/option]
+            [option]
+                message=_"I wonder, do you think that I have some ancient legacy in my blood?"
+                [show_if]
+                    [not]
+                        [variable]
+                            name=quests.asked_about_legacy
+                            equals=yes
+                        [/variable]
+                    [/not]
+                [/show_if]
+                [command]
+                    [message]
+                        speaker=Bala
+                        message=_"Everybody has some legacy. You have not discovered yours, it seems."
+                    [/message]
+                    [message]
+                        speaker=Prion
+                        message=_"Try to guess."
+                        {LEGACY_MESSAGE_OPTIONS legacy} # This one is defined in LotI, but it's just for this case - so that adding legacies would not require updating this campaign
+                    [/message]
+                    [store_unit]
+                        [filter]
+                            id=Krux
+                        [/filter]
+                        variable=krux_store
+                        kill=no
+                    [/store_unit]
+                    [for]
+                        array=krux_store.modifications.advancement
+                        [do]
+                            [if]
+                                [variable]
+                                    name=krux_store.modifications.advancement[$i].id
+                                    equals=disabled_legacy
+                                [/variable]
+                                [then]
+                                    {VARIABLE krux_store.modifications.advancement[$i].id $legacy}
+                                [/then]
+                            [/if]
+                        [/do]
+                    [/foreach]
+                    [unstore_unit]
+                        variable=krux_store
+                        find_vacant=no
+                    [/unstore_unit]
+                    {CLEAR_VARIABLE legacy}
+                    [message]
+                        speaker=Prion
+                        message=_"Correct."
+                    [/message]
+                    [message]
+                        speaker=Krux
+                        message=_"I always knew it. My intuition was right. Acantha has the same...?"
+                    [/message]
+                    [message]
+                        speaker=Bala
+                        message=_"She might not have the same legacy."
+                    [/message]
+                    {VARIABLE quests.asked_about_legacy yes}
+                [/command]
+            [/option]
+            [option]
+                message=_"That is all that I wanted to ask."
+                [command]
+                    [break]
+                        [message]
+                            speaker=Prion
+                            message=_"Fine. Goodbye, son."
+                        [/message]
+                        [message]
+                            speaker=Acanthamoeba
+                            message=_"Goodbye, dad."
+                        [/message]
+                    [/break]
+                [/command]
+            [/option]
+        [/repeating_message]
+        [if]
+            [variable]
+                name=quests.overall
+                not_equals=11
+            [/variable]
+            [and]
                 [variable]
                     name=quests.overall
-                    less_than=11
+                    not_equals=13
                 [/variable]
-                [then]
-                    {MOVE_UNIT id=Agrippa 7 1}
-                    [kill]
-                        id=Agrippa
-                        fire_event=no
-                        animate=no
-                    [/kill]
-                [/then]
-            [/if]
-            {MOVE_UNIT id=Prion 3 1}
-            [kill]
-                id=Prion
-                fire_event=no
-                animate=no
-            [/kill]
-            {MOVE_UNIT id=Bala 1 3}
-            [kill]
-                id=Bala
-                fire_event=no
-                animate=no
-            [/kill]
-            [move_unit]
-                side=1
-                to_x=22
-                to_y=15
-            [/move_unit]
-            [if]
-                [variable]
-                    name=quests.do_talk_about_mansions
-                    equals=yes
-                [/variable]
-                [then]
-                    [message]
-                        speaker=Antipos
-                        message=_"Something new?"
-                    [/message]
-                    [message]
-                        speaker=Krux
-                        message=_"Yes, we have to travel south and deal with Marilyn from House Mansion who started occupying our towns. I shall explain the rest on the road."
-                    [/message]
-                    {CLEAR_VARIABLE quests.do_talk_about_mansions}
-                [/then]
-            [/if]
-            [if]
-                [variable]
-                    name=quests.do_talk_about_elf
-                    equals=yes
-                [/variable]
-                [then]
-                    [message]
-                        speaker=Antipos
-                        message=_"Something new?"
-                    [/message]
-                    [message]
-                        speaker=Krux
-                        message=_"Yes, I was asked to find an elf to marry. Quite odd, I am telling you. I will tell you the rest on the way."
-                    [/message]
-                    {CLEAR_VARIABLE quests.do_talk_about_elf}
-                [/then]
-            [/if]
-        [/then]
-    [/if]
+            [/and]
+            [then]
+                [if]
+                    [variable]
+                        name=quests.overall
+                        less_than=11
+                    [/variable]
+                    [then]
+                        {MOVE_UNIT id=Agrippa 7 1}
+                        [kill]
+                            id=Agrippa
+                            fire_event=no
+                            animate=no
+                        [/kill]
+                    [/then]
+                [/if]
+                {MOVE_UNIT id=Prion 3 1}
+                [kill]
+                    id=Prion
+                    fire_event=no
+                    animate=no
+                [/kill]
+                {MOVE_UNIT id=Bala 1 3}
+                [kill]
+                    id=Bala
+                    fire_event=no
+                    animate=no
+                [/kill]
+                [move_unit]
+                    side=1
+                    to_x=22
+                    to_y=15
+                [/move_unit]
+                [if]
+                    [variable]
+                        name=quests.do_talk_about_mansions
+                        equals=yes
+                    [/variable]
+                    [then]
+                        [message]
+                            speaker=Antipos
+                            message=_"Something new?"
+                        [/message]
+                        [message]
+                            speaker=Krux
+                            message=_"Yes, we have to travel south and deal with Marilyn from House Mansion who started occupying our towns. I shall explain the rest on the road."
+                        [/message]
+                        {CLEAR_VARIABLE quests.do_talk_about_mansions}
+                    [/then]
+                [/if]
+                [if]
+                    [variable]
+                        name=quests.do_talk_about_elf
+                        equals=yes
+                    [/variable]
+                    [then]
+                        [message]
+                            speaker=Antipos
+                            message=_"Something new?"
+                        [/message]
+                        [message]
+                            speaker=Krux
+                            message=_"Yes, I was asked to find an elf to marry. Quite odd, I am telling you. I will tell you the rest on the way."
+                        [/message]
+                        {CLEAR_VARIABLE quests.do_talk_about_elf}
+                    [/then]
+                [/if]
+            [/then]
+        [/if]
     [/event]
 
     [event]
@@ -1527,34 +1530,34 @@
     [/event]
 
 #define BUY_GEM VAR COST
-[show_if]
-    [variable]
-        name=gold
-        greater_than_equal_to={COST}
-    [/variable]
-[/show_if]
-[command]
-    {VARIABLE_OP {VAR} add 1}
-    [gold]
-        side=1
-        amount=-{COST}
-    [/gold]
-[/command]
+    [show_if]
+        [variable]
+            name=gold
+            greater_than_equal_to={COST}
+        [/variable]
+    [/show_if]
+    [command]
+        {VARIABLE_OP {VAR} add 1}
+        [gold]
+            side=1
+            amount=-{COST}
+        [/gold]
+    [/command]
 #enddef
 #define SELL_GEM VAR COST
-[show_if]
-    [variable]
-        name={VAR}
-        greater_than_equal_to=1
-    [/variable]
-[/show_if]
-[command]
-    {VARIABLE_OP {VAR} sub 1}
-    [gold]
-        side=1
-        amount={COST}
-    [/gold]
-[/command]
+    [show_if]
+        [variable]
+            name={VAR}
+            greater_than_equal_to=1
+        [/variable]
+    [/show_if]
+    [command]
+        {VARIABLE_OP {VAR} sub 1}
+        [gold]
+            side=1
+            amount={COST}
+        [/gold]
+    [/command]
 #enddef
 
     [event]
@@ -1570,162 +1573,162 @@
             side=1
             variable=gold
         [/store_gold]
-    [if]
-        [variable]
-            name=quests.strych_told_scam
-            equals=yes
-        [/variable]
-        [then]
-            [message]
-                speaker=Krux
-                message=_"We ought to be careful with this one. He may sell gems of great value, but the price might be great too. We should always verify if we really need what he sells. I do not to explain to my father where have I spent lots of gold."
-            [/message]
-            {VARIABLE quests.strych_told_scam yes}
-        [/then]
-    [/if]
+        [if]
+            [variable]
+                name=quests.strych_told_scam
+                equals=yes
+            [/variable]
+            [then]
+                [message]
+                    speaker=Krux
+                    message=_"We ought to be careful with this one. He may sell gems of great value, but the price might be great too. We should always verify if we really need what he sells. I do not to explain to my father where have I spent lots of gold."
+                [/message]
+                {VARIABLE quests.strych_told_scam yes}
+            [/then]
+        [/if]
         [message]
             speaker=trader2
             message= _ "Hello, I am a trader. I buy and sell magical gems. Would you like to buy some or sell some?"
             [option]
                 message=_"Buy."
                 [command]
-            [while]
-                [not]
-                    [variable]
-                        name=done
-                        equals=yes
-                    [/variable]
-                [/not]
-                [do]
-                    [store_gold]
-                        side=1
-                        variable=gold
-                    [/store_gold]
-                    [message]
-                        speaker=trader2
-                        message= _ "Best prices in this kingdom! Well, best because I am the only seller."
-                        [option]
-                        message=_"Buy an obsidian for 5 gold (currently having $obsidians of them)"
-                        {BUY_GEM obsidians 5}
-                        [/option]
-                        [option]
-                        message=_"Buy a topaz for 9 gold (currently having $topazes of them)"
-                        {BUY_GEM topazes 9}
-                        [/option]
-                        [option]
-                        message=_"Buy an opal for 16 gold (currently having $opals of them)"
-                        {BUY_GEM opals 16}
-                        [/option]
-                        [option]
-                        message=_"Buy a pearl for 30 gold (currently having $pearls of them)"
-                        {BUY_GEM pearls 30}
-                        [/option]
-                        [option]
-                        message=_"Buy a diamond for 55 gold (currently having $diamonds of them)"
-                        {BUY_GEM diamonds 55}
-                        [/option]
-                        [option]
-                        message=_"Buy a ruby for 100 gold (currently having $rubies of them)"
-                        {BUY_GEM rubies 100}
-                        [/option]
-                        [option]
-                        message=_"Buy an emerald for 200 gold (currently having $emeralds of them)"
-                        {BUY_GEM emeralds 200}
-                        [/option]
-                        [option]
-                        message=_"Buy an amethyst for 500 gold (currently having $amethysts of them)"
-                        {BUY_GEM amethysts 500}
-                        [/option]
-                        [option]
-                        message=_"Buy a sapphire for 1000 gold (currently having $sapphires of them)"
-                        {BUY_GEM sapphires 1000}
-                        [/option]
-                        [option]
-                        message=_"Buy a black pearl for 2000 gold (currently having $black_pearls of them)"
-                        {BUY_GEM black_pearls 2000}
-                        [/option]
-                        [option]
-                        message=_"I have bought all I needed."
-                        [command]
-                            {VARIABLE done yes}
-                        [/command]
-                        [/option]
-                    [/message]
-                    {CLEAR_VARIABLE gold}
-                [/do]
-            [/while]
-            {CLEAR_VARIABLE done}
+                    [while]
+                        [not]
+                            [variable]
+                                name=done
+                                equals=yes
+                            [/variable]
+                        [/not]
+                        [do]
+                            [store_gold]
+                                side=1
+                                variable=gold
+                            [/store_gold]
+                            [message]
+                                speaker=trader2
+                                message= _ "Best prices in this kingdom! Well, best because I am the only seller."
+                                [option]
+                                    message=_"Buy an obsidian for 5 gold (currently having $obsidians of them)"
+                                    {BUY_GEM obsidians 5}
+                                [/option]
+                                [option]
+                                    message=_"Buy a topaz for 9 gold (currently having $topazes of them)"
+                                    {BUY_GEM topazes 9}
+                                [/option]
+                                [option]
+                                    message=_"Buy an opal for 16 gold (currently having $opals of them)"
+                                    {BUY_GEM opals 16}
+                                [/option]
+                                [option]
+                                    message=_"Buy a pearl for 30 gold (currently having $pearls of them)"
+                                    {BUY_GEM pearls 30}
+                                [/option]
+                                [option]
+                                    message=_"Buy a diamond for 55 gold (currently having $diamonds of them)"
+                                    {BUY_GEM diamonds 55}
+                                [/option]
+                                [option]
+                                    message=_"Buy a ruby for 100 gold (currently having $rubies of them)"
+                                    {BUY_GEM rubies 100}
+                                [/option]
+                                [option]
+                                    message=_"Buy an emerald for 200 gold (currently having $emeralds of them)"
+                                    {BUY_GEM emeralds 200}
+                                [/option]
+                                [option]
+                                    message=_"Buy an amethyst for 500 gold (currently having $amethysts of them)"
+                                    {BUY_GEM amethysts 500}
+                                [/option]
+                                [option]
+                                    message=_"Buy a sapphire for 1000 gold (currently having $sapphires of them)"
+                                    {BUY_GEM sapphires 1000}
+                                [/option]
+                                [option]
+                                    message=_"Buy a black pearl for 2000 gold (currently having $black_pearls of them)"
+                                    {BUY_GEM black_pearls 2000}
+                                [/option]
+                                [option]
+                                    message=_"I have bought all I needed."
+                                    [command]
+                                        {VARIABLE done yes}
+                                    [/command]
+                                [/option]
+                            [/message]
+                            {CLEAR_VARIABLE gold}
+                        [/do]
+                    [/while]
+                    {CLEAR_VARIABLE done}
                 [/command]
             [/option]
             [option]
                 message=_"Sell."
                 [command]
-            [while]
-                [not]
-                    [variable]
-                        name=done
-                        equals=yes
-                    [/variable]
-                [/not]
-                [do]
-                    [store_gold]
-                        side=1
-                        variable=gold
-                    [/store_gold]
-                    [message]
-                        speaker=trader2
-                        message= _ "I will pay you more than anyone in this kingdom! Well, I don't think anyone else is buying them..."
-                        [option]
-                        message=_"Sell an obsidian for 3 gold (currently having $obsidians of them)"
-                        {SELL_GEM obsidians 3}
-                        [/option]
-                        [option]
-                        message=_"Sell a topaz for 5 gold (currently having $topazes of them)"
-                        {SELL_GEM topazes 5}
-                        [/option]
-                        [option]
-                        message=_"Sell an opal for 8 gold (currently having $opals of them)"
-                        {SELL_GEM opals 8}
-                        [/option]
-                        [option]
-                        message=_"Sell a pearl for 12 gold (currently having $pearls of them)"
-                        {SELL_GEM pearls 12}
-                        [/option]
-                        [option]
-                        message=_"Sell a diamond for 18 gold (currently having $diamonds of them)"
-                        {SELL_GEM diamonds 18}
-                        [/option]
-                        [option]
-                        message=_"Sell a ruby for 25 gold (currently having $rubies of them)"
-                        {SELL_GEM rubies 25}
-                        [/option]
-                        [option]
-                        message=_"Sell an emerald for 40 gold (currently having $emeralds of them)"
-                        {SELL_GEM emeralds 40}
-                        [/option]
-                        [option]
-                        message=_"Sell an amethyst for 60 gold (currently having $amethysts of them)"
-                        {SELL_GEM amethysts 60}
-                        [/option]
-                        [option]
-                        message=_"Sell a sapphire for 90 gold (currently having $sapphires of them)"
-                        {SELL_GEM sapphires 90}
-                        [/option]
-                        [option]
-                        message=_"Sell a black pearl for 150 gold (currently having $black_pearls of them)"
-                        {SELL_GEM black_pearls 150}
-                        [/option]
-                        [option]
-                        message=_"I have sold all I could."
-                        [command]
-                            {VARIABLE done yes}
-                        [/command]
-                        [/option]
-                    [/message]
-                    {CLEAR_VARIABLE gold}
-                [/do]
-            [/while]
-            {CLEAR_VARIABLE done}
+                    [while]
+                        [not]
+                            [variable]
+                                name=done
+                                equals=yes
+                            [/variable]
+                        [/not]
+                        [do]
+                            [store_gold]
+                                side=1
+                                variable=gold
+                            [/store_gold]
+                            [message]
+                                speaker=trader2
+                                message= _ "I will pay you more than anyone in this kingdom! Well, I don't think anyone else is buying them..."
+                                [option]
+                                    message=_"Sell an obsidian for 3 gold (currently having $obsidians of them)"
+                                    {SELL_GEM obsidians 3}
+                                [/option]
+                                [option]
+                                    message=_"Sell a topaz for 5 gold (currently having $topazes of them)"
+                                    {SELL_GEM topazes 5}
+                                [/option]
+                                [option]
+                                    message=_"Sell an opal for 8 gold (currently having $opals of them)"
+                                    {SELL_GEM opals 8}
+                                [/option]
+                                [option]
+                                    message=_"Sell a pearl for 12 gold (currently having $pearls of them)"
+                                    {SELL_GEM pearls 12}
+                                [/option]
+                                [option]
+                                    message=_"Sell a diamond for 18 gold (currently having $diamonds of them)"
+                                    {SELL_GEM diamonds 18}
+                                [/option]
+                                [option]
+                                    message=_"Sell a ruby for 25 gold (currently having $rubies of them)"
+                                    {SELL_GEM rubies 25}
+                                [/option]
+                                [option]
+                                    message=_"Sell an emerald for 40 gold (currently having $emeralds of them)"
+                                    {SELL_GEM emeralds 40}
+                                [/option]
+                                [option]
+                                    message=_"Sell an amethyst for 60 gold (currently having $amethysts of them)"
+                                    {SELL_GEM amethysts 60}
+                                [/option]
+                                [option]
+                                    message=_"Sell a sapphire for 90 gold (currently having $sapphires of them)"
+                                    {SELL_GEM sapphires 90}
+                                [/option]
+                                [option]
+                                    message=_"Sell a black pearl for 150 gold (currently having $black_pearls of them)"
+                                    {SELL_GEM black_pearls 150}
+                                [/option]
+                                [option]
+                                    message=_"I have sold all I could."
+                                    [command]
+                                        {VARIABLE done yes}
+                                    [/command]
+                                [/option]
+                            [/message]
+                            {CLEAR_VARIABLE gold}
+                        [/do]
+                    [/while]
+                    {CLEAR_VARIABLE done}
                 [/command]
             [/option]
             [option]
@@ -1738,7 +1741,6 @@
     [/event]
 #undef SELL_GEM
 #undef BUY_GEM
-    
 
     [event]
         name=moveto

--- a/spinoffs/Affably_Evil/utils/global_events.cfg
+++ b/spinoffs/Affably_Evil/utils/global_events.cfg
@@ -1,4 +1,4 @@
-#textdomain wesnth-affably_evil
+#textdomain wesnoth-affably_evil
 #define REMOVE_FROM_RECALL_LIST NAME
     [for]
         array=party_members

--- a/spinoffs/Affably_Evil/utils/global_events.cfg
+++ b/spinoffs/Affably_Evil/utils/global_events.cfg
@@ -1,23 +1,24 @@
 #textdomain wesnth-affably_evil
 #define REMOVE_FROM_RECALL_LIST NAME
-{FOREACH party_members i}
-    [if]
-        [variable]
-            name=party_members[$i].id
-            equals={NAME}
-        [/variable]
-        [then]
-            {CLEAR_VARIABLE party_members[$i]}
-            {VARIABLE_OP i sub 1}
-        [/then]
-    [/if]
-{NEXT i}
+    [for]
+        array=party_members
+        [do]
+            [if]
+                [variable]
+                    name=party_members[$i].id
+                    equals={NAME}
+                [/variable]
+                [then]
+                    {CLEAR_VARIABLE party_members[$i]}
+                    {VARIABLE_OP i sub 1}
+                [/then]
+            [/if]
+        [/do]
+    [/foreach]
 #enddef
 #define AE_GLOBAL_EVENTS_LIST
 
-
-
-# Deaths
+    # Deaths
 
     [event]
         name=last breath
@@ -92,14 +93,14 @@
             message= _ "I am amazed by your ways of speaking, Krux. I would just say that I am happy that there is one less scoundrel walking this world."
         [/message]
         {VARIABLE chars.judas_died yes}
-    {REMOVE_FROM_RECALL_LIST Judas}
+        {REMOVE_FROM_RECALL_LIST Judas}
     [/event]
 
     [event]
         name=last breath
         [filter]
             id=Hare
-        side=1
+            side=1
         [/filter]
         [message]
             speaker=unit
@@ -122,7 +123,7 @@
             message= _ "I must admit that I was never really fond of this knucklehead. A pity you will not let me give his dying body a kick."
         [/message]
         {VARIABLE chars.hare_died yes}
-    {REMOVE_FROM_RECALL_LIST Hare}
+        {REMOVE_FROM_RECALL_LIST Hare}
     [/event]
 
     [event]
@@ -159,7 +160,7 @@
             message= _ "That emerald is a fake. A very nice fake, but a fake. Nothing worth stealing. I will let his wife have it when I see her."
         [/message]
         {VARIABLE chars.xalzaxx_died yes}
-    {REMOVE_FROM_RECALL_LIST Xalzaxx}
+        {REMOVE_FROM_RECALL_LIST Xalzaxx}
     [/event]
 
     [event]
@@ -192,7 +193,7 @@
             message= _ "What is so interesting about that? He wants to become an undead, like way too many humans want."
         [/message]
         {VARIABLE chars.lucretia_died yes}
-    {REMOVE_FROM_RECALL_LIST Lucretia}
+        {REMOVE_FROM_RECALL_LIST Lucretia}
     [/event]
 
     [event]
@@ -213,14 +214,14 @@
             message= _ "You will..."
         [/message]
         {VARIABLE chars.dwarf_merc_died yes}
-    {REMOVE_FROM_RECALL_LIST dwarf_merc}
+        {REMOVE_FROM_RECALL_LIST dwarf_merc}
     [/event]
 
     [event]
         name=last breath
         [filter]
             id=Fowleri
-        side=1
+            side=1
         [/filter]
         [message]
             speaker=Fowleri
@@ -244,33 +245,36 @@
     [/event]
 
     [event]
-    name=side 1 turn refresh
-    first_time_only=no
-    [store_unit]
-        [filter]
-            side=1
-        [/filter]
-        variable=fixing
-    [/store_unit]
-    {FOREACH fixing i}
-        [if]
-            [variable]
-                name=fixing[$i].variables.hero
-                equals=yes
-            [/variable]
-            [then]
-                {CLEAR_VARIABLE fixing[$i].variables.cant_pick}
-            [/then]
-            [else]
-                {VARIABLE fixing[$i].variables.cant_pick yes}
-            [/else]
-        [/if]
-        [unstore_unit]
-            variable=fixing[$i]
-            find_vacant=no
-        [/unstore_unit]
-    {NEXT i}
-    {CLEAR_VARIABLE fixing}
+        name=side 1 turn refresh
+        first_time_only=no
+        [store_unit]
+            [filter]
+                side=1
+            [/filter]
+            variable=fixing
+        [/store_unit]
+        [for]
+            array=fixing
+            [do]
+                [if]
+                    [variable]
+                        name=fixing[$i].variables.hero
+                        equals=yes
+                    [/variable]
+                    [then]
+                        {CLEAR_VARIABLE fixing[$i].variables.cant_pick}
+                    [/then]
+                    [else]
+                        {VARIABLE fixing[$i].variables.cant_pick yes}
+                    [/else]
+                [/if]
+                [unstore_unit]
+                    variable=fixing[$i]
+                    find_vacant=no
+                [/unstore_unit]
+            [/do]
+        [/for]
+        {CLEAR_VARIABLE fixing}
     [/event]
 
     [event]
@@ -288,107 +292,107 @@
         first_time_only=no
         [message]
             speaker=narrator
-        caption=_"Choose a villain name"
+            caption=_"Choose a villain name"
             message="Choose how the protagonist is to be called."
             image="wesnoth-icon.png"
-        [option]
-        message=_"Krux the Conqueror"
-        [command]
-            {VARIABLE villain_name _"Krux the Conqueror"}
-        [/command]
-        [show_if]
-            [variable]
-                name=names_unlocked.conqueror
-                equals=yes
-            [/variable]
-        [/show_if]
-        [/option]
-        [option]
-        message=_"Krux the Necrophiliac"
-        [command]
-            {VARIABLE villain_name _"Krux the Necrophiliac"}
-        [/command]
-        [show_if]
-            [variable]
-                name=names_unlocked.necrophiliac
-                equals=yes
-            [/variable]
-        [/show_if]
-        [/option]
-        [option]
-        message=_"Krux the Usurper"
-        [command]
-            {VARIABLE villain_name _"Krux the Usurper"}
-        [/command]
-        [show_if]
-            [variable]
-                name=names_unlocked.usurper
-                equals=yes
-            [/variable]
-        [/show_if]
-        [/option]
-        [option]
-        message=_"Krux the Necromancer"
-        [command]
-            {VARIABLE villain_name _"Krux the Necromancer"}
-        [/command]
-        [show_if]
-            [variable]
-                name=names_unlocked.necromancer
-                equals=yes
-            [/variable]
-        [/show_if]
-        [/option]
-        [option]
-        message=_"Krux the Tyrant"
-        [command]
-            {VARIABLE villain_name _"Krux the Tyrant"}
-        [/command]
-        [show_if]
-            [variable]
-                name=names_unlocked.tyrant
-                equals=yes
-            [/variable]
-        [/show_if]
-        [/option]
-        [option]
-        message=_"Krux the Hangman"
-        [command]
-            {VARIABLE villain_name _"Krux the Hangman"}
-        [/command]
-        [/option]
-        [option]
-        message=_"Krux the Incarcerator"
-        [command]
-            {VARIABLE villain_name _"Krux the Incarcerator"}
-        [/command]
-        [/option]
-        [option]
-        message=_"Krux de Rais"
-        [command]
-            {VARIABLE villain_name _"Krux de Rais"}
-        [/command]
-        [/option]
-        [option]
-        message=_"Krux"
-        [command]
-            {VARIABLE villain_name _"Krux"}
-        [/command]
-        [/option]
+            [option]
+                message=_"Krux the Conqueror"
+                [command]
+                    {VARIABLE villain_name _"Krux the Conqueror"}
+                [/command]
+                [show_if]
+                    [variable]
+                        name=names_unlocked.conqueror
+                        equals=yes
+                    [/variable]
+                [/show_if]
+            [/option]
+            [option]
+                message=_"Krux the Necrophiliac"
+                [command]
+                    {VARIABLE villain_name _"Krux the Necrophiliac"}
+                [/command]
+                [show_if]
+                    [variable]
+                        name=names_unlocked.necrophiliac
+                        equals=yes
+                    [/variable]
+                [/show_if]
+            [/option]
+            [option]
+                message=_"Krux the Usurper"
+                [command]
+                    {VARIABLE villain_name _"Krux the Usurper"}
+                [/command]
+                [show_if]
+                    [variable]
+                        name=names_unlocked.usurper
+                        equals=yes
+                    [/variable]
+                [/show_if]
+            [/option]
+            [option]
+                message=_"Krux the Necromancer"
+                [command]
+                    {VARIABLE villain_name _"Krux the Necromancer"}
+                [/command]
+                [show_if]
+                    [variable]
+                        name=names_unlocked.necromancer
+                        equals=yes
+                    [/variable]
+                [/show_if]
+            [/option]
+            [option]
+                message=_"Krux the Tyrant"
+                [command]
+                    {VARIABLE villain_name _"Krux the Tyrant"}
+                [/command]
+                [show_if]
+                    [variable]
+                        name=names_unlocked.tyrant
+                        equals=yes
+                    [/variable]
+                [/show_if]
+            [/option]
+            [option]
+                message=_"Krux the Hangman"
+                [command]
+                    {VARIABLE villain_name _"Krux the Hangman"}
+                [/command]
+            [/option]
+            [option]
+                message=_"Krux the Incarcerator"
+                [command]
+                    {VARIABLE villain_name _"Krux the Incarcerator"}
+                [/command]
+            [/option]
+            [option]
+                message=_"Krux de Rais"
+                [command]
+                    {VARIABLE villain_name _"Krux de Rais"}
+                [/command]
+            [/option]
+            [option]
+                message=_"Krux"
+                [command]
+                    {VARIABLE villain_name _"Krux"}
+                [/command]
+            [/option]
         [/message]
-    [modify_unit]
-        [filter]
-            id=Krux
-        [/filter]
-        name=$villain_name
-    [/modify_unit]
-    {CLEAR_VARIABLE villain_name}
+        [modify_unit]
+            [filter]
+                id=Krux
+            [/filter]
+            name=$villain_name
+        [/modify_unit]
+        {CLEAR_VARIABLE villain_name}
     [/event]
 
 #enddef
 
 #define CHOOSE_VILLAIN_NAME
-[fire_event]
-    name=choose name
-[/fire_event]
+    [fire_event]
+        name=choose name
+    [/fire_event]
 #enddef

--- a/spinoffs/Affably_Evil/utils/utils.cfg
+++ b/spinoffs/Affably_Evil/utils/utils.cfg
@@ -1,4 +1,4 @@
-#textdomain wesnth-affably_evil
+#textdomain wesnoth-affably_evil
 #define AE_GLOBAL_EVENTS_RPG
 
     {DROPS 15 15 (axe,staff,sword,sword,sword,sword,knife,bow,mace) no 2,3,4,5,6,7,8}

--- a/spinoffs/Affably_Evil/utils/utils.cfg
+++ b/spinoffs/Affably_Evil/utils/utils.cfg
@@ -63,157 +63,160 @@
 #enddef
 
 #define AE_RECALL_ALL X Y
-{FOREACH party_members i}
-    [recall]
-        id=$party_members[$i].id
-        x,y={X},{Y}
-        show=no
-    [/recall]
-{NEXT i}
+    [for]
+        array=party_members
+        [do]
+            [recall]
+                id=$party_members[$i].id
+                x,y={X},{Y}
+                show=no
+            [/recall]
+        [/do]
+    [/for]
 #enddef
 
 #define AE_ORIGIN PREVIOUS X Y
-[if]
-    [variable]
-        name=previous_scenario
-        equals={PREVIOUS}
-    [/variable]
-    [then]
-        [teleport]
-            [filter]
-                id=Krux
-            [/filter]
-            x,y={X},{Y}
-            clear_shroud=yes
-        [/teleport]
-        {AE_RECALL_ALL {X} {Y}}
-    [/then]
-[/if]
+    [if]
+        [variable]
+            name=previous_scenario
+            equals={PREVIOUS}
+        [/variable]
+        [then]
+            [teleport]
+                [filter]
+                    id=Krux
+                [/filter]
+                x,y={X},{Y}
+                clear_shroud=yes
+            [/teleport]
+            {AE_RECALL_ALL {X} {Y}}
+        [/then]
+    [/if]
 #enddef
 
 #define AE_TRANSITION RANGE_X RANGE_Y TARGET TARGET_DESC DESC_X DESC_Y
-[label]
-    x,y={DESC_X},{DESC_Y}
-    text={TARGET_DESC}
-    color=255,255,255
-[/label]
-[event]
-    name=moveto
-    first_time_only=no
-    [filter]
-        x,y={RANGE_X},{RANGE_Y}
-        side=1
-        [filter_wml]
-            [variables]
-                hero=yes
-            [/variables]
-        [/filter_wml]
-    [/filter]
-    [message]
-        speaker=narrator
-        caption=_"Area transition"
-        message=_"Do you want to go to " + {TARGET_DESC} + _"?"
-        [option]
-            message=_"Yes, of course."
-            [command]
-                {VARIABLE previous_scenario $current_scenario}
-                {AE_SAVE_GOLD}
-                [endlevel]
-                    result=victory
-                    bonus=no
-                    next_scenario={TARGET}
-                    {NEW_GOLD_CARRYOVER 100}
-                    linger_mode=no
-                    carryover_report=no
-                [/endlevel]
-            [/command]
-        [/option]
-        [option]
-            message=_"No, that is not the place where I wanted to go."
-            [command]
-                [allow_undo]
-                [/allow_undo]
-            [/command]
-        [/option]
-    [/message]
-[/event]
+    [label]
+        x,y={DESC_X},{DESC_Y}
+        text={TARGET_DESC}
+        color=255,255,255
+    [/label]
+    [event]
+        name=moveto
+        first_time_only=no
+        [filter]
+            x,y={RANGE_X},{RANGE_Y}
+            side=1
+            [filter_wml]
+                [variables]
+                    hero=yes
+                [/variables]
+            [/filter_wml]
+        [/filter]
+        [message]
+            speaker=narrator
+            caption=_"Area transition"
+            message=_"Do you want to go to " + {TARGET_DESC} + _"?"
+            [option]
+                message=_"Yes, of course."
+                [command]
+                    {VARIABLE previous_scenario $current_scenario}
+                    {AE_SAVE_GOLD}
+                    [endlevel]
+                        result=victory
+                        bonus=no
+                        next_scenario={TARGET}
+                        {NEW_GOLD_CARRYOVER 100}
+                        linger_mode=no
+                        carryover_report=no
+                    [/endlevel]
+                [/command]
+            [/option]
+            [option]
+                message=_"No, that is not the place where I wanted to go."
+                [command]
+                    [allow_undo]
+                    [/allow_undo]
+                [/command]
+            [/option]
+        [/message]
+    [/event]
 #enddef
 
 #define AE_PLACE_WAYPOINT X Y
-{PLACE_IMAGE scenery/monolith1.png {X} {Y}}
-[event]
-    name=moveto
-    first_time_only=no
-    [filter]
-        side=1
-        x,y={X},{Y}
-        [filter_wml]
-            [variables]
-                hero=yes
-            [/variables]
-        [/filter_wml]
-    [/filter]
-    [filter_condition]
-        [not]
-            [variable]
-                name=disallow_waypoint
-                equals=yes
-            [/variable]
-        [/not]
-    [/filter_condition]
-    [fire_event]
-        name=waypoint
-    [/fire_event]
-[/event]
-[event]
-    name=prestart
-    {AE_ORIGIN waypoint {X} {Y}}
-[/event]
+    {PLACE_IMAGE scenery/monolith1.png {X} {Y}}
+    [event]
+        name=moveto
+        first_time_only=no
+        [filter]
+            side=1
+            x,y={X},{Y}
+            [filter_wml]
+                [variables]
+                    hero=yes
+                [/variables]
+            [/filter_wml]
+        [/filter]
+        [filter_condition]
+            [not]
+                [variable]
+                    name=disallow_waypoint
+                    equals=yes
+                [/variable]
+            [/not]
+        [/filter_condition]
+        [fire_event]
+            name=waypoint
+        [/fire_event]
+    [/event]
+    [event]
+        name=prestart
+        {AE_ORIGIN waypoint {X} {Y}}
+    [/event]
 #enddef
 
 #define SCENARIO_DURATION_VARIABLE NAME VALUE
-{VARIABLE {NAME} {VALUE}}
-[event]
-    name=victory
-    id={NAME}_clear_event
-    {CLEAR_VARIABLE NAME}
-[/event]
+    {VARIABLE {NAME} {VALUE}}
+    [event]
+        name=victory
+        id={NAME}_clear_event
+        {CLEAR_VARIABLE NAME}
+    [/event]
 #enddef
 
 #define AE_SPAWN_UNITS_NO_LEADER SIDE QUANTITY TYPES X Y
-{VARIABLE quantity $party_members.length}
-{VARIABLE_OP quantity multiply {QUANTITY}}
+    {VARIABLE quantity $party_members.length}
+    {VARIABLE_OP quantity multiply {QUANTITY}}
 #ifdef HARD
     {VARIABLE_OP quantity multiply 1.3}
 #endif
 #ifdef EASY
     {VARIABLE_OP quantity divide 1.2}
 #endif
-[while]
-    [variable]
-        name=quantity
-        greater_than=0
-    [/variable]
-    [do]
-        {VARIABLE_OP unit_type rand {TYPES}}
-        {GENERIC_UNIT {SIDE} $unit_type {X} {Y}}
-        {VARIABLE_OP quantity sub 1}
-    [/do]
-[/while]
-{CLEAR_VARIABLE quantity,unit_type}
+    [while]
+        [variable]
+            name=quantity
+            greater_than=0
+        [/variable]
+        [do]
+            {VARIABLE_OP unit_type rand {TYPES}}
+            {GENERIC_UNIT {SIDE} $unit_type {X} {Y}}
+            {VARIABLE_OP quantity sub 1}
+        [/do]
+    [/while]
+    {CLEAR_VARIABLE quantity,unit_type}
 #enddef
 
 #define AE_SPAWN_UNITS SIDE QUANTITY TYPES X Y LEADER_TYPE LEADER_ID
-[unit]
-    side={SIDE}
-    type={LEADER_TYPE}
-    id={LEADER_ID}
-    generate_name=yes
-    x,y={X},{Y}
-    random_traits=yes
-    upkeep=full
-[/unit]
-{AE_SPAWN_UNITS_NO_LEADER {SIDE} {QUANTITY} {TYPES} {X} {Y}}
+    [unit]
+        side={SIDE}
+        type={LEADER_TYPE}
+        id={LEADER_ID}
+        generate_name=yes
+        x,y={X},{Y}
+        random_traits=yes
+        upkeep=full
+    [/unit]
+    {AE_SPAWN_UNITS_NO_LEADER {SIDE} {QUANTITY} {TYPES} {X} {Y}}
 #enddef
 
 #define AE_GOLD_CHEST X Y VAR
@@ -224,9 +227,9 @@
         [/variable]
         [else]
             {PLACE_IMAGE items/chest-plain-closed.png {X} {Y}}
-        [+item]
-        visible_in_fog=no
-        [/item]
+            [+item]
+                visible_in_fog=no
+            [/item]
             [event]
                 name=moveto
                 [filter]
@@ -258,113 +261,119 @@
 #enddef
 
 #define CLEAR_RECALLS
-[kill]
-    side=1
-    [not]
-        [filter_wml]
-            [variables]
-                hero=yes
-            [/variables]
-        [/filter_wml]
-    [/not]
-    fire_event=no
-    animate=no
-[/kill]
+    [kill]
+        side=1
+        [not]
+            [filter_wml]
+                [variables]
+                    hero=yes
+                [/variables]
+            [/filter_wml]
+        [/not]
+        fire_event=no
+        animate=no
+    [/kill]
 #enddef
 
 #define INCARCERATION
     [event]
-    name=attack end
-    first_time_only=no
-    [store_unit]
-        [filter]
-            [not]
-                [filter_wml]
+        name=attack end
+        first_time_only=no
+        [store_unit]
+            [filter]
+                [not]
+                    [filter_wml]
                         [variables]
                             can_incarcerate=yes
                         [/variables]
-                [/filter_wml]
-            [/not]
-        [/filter]
-        variable=possibly
-        kill=no
-    [/store_unit]
-    {FOREACH possibly i}
-        [if]
-            [variable]
-                name=possibly[$i].hitpoints
-                less_than_equal_to=4
-            [/variable]
-            [then]
-                {VARIABLE possibly[$i].variables.can_incarcerate yes}
-                [unstore_unit]
-                    variable=possibly[$i]
-                    find_vacant=no
-                [/unstore_unit]
-            [/then]
-        [/if]
-    {NEXT i}
-    {CLEAR_VARIABLE possibly}
+                    [/filter_wml]
+                [/not]
+            [/filter]
+            variable=possibly
+            kill=no
+        [/store_unit]
+        [for]
+            array=possibly
+            [do]
+                [if]
+                    [variable]
+                        name=possibly[$i].hitpoints
+                        less_than_equal_to=4
+                    [/variable]
+                    [then]
+                        {VARIABLE possibly[$i].variables.can_incarcerate yes}
+                        [unstore_unit]
+                            variable=possibly[$i]
+                            find_vacant=no
+                        [/unstore_unit]
+                    [/then]
+                [/if]
+            [/do]
+        [/for]
+        {CLEAR_VARIABLE possibly}
     [/event]
     [event]
-    name=turn refresh
-    first_time_only=no
-    [store_unit]
-        [filter]
-            [filter_wml]
-                [variables]
-                    can_incarcerate=yes
-                [/variables]
-            [/filter_wml]
-        [/filter]
-        variable=incarceratables
-        kill=no
-    [/store_unit]
-    {FOREACH incarceratables i}
-        [if]
-            [variable]
-                name=incarceratables[$i].hitpoints
-                greater_than=4
-            [/variable]
-            [then]
-                {CLEAR_VARIABLE incarceratables[$i].varaibles.can_incarcerate}
-                [unstore_unit]
-                    variable=incarceratables[$i]
-                    find_vacant=no
-                [/unstore_unit]
-            [/then]
-        [/if]
-    {NEXT i}
-    {CLEAR_VARIABLE incarceratables}
+        name=turn refresh
+        first_time_only=no
+        [store_unit]
+            [filter]
+                [filter_wml]
+                    [variables]
+                        can_incarcerate=yes
+                    [/variables]
+                [/filter_wml]
+            [/filter]
+            variable=incarceratables
+            kill=no
+        [/store_unit]
+        [for]
+            array=incarceratables
+            [do]
+                [if]
+                    [variable]
+                        name=incarceratables[$i].hitpoints
+                        greater_than=4
+                    [/variable]
+                    [then]
+                        {CLEAR_VARIABLE incarceratables[$i].varaibles.can_incarcerate}
+                        [unstore_unit]
+                            variable=incarceratables[$i]
+                            find_vacant=no
+                        [/unstore_unit]
+                    [/then]
+                [/if]
+            [/do]
+        [/for]
+        {CLEAR_VARIABLE incarceratables}
     [/event]
 #enddef
 
 #define AE_SAVE_GOLD
-[store_gold]
-    side=1
-    variable=cash
-[/store_gold]
+    [store_gold]
+        side=1
+        variable=cash
+    [/store_gold]
 #enddef
 #define AE_GET_GOLD
-[store_gold]
-    side=1
-    variable=current_cash
-[/store_gold]
-[gold]
-    side=1
-    amount=$($cash-$current_cash)
-[/gold]
-{CLEAR_VARIABLE current_cash}
+    [store_gold]
+        side=1
+        variable=current_cash
+    [/store_gold]
+    [gold]
+        side=1
+        amount=$($cash-$current_cash)
+    [/gold]
+    {CLEAR_VARIABLE current_cash}
 #enddef
 #define AE_COLLECT_GOLD PERCENTAGE
-[store_gold]
-    side=1
-    variable=current_cash
-[/store_gold]
-{VARIABLE_OP current_cash multiply {PERCENTAGE}}
-{VARIABLE_OP current_cash divide 100}
-{VARIABLE_OP cash add $current_cash}
-{CLEAR_VARIABLE current_cash}
+    [store_gold]
+        side=1
+        variable=current_cash
+    [/store_gold]
+    {VARIABLE_OP current_cash multiply {PERCENTAGE}}
+    {VARIABLE_OP current_cash divide 100}
+    {VARIABLE_OP cash add $current_cash}
+    {CLEAR_VARIABLE current_cash}
 #enddef
 
 #define WEAPON_SPECIAL_IMPRECISE

--- a/spinoffs/Kill_the_King/scenarios/05_Back_in_the_Game.cfg
+++ b/spinoffs/Kill_the_King/scenarios/05_Back_in_the_Game.cfg
@@ -28,7 +28,7 @@
     [side]
         type=Aarron
         id=Aarron
-    name=_"Aarron"
+        name=_"Aarron"
         canrecruit=yes
         side=1
         controller=human
@@ -47,39 +47,39 @@
         team_name=sabotage,law
         user_team_name=_"Unrelated guys"
         ai_algorithm=idle_ai
-    [unit]
-        type=Thug
-        generate_name=yes
-        id=creep
-        random_traits=yes
-        x,y=4,33
-    [/unit]
-    [unit]
-        type=Footpad
-        generate_name=yes
-        id=fan
-        random_traits=yes
-        x,y=3,33
-    [/unit]
-    {GENERIC_UNIT 2 Footpad 3 30}
-    {GENERIC_UNIT 2 Peasant 1 33}
-    {GENERIC_UNIT 2 Peasant 7 29}
-    {GENERIC_UNIT 2 Bandit 9 31}
-    {GENERIC_UNIT 2 Peasant 9 33}
-    {GENERIC_UNIT 2 Peasant 2 32}
-    {GENERIC_UNIT 2 Footpad 6 32}
+        [unit]
+            type=Thug
+            generate_name=yes
+            id=creep
+            random_traits=yes
+            x,y=4,33
+        [/unit]
+        [unit]
+            type=Footpad
+            generate_name=yes
+            id=fan
+            random_traits=yes
+            x,y=3,33
+        [/unit]
+        {GENERIC_UNIT 2 Footpad 3 30}
+        {GENERIC_UNIT 2 Peasant 1 33}
+        {GENERIC_UNIT 2 Peasant 7 29}
+        {GENERIC_UNIT 2 Bandit 9 31}
+        {GENERIC_UNIT 2 Peasant 9 33}
+        {GENERIC_UNIT 2 Peasant 2 32}
+        {GENERIC_UNIT 2 Footpad 6 32}
     [/side]
     [side]
-    type=Duke
-    generate_name=yes
-    canrecruit=yes
-    id=enemy_boss
+        type=Duke
+        generate_name=yes
+        canrecruit=yes
+        id=enemy_boss
         side=3
         team_name=law
         user_team_name=_"Law & Order"
-    recruit=White Mage,Red Mage,Dragoon,Swordsman,Pikeman,Longbowman,Shock Trooper
-    {INCOME 12 14 16}
-    {GOLD 350 450 550}
+        recruit=White Mage,Red Mage,Dragoon,Swordsman,Pikeman,Longbowman,Shock Trooper
+        {INCOME 12 14 16}
+        {GOLD 350 450 550}
         [modifications]
             [object]
                 [effect]
@@ -87,7 +87,7 @@
                     replace="true"
                     [movement_costs]
                         flat={UNREACHABLE}
-            castle={UNREACHABLE}
+                        castle={UNREACHABLE}
                     [/movement_costs]
                 [/effect]
             [/object]
@@ -95,16 +95,16 @@
     [/side]
     {STARTING_VILLAGES 3 20}
     [side]
-    type=Grand Marshal
-    generate_name=yes
-    canrecruit=yes
-    id=enemy1
+        type=Grand Marshal
+        generate_name=yes
+        canrecruit=yes
+        id=enemy1
         side=4
         team_name=law
         user_team_name=_"Law & Order"
-    recruit=Swordsman,Longbowman,Duelist,Shock Trooper,White Mage
-    {INCOME 8 11 14}
-    {GOLD 250 280 310}
+        recruit=Swordsman,Longbowman,Duelist,Shock Trooper,White Mage
+        {INCOME 8 11 14}
+        {GOLD 250 280 310}
         [modifications]
             [object]
                 [effect]
@@ -112,23 +112,23 @@
                     replace="true"
                     [movement_costs]
                         flat={UNREACHABLE}
-            castle={UNREACHABLE}
+                        castle={UNREACHABLE}
                     [/movement_costs]
                 [/effect]
             [/object]
         [/modifications]
     [/side]
     [side]
-    type=General
-    generate_name=yes
-    canrecruit=yes
-    id=enemy2
+        type=General
+        generate_name=yes
+        canrecruit=yes
+        id=enemy2
         side=5
         team_name=law
         user_team_name=_"Law & Order"
-    recruit=Fencer,Heavy Infantryman,Mage,Bowman,Cavalryman
-    {INCOME 8 11 14}
-    {GOLD 160 190 230}
+        recruit=Fencer,Heavy Infantryman,Mage,Bowman,Cavalryman
+        {INCOME 8 11 14}
+        {GOLD 160 190 230}
         [modifications]
             [object]
                 [effect]
@@ -136,7 +136,7 @@
                     replace="true"
                     [movement_costs]
                         flat={UNREACHABLE}
-            castle={UNREACHABLE}
+                        castle={UNREACHABLE}
                     [/movement_costs]
                 [/effect]
             [/object]
@@ -144,112 +144,112 @@
     [/side]
     [event]
         name=prestart
-    [item]
-        x,y=10,29
-        image=scenery/well.png
-    [/item]
-    [item]
-        x,y=39,7
-        image=scenery/well.png
-    [/item]
-    [item]
-        x,y=39,15
-        image=scenery/well.png
-    [/item]
-    [recall]
-        id=Strigo
-        x,y=4,30
-    [/recall]
-    [recall]
-        id=Mortimer
-        x,y=2,31
-    [/recall]
-    [recall]
-        id=Calcy
-        x,y=7,31
-    [/recall]
-    [unit]
-        side=1
-        canrecruit=yes
-        id=Slayerina
-        type=Slayerina
-        name=_"Slayerina"
-        x,y=4,32
-    [/unit]
-    [unit]
-        side=1
-        id=lovelia_ghost
-        type=Faerie Incarnation
-        name=_"Lovelia"
-        x,y=recall,recall
-        [modifications]
-            {TRAIT_UNDEAD}
-            [trait]
-                id=ethereal
-                male_name= _ "ethereal"
-                female_name= _ "female^ethereal"
-                description= _ "Similar to ghosts in many ways"
-                [effect]
-                    apply_to=attack
-                    range=melee
-                    set_type=arcane
-                    increase_damage=-50%
-                    [set_specials]
-                        mode=append
-                        {WEAPON_SPECIAL_DRAIN}
-                    [/set_specials]
-                [/effect]
-                [effect]
-                    apply_to=resistance
-                    replace=true
-                    [resistance]
-                    cold=30
-                    fire=80
-                    blade=60
-                    arcane=100
-                    impact=60
-                    pierce=60
-                    [/resistance]
-                [/effect]
-                [effect]
-                    apply_to=movement_costs
-                    replace=true
-                    [movement_costs]
-                    frozen=1
-                    shallow_water=2
-                    deep_water=2
-                    reef=2
-                    flat=1
-                    castle=1
-                    village=1
-                    forest=1
-                    cave=1
-                    hills=1
-                    forest=1
-                    fungus=1
-                    swamp_water=1
-                    sand=1
-                    unwalkable=1
-                    [/movement_costs]
-                [/effect]
-                [effect]
-                    apply_to=defense
-                    replace=true
-                    [defense]
-                    unwalkable=50
-                    [/defense]
-                [/effect]
-                [effect]
-                    apply_to=hitpoints
-                    increase_total=-40%
-                [/effect]
-                [effect]
-                    apply_to=image_mod
-                    add="~GS()~O(50%)"
-                [/effect]
-            [/trait]
-        [/modifications]
-    [/unit]
+        [item]
+            x,y=10,29
+            image=scenery/well.png
+        [/item]
+        [item]
+            x,y=39,7
+            image=scenery/well.png
+        [/item]
+        [item]
+            x,y=39,15
+            image=scenery/well.png
+        [/item]
+        [recall]
+            id=Strigo
+            x,y=4,30
+        [/recall]
+        [recall]
+            id=Mortimer
+            x,y=2,31
+        [/recall]
+        [recall]
+            id=Calcy
+            x,y=7,31
+        [/recall]
+        [unit]
+            side=1
+            canrecruit=yes
+            id=Slayerina
+            type=Slayerina
+            name=_"Slayerina"
+            x,y=4,32
+        [/unit]
+        [unit]
+            side=1
+            id=lovelia_ghost
+            type=Faerie Incarnation
+            name=_"Lovelia"
+            x,y=recall,recall
+            [modifications]
+                {TRAIT_UNDEAD}
+                [trait]
+                    id=ethereal
+                    male_name= _ "ethereal"
+                    female_name= _ "female^ethereal"
+                    description= _ "Similar to ghosts in many ways"
+                    [effect]
+                        apply_to=attack
+                        range=melee
+                        set_type=arcane
+                        increase_damage=-50%
+                        [set_specials]
+                            mode=append
+                            {WEAPON_SPECIAL_DRAIN}
+                        [/set_specials]
+                    [/effect]
+                    [effect]
+                        apply_to=resistance
+                        replace=true
+                        [resistance]
+                            cold=30
+                            fire=80
+                            blade=60
+                            arcane=100
+                            impact=60
+                            pierce=60
+                        [/resistance]
+                    [/effect]
+                    [effect]
+                        apply_to=movement_costs
+                        replace=true
+                        [movement_costs]
+                            frozen=1
+                            shallow_water=2
+                            deep_water=2
+                            reef=2
+                            flat=1
+                            castle=1
+                            village=1
+                            forest=1
+                            cave=1
+                            hills=1
+                            forest=1
+                            fungus=1
+                            swamp_water=1
+                            sand=1
+                            unwalkable=1
+                        [/movement_costs]
+                    [/effect]
+                    [effect]
+                        apply_to=defense
+                        replace=true
+                        [defense]
+                            unwalkable=50
+                        [/defense]
+                    [/effect]
+                    [effect]
+                        apply_to=hitpoints
+                        increase_total=-40%
+                    [/effect]
+                    [effect]
+                        apply_to=image_mod
+                        add="~GS()~O(50%)"
+                    [/effect]
+                [/trait]
+            [/modifications]
+        [/unit]
         [objectives]
             side=1
             [objective]
@@ -269,49 +269,49 @@
     [/event]
     [event]
         name=start
-    {START_SINGING 4 32}
-    {SING_A_VERSE 4 32 _"For the king!"}
-    {SING_A_VERSE 4 32 _"For the land!"}
-    {SING_A_VERSE 4 32 _"For the folk!"}
-    {SING_A_VERSE 4 32 _"For our ways!"}
+        {START_SINGING 4 32}
+        {SING_A_VERSE 4 32 _"For the king!"}
+        {SING_A_VERSE 4 32 _"For the land!"}
+        {SING_A_VERSE 4 32 _"For the folk!"}
+        {SING_A_VERSE 4 32 _"For our ways!"}
 
-    {SING_A_VERSE 4 32 _"I fight like beast"}
-    {SING_A_VERSE 4 32 _"I will be a hero"}
-    {SING_A_VERSE 4 32 _"But my leader"}
-    {SING_A_VERSE 4 32 _"Is just a big zero"}
+        {SING_A_VERSE 4 32 _"I fight like beast"}
+        {SING_A_VERSE 4 32 _"I will be a hero"}
+        {SING_A_VERSE 4 32 _"But my leader"}
+        {SING_A_VERSE 4 32 _"Is just a big zero"}
 
-    {SING_A_VERSE 5 32 _"GRURHHRGHRAARRGHERRROW!"}
+        {SING_A_VERSE 5 32 _"GRURHHRGHRAARRGHERRROW!"}
 
-    {SING_A_VERSE 4 32 _"The war rages"}
-    {SING_A_VERSE 4 32 _"The rebels run roaring"}
-    {SING_A_VERSE 4 32 _"Right before me"}
-    {SING_A_VERSE 4 32 _"A man is towering"}
-    {SING_A_VERSE 4 32 _"I might win"}
-    {SING_A_VERSE 4 32 _"But I might die"}
-    {SING_A_VERSE 4 32 _"I can win nothing"}
-    {SING_A_VERSE 4 32 _"Why should I try?"}
+        {SING_A_VERSE 4 32 _"The war rages"}
+        {SING_A_VERSE 4 32 _"The rebels run roaring"}
+        {SING_A_VERSE 4 32 _"Right before me"}
+        {SING_A_VERSE 4 32 _"A man is towering"}
+        {SING_A_VERSE 4 32 _"I might win"}
+        {SING_A_VERSE 4 32 _"But I might die"}
+        {SING_A_VERSE 4 32 _"I can win nothing"}
+        {SING_A_VERSE 4 32 _"Why should I try?"}
 
-    {SING_A_VERSE 5 32 _"HRRAAGHTHRUGHAYDRAAAI!"}
+        {SING_A_VERSE 5 32 _"HRRAAGHTHRUGHAYDRAAAI!"}
 
-    {SING_A_VERSE 4 32 _"I THROW AWAY MY SWORD"}
-    {SING_A_VERSE 4 32 _"I JUST NEED MY SHIELD"}
-    {SING_A_VERSE 4 32 _"WHO CARES I GAVE A WORD"}
-    {SING_A_VERSE 4 32 _"IN FILTHY MUD I KNEEL"}
+        {SING_A_VERSE 4 32 _"I THROW AWAY MY SWORD"}
+        {SING_A_VERSE 4 32 _"I JUST NEED MY SHIELD"}
+        {SING_A_VERSE 4 32 _"WHO CARES I GAVE A WORD"}
+        {SING_A_VERSE 4 32 _"IN FILTHY MUD I KNEEL"}
 
-    {SING_A_VERSE 4 32 _"Screw this useless war"}
-    {SING_A_VERSE 4 32 _"I will be a farmer"}
-    {SING_A_VERSE 4 32 _"I can afford some land"}
-    {SING_A_VERSE 4 32 _"When I sell my armour"}
+        {SING_A_VERSE 4 32 _"Screw this useless war"}
+        {SING_A_VERSE 4 32 _"I will be a farmer"}
+        {SING_A_VERSE 4 32 _"I can afford some land"}
+        {SING_A_VERSE 4 32 _"When I sell my armour"}
 
-    {SING_A_VERSE 5 32 _"ERGHARRRGHRAAARHMOORGH!"}
+        {SING_A_VERSE 5 32 _"ERGHARRRGHRAAARHMOORGH!"}
 
-    {SING_A_VERSE 4 32 _"I THROW AWAY MY SWORD"}
-    {SING_A_VERSE 4 32 _"I JUST NEED MY SHIELD"}
-    {SING_A_VERSE 4 32 _"WHO CARES I GAVE A WORD"}
-    {SING_A_VERSE 4 32 _"IN FILTHY MUD I KNEEL"}
-    {STOP_SINGING 4 32}
+        {SING_A_VERSE 4 32 _"I THROW AWAY MY SWORD"}
+        {SING_A_VERSE 4 32 _"I JUST NEED MY SHIELD"}
+        {SING_A_VERSE 4 32 _"WHO CARES I GAVE A WORD"}
+        {SING_A_VERSE 4 32 _"IN FILTHY MUD I KNEEL"}
+        {STOP_SINGING 4 32}
 
-    {KTK_UNLOCK_LYRICS loyalty}
+        {KTK_UNLOCK_LYRICS loyalty}
         [message]
             speaker=creep
             message=_"You are gorgeous, Slayerina!"
@@ -415,123 +415,126 @@
     [/event]
 
     [event]
-    name=enemies defeated
-    [message]
-        speaker=Mortimer
-        message=_"We made it. The gates to Weldyn are ours!"
-    [/message]
-    [message]
-        speaker=Aarron
-        message=_"Let us celebrate this victory. Teaching the locals who we are!"
-    [/message]
-    [message]
-        speaker=Strigo
-        message=_"I am up for it!"
-    [/message]
-    [move_unit]
-        [filter_location]
-            terrain=Kh
-        [/filter_location]
-        to_x,to_y=36,8
-    [/move_unit]
-    {MOVE_UNIT id=Strigo 37 2}
-    {MOVE_UNIT id=Mortimer 35 2}
-    {MOVE_UNIT id=Calcy 39 2}
-    {MOVE_UNIT id=Aarron 40 4}
-    {MOVE_UNIT id=Slayerina 36 5}
-    {GENERIC_UNIT 2 Peasant 33 7}
-    {GENERIC_UNIT 2 Fencer 35 9}
-    {GENERIC_UNIT 2 Thug 39 7}
-    {GENERIC_UNIT 2 Peasant 41 7}
-    {GENERIC_UNIT 2 Footpad 43 6}
-    {GENERIC_UNIT 2 Peasant 38 9}
-    {GENERIC_UNIT 2 Fencer 43 5}
-    {GENERIC_UNIT 2 Spearman 31 2}
-    [unit]
-        side=2
-        id=fan2
-        type=Peasant
-        gender=female
-        generate_name=yes
-        random_traits=yes
-        x,y=40,6
-    [/unit]
-    [unit]
-        type=Fencer
-        x,y=31,5
-        id=king
-        name=_"Incognitty"
-        random_traits=yes
-        [modifications]
-            [object]
-            [effect]
-                apply_to=profile
-                portrait=portraits/king.png
-            [/effect]
-            [/object]
-        [/modifications]
-    [/unit]
-    [message]
-        speaker=Slayerina
-        message=_"Okay, everyone ready? We are celebrating a victory, so we will start with a song about our most usual way of celebrating!"
-    [/message]
-    # Sync their animations
-    [store_unit]
-        [filter]
-            side=1
-            canrecruit=yes
-        [/filter]
-        variable=band
-        kill=yes
-    [/store_unit]
-    {FOREACH band i}
-        [unstore_unit]
-            variable=band[$i]
-        [/unstore_unit]
-    {NEXT i}
-    {CLEAR_VARIABLE band}
-    {START_SINGING 36 5}
-    {SING_A_VERSE 36 5 _"I drink all the time"}
-    {SING_A_VERSE 36 5 _"Ale, wine, beer"}
-    {SING_A_VERSE 36 5 _"I beat all my children"}
-    {SING_A_VERSE 36 5 _"And then you my dear"}
+        name=enemies defeated
+        [message]
+            speaker=Mortimer
+            message=_"We made it. The gates to Weldyn are ours!"
+        [/message]
+        [message]
+            speaker=Aarron
+            message=_"Let us celebrate this victory. Teaching the locals who we are!"
+        [/message]
+        [message]
+            speaker=Strigo
+            message=_"I am up for it!"
+        [/message]
+        [move_unit]
+            [filter_location]
+                terrain=Kh
+            [/filter_location]
+            to_x,to_y=36,8
+        [/move_unit]
+        {MOVE_UNIT id=Strigo 37 2}
+        {MOVE_UNIT id=Mortimer 35 2}
+        {MOVE_UNIT id=Calcy 39 2}
+        {MOVE_UNIT id=Aarron 40 4}
+        {MOVE_UNIT id=Slayerina 36 5}
+        {GENERIC_UNIT 2 Peasant 33 7}
+        {GENERIC_UNIT 2 Fencer 35 9}
+        {GENERIC_UNIT 2 Thug 39 7}
+        {GENERIC_UNIT 2 Peasant 41 7}
+        {GENERIC_UNIT 2 Footpad 43 6}
+        {GENERIC_UNIT 2 Peasant 38 9}
+        {GENERIC_UNIT 2 Fencer 43 5}
+        {GENERIC_UNIT 2 Spearman 31 2}
+        [unit]
+            side=2
+            id=fan2
+            type=Peasant
+            gender=female
+            generate_name=yes
+            random_traits=yes
+            x,y=40,6
+        [/unit]
+        [unit]
+            type=Fencer
+            x,y=31,5
+            id=king
+            name=_"Incognitty"
+            random_traits=yes
+            [modifications]
+                [object]
+                    [effect]
+                        apply_to=profile
+                        portrait=portraits/king.png
+                    [/effect]
+                [/object]
+            [/modifications]
+        [/unit]
+        [message]
+            speaker=Slayerina
+            message=_"Okay, everyone ready? We are celebrating a victory, so we will start with a song about our most usual way of celebrating!"
+        [/message]
+        # Sync their animations
+        [store_unit]
+            [filter]
+                side=1
+                canrecruit=yes
+            [/filter]
+            variable=band
+            kill=yes
+        [/store_unit]
+        [foreach]
+            [do]
+                array=band
+                [unstore_unit]
+                    variable=this_item
+                [/unstore_unit]
+            [/do]
+        [/foreach]
+        {CLEAR_VARIABLE band}
+        {START_SINGING 36 5}
+        {SING_A_VERSE 36 5 _"I drink all the time"}
+        {SING_A_VERSE 36 5 _"Ale, wine, beer"}
+        {SING_A_VERSE 36 5 _"I beat all my children"}
+        {SING_A_VERSE 36 5 _"And then you my dear"}
 
-    {SING_A_VERSE 36 5 _"Now it is a law"}
-    {SING_A_VERSE 36 5 _"Now it is an honour"}
-    {SING_A_VERSE 36 5 _"To shamble every day"}
-    {SING_A_VERSE 36 5 _"Like a drunken sailor"}
+        {SING_A_VERSE 36 5 _"Now it is a law"}
+        {SING_A_VERSE 36 5 _"Now it is an honour"}
+        {SING_A_VERSE 36 5 _"To shamble every day"}
+        {SING_A_VERSE 36 5 _"Like a drunken sailor"}
 
-    {SING_ALL_A_VERSE _"DRINK!"}
-    {SING_ALL_A_VERSE _"DRINK!"}
+        {SING_ALL_A_VERSE _"DRINK!"}
+        {SING_ALL_A_VERSE _"DRINK!"}
 
-    {SING_A_VERSE 36 5 _"King is our idol"}
-    {SING_A_VERSE 36 5 _"Walk in his footsteps"}
-    {SING_A_VERSE 36 5 _"He drowns in alcohol"}
-    {SING_A_VERSE 36 5 _"Do all that he does"}
+        {SING_A_VERSE 36 5 _"King is our idol"}
+        {SING_A_VERSE 36 5 _"Walk in his footsteps"}
+        {SING_A_VERSE 36 5 _"He drowns in alcohol"}
+        {SING_A_VERSE 36 5 _"Do all that he does"}
 
-    {SING_A_VERSE 36 5 _"The greatest example"}
-    {SING_A_VERSE 36 5 _"is our great king"}
-    {SING_A_VERSE 36 5 _"So you must be like him"}
-    {SING_A_VERSE 36 5 _"Have another drink"}
+        {SING_A_VERSE 36 5 _"The greatest example"}
+        {SING_A_VERSE 36 5 _"is our great king"}
+        {SING_A_VERSE 36 5 _"So you must be like him"}
+        {SING_A_VERSE 36 5 _"Have another drink"}
 
-    {SING_ALL_A_VERSE _"DRINK!"}
-    {SING_ALL_A_VERSE _"DRINK!"}
+        {SING_ALL_A_VERSE _"DRINK!"}
+        {SING_ALL_A_VERSE _"DRINK!"}
 
-    {SING_A_VERSE 36 5 _"Agile as a fat bear"}
-    {SING_A_VERSE 36 5 _"Head wrapped in stupour"}
-    {SING_A_VERSE 36 5 _"The only thing we need"}
-    {SING_A_VERSE 36 5 _"Is to get more liquor"}
+        {SING_A_VERSE 36 5 _"Agile as a fat bear"}
+        {SING_A_VERSE 36 5 _"Head wrapped in stupour"}
+        {SING_A_VERSE 36 5 _"The only thing we need"}
+        {SING_A_VERSE 36 5 _"Is to get more liquor"}
 
-    {SING_A_VERSE 36 5 _"Attacking whatever"}
-    {SING_A_VERSE 36 5 _"No feeling of rue"}
-    {SING_A_VERSE 36 5 _"According to law"}
-    {SING_A_VERSE 36 5 _"Now a big virtue"}
+        {SING_A_VERSE 36 5 _"Attacking whatever"}
+        {SING_A_VERSE 36 5 _"No feeling of rue"}
+        {SING_A_VERSE 36 5 _"According to law"}
+        {SING_A_VERSE 36 5 _"Now a big virtue"}
 
-    {SING_ALL_A_VERSE _"DRINK!"}
-    {SING_ALL_A_VERSE _"DRINK!"}
-    {STOP_SINGING 36 5}
+        {SING_ALL_A_VERSE _"DRINK!"}
+        {SING_ALL_A_VERSE _"DRINK!"}
+        {STOP_SINGING 36 5}
 
-    {KTK_UNLOCK_LYRICS drink}
+        {KTK_UNLOCK_LYRICS drink}
         [message]
             speaker=Slayerina
             message=_"I hope you understood the satiric meaning of this song and will not spend all your savings on..."
@@ -544,10 +547,10 @@
             speaker=Aarron
             message=_"That man is so drunk that he understands nothing. He must have drunk several mugs of ale before even arriving here."
         [/message]
-    [message]
-        speaker=Mortimer
-        message=_"We are not here to punish people for drinking. I doubt that ever cured a drunkard. Let us just ignore him!"
-    [/message]
+        [message]
+            speaker=Mortimer
+            message=_"We are not here to punish people for drinking. I doubt that ever cured a drunkard. Let us just ignore him!"
+        [/message]
         [message]
             speaker=king
             message=_"Hey you! Play that great song again so that I coukd enjoy my next... gulp... cough, cough. Argh, cough, cough..."
@@ -556,10 +559,10 @@
             speaker=Aarron
             message=_"He is choking on something!"
         [/message]
-    [message]
-        speaker=Strigo
-        message=_"He was just drinking beer!"
-    [/message]
+        [message]
+            speaker=Strigo
+            message=_"He was just drinking beer!"
+        [/message]
         [message]
             speaker=Slayerina
             message=_"No, there was something floating in the beer. Some decoration."
@@ -572,23 +575,23 @@
             speaker=fan2
             message=_"Somebody do something!"
         [/message]
-    [store_unit]
-        [filter]
+        [store_unit]
+            [filter]
+                id=king
+            [/filter]
+            variable=king
+            kill=no
+        [/store_unit]
+        [kill]
             id=king
-        [/filter]
-        variable=king
-        kill=no
-    [/store_unit]
-    [kill]
-        id=king
-        animate=yes
-    [/kill]
-    [item]
-        x,y=$king.x,$king.y
-        image="units/human-loyalists/fencer-die5.png~RC(magenta>blue)"
-    [/item]
-    {MOVE_UNIT id=Slayerina $king.x $king.y}
-    {CLEAR_VARIABLE king}
+            animate=yes
+        [/kill]
+        [item]
+            x,y=$king.x,$king.y
+            image="units/human-loyalists/fencer-die5.png~RC(magenta>blue)"
+        [/item]
+        {MOVE_UNIT id=Slayerina $king.x $king.y}
+        {CLEAR_VARIABLE king}
         [message]
             speaker=Slayerina
             message=_"It is too late. He is dead. He choked on a small wooden ship decoration that was floating on his ale."
@@ -597,14 +600,14 @@
             speaker=Aarron
             message=_"He seemed oddly familiar to me. Like if I knew him before."
         [/message]
-    [message]
-        speaker=Strigo
-        message=_"I must admit that he was familiar to me too!"
-    [/message]
-    [message]
-        speaker=Mortimer
-        message=_"He looks... very much like our king."
-    [/message]
+        [message]
+            speaker=Strigo
+            message=_"I must admit that he was familiar to me too!"
+        [/message]
+        [message]
+            speaker=Mortimer
+            message=_"He looks... very much like our king."
+        [/message]
         [message]
             speaker=Aarron
             message=_"Yes. This man was the king we fought."
@@ -613,22 +616,22 @@
             speaker=Slayerina
             message=_"This is not as good as we wanted. He will be replaced by his heir and there is no assurance that he will be good. Now we will hardly find an excuse to storm the castle and replace the king."
         [/message]
-    [message]
-        speaker=Mortimer
-        message=_"What is even worse, I had a specific suitable person in mind. Now there will be some mediocre heir. And this king's cause of death will be obscured and the history will speak that he died of disease or in battle."
-    [/message]
+        [message]
+            speaker=Mortimer
+            message=_"What is even worse, I had a specific suitable person in mind. Now there will be some mediocre heir. And this king's cause of death will be obscured and the history will speak that he died of disease or in battle."
+        [/message]
         [message]
             speaker=Aarron
             message=_"Maybe we could push an idea that sons are like their fathers and this one would become a drunkard too for sure."
         [/message]
-    [message]
-        speaker=Strigo
-        message=_"That is bad. We have nothing to fight for!"
-    [/message]
-    [message]
-        speaker=Calcy
-        message=_"Let us just maintain the current state of affairs and march on Weldyn when a good situation arises."
-    [/message]
+        [message]
+            speaker=Strigo
+            message=_"That is bad. We have nothing to fight for!"
+        [/message]
+        [message]
+            speaker=Calcy
+            message=_"Let us just maintain the current state of affairs and march on Weldyn when a good situation arises."
+        [/message]
         [message]
             speaker=Slayerina
             message=_"I guess that is the only thing we can possibly do..."
@@ -637,10 +640,10 @@
             speaker=Aarron
             message=_"It will never arise, our follower musicians will get better than us because we are not a super talented lot and we shall be forgotten... Pfft."
         [/message]
-    [endlevel]
-        result=victory
-        bonus=no
-    [/endlevel]
+        [endlevel]
+            result=victory
+            bonus=no
+        [/endlevel]
     [/event]
 
     [event]

--- a/spinoffs/Kill_the_King/scenarios/05_Back_in_the_Game.cfg
+++ b/spinoffs/Kill_the_King/scenarios/05_Back_in_the_Game.cfg
@@ -485,8 +485,8 @@
             kill=yes
         [/store_unit]
         [foreach]
+            array=band
             [do]
-                array=band
                 [unstore_unit]
                     variable=this_item
                 [/unstore_unit]

--- a/spinoffs/The_Beautiful_Child/scenarios/03_To_Tame_a_Land.cfg
+++ b/spinoffs/The_Beautiful_Child/scenarios/03_To_Tame_a_Land.cfg
@@ -9,7 +9,6 @@
     {DEFAULT_MUSIC_PLAYLIST}
     {DEFAULT_SCHEDULE}
 
-
     [side]
         type=Swordsman
         id=player
@@ -29,78 +28,78 @@
         side=2
         team_name=enemy_1
         user_team_name=_"Black Reavers"
-    {GOLD 200 220 250}
-    income=-2
-    recruit=Thief,Thug,Poacher,Footpad
+        {GOLD 200 220 250}
+        income=-2
+        recruit=Thief,Thug,Poacher,Footpad
         village_gold=3
-    [ai]
-        aggression=1.0
-    [/ai]
+        [ai]
+            aggression=1.0
+        [/ai]
     [/side]
     [side]
         no_leader=yes
         side=3
         team_name=enemy_2
         user_team_name=_"Deathraptors"
-    {GOLD 200 220 250}
-    income=-2
-    village_gold=3
-    recruit=Rogue,Bandit,Trapper,Outlaw
-    [ai]
-        aggression=1.0
-    [/ai]
+        {GOLD 200 220 250}
+        income=-2
+        village_gold=3
+        recruit=Rogue,Bandit,Trapper,Outlaw
+        [ai]
+            aggression=1.0
+        [/ai]
     [/side]
     [side]
         no_leader=yes
         side=4
         team_name=enemy_3
         user_team_name=_"Sons of Vice"
-    {GOLD 200 220 250}
-    income=-2
-    village_gold=3
-    recruit=Thug,Poacher
-    [ai]
-        aggression=1.0
-    [/ai]
+        {GOLD 200 220 250}
+        income=-2
+        village_gold=3
+        recruit=Thug,Poacher
+        [ai]
+            aggression=1.0
+        [/ai]
     [/side]
     [side]
         no_leader=yes
         side=5
         team_name=enemy_alliance
         user_team_name=_"The Bloody Alliance"
-    {GOLD 200 250 300}
-    income=-2
-    village_gold=3
-    recruit=Thief,Thug,Poacher,Footpad
-    [ai]
-        aggression=1.0
-    [/ai]
+        {GOLD 200 250 300}
+        income=-2
+        village_gold=3
+        recruit=Thief,Thug,Poacher,Footpad
+        [ai]
+            aggression=1.0
+        [/ai]
     [/side]
     [side]
         no_leader=yes
         side=6
         team_name=enemy_alliance
         user_team_name=_"The Bloody Alliance"
-    {GOLD 200 250 300}
-    income=-2
-    village_gold=3
-    recruit=Thief,Thug,Poacher,Footpad
-    [ai]
-        aggression=1.0
-    [/ai]
+        {GOLD 200 250 300}
+        income=-2
+        village_gold=3
+        recruit=Thief,Thug,Poacher,Footpad
+        [ai]
+            aggression=1.0
+        [/ai]
     [/side]
     [side]
         no_leader=yes
         side=7
         team_name=enemy_alliance
         user_team_name=_"The Bloody Alliance"
-    {GOLD 300 350 400}
-    income=-2
-    village_gold=3
-    recruit=Thief,Thug,Poacher,Footpad
-    [ai]
-        aggression=1.0
-    [/ai]
+        {GOLD 300 350 400}
+        income=-2
+        village_gold=3
+        recruit=Thief,Thug,Poacher,Footpad
+        [ai]
+            aggression=1.0
+        [/ai]
     [/side]
 
     [event]
@@ -110,24 +109,24 @@
             [objective]
                 description= _ "Defeat or hire all enemy leaders"
                 condition=win
-        [show_if]
-            [not]
-                [variable]
-                    name=met_boss
-                    equals=yes
-                [/variable]
-            [/not]
-        [/show_if]
+                [show_if]
+                    [not]
+                        [variable]
+                            name=met_boss
+                            equals=yes
+                        [/variable]
+                    [/not]
+                [/show_if]
             [/objective]
             [objective]
                 description= _ "Defeat the cult leader"
                 condition=win
-        [show_if]
-            [variable]
-                name=met_boss
-                equals=yes
-            [/variable]
-        [/show_if]
+                [show_if]
+                    [variable]
+                        name=met_boss
+                        equals=yes
+                    [/variable]
+                [/show_if]
             [/objective]
             [objective]
                 description= _ "Death of player, Rimaru or Burke"
@@ -138,34 +137,34 @@
                 condition=lose
             [/objective]
         [/objectives]
-    [recall]
-        id=Rimaru
-        x,y=56,8
-    [/recall]
-    [recall]
-        id=bandit_merc
-        x,y=56,5
-    [/recall]
-    [recall]
-        id=elf_merc
-        x,y=56,10
-    [/recall]
-    [recall]
-        id=faithful_lieutenant
-        x,y=56,4
-    [/recall]
-    [recall]
-        id=she_brother
-        x,y=56,9
-    [/recall]
-    [recall]
-        id=hired_swordsman
-        x,y=57,4
-    [/recall]
-    [recall]
-        id=Burke
-        x,y=57,11
-    [/recall]
+        [recall]
+            id=Rimaru
+            x,y=56,8
+        [/recall]
+        [recall]
+            id=bandit_merc
+            x,y=56,5
+        [/recall]
+        [recall]
+            id=elf_merc
+            x,y=56,10
+        [/recall]
+        [recall]
+            id=faithful_lieutenant
+            x,y=56,4
+        [/recall]
+        [recall]
+            id=she_brother
+            x,y=56,9
+        [/recall]
+        [recall]
+            id=hired_swordsman
+            x,y=57,4
+        [/recall]
+        [recall]
+            id=Burke
+            x,y=57,11
+        [/recall]
     [/event]
 
     [event]
@@ -183,269 +182,267 @@
             speaker=Burke
             message=_"I would not call that alliance, that's hiring. If my information is correct, there are three sovereign clans, Deathraptors, Sons of Vice and Black Reavers. Then, there is an alliance. A really dangerous alliance, they can possibly overpower even our town, but most of the time they're attacking lord Konrad, because he's in more accessible places. They called it Bloody Alliance."
         [/message]
-    [if]
-        [have_unit]
-            id=bandit_merc
-        [/have_unit]
-        [then]
-            [message]
-                speaker=bandit_merc
-                message=_"Amazing names. We should name ourselves Doom Rampage Deathsquad or something like that, they will surely like us more then."
-            [/message]
-        [/then]
-        [else]
-            [message]
-                speaker=Rimaru
-                message=_"They have interesting names. Maybe we could name ourself Doom Rampage Deathsquad or something similar, it will make us look more serious to them."
-            [/message]
-        [/else]
-    [/if]
+        [if]
+            [have_unit]
+                id=bandit_merc
+            [/have_unit]
+            [then]
+                [message]
+                    speaker=bandit_merc
+                    message=_"Amazing names. We should name ourselves Doom Rampage Deathsquad or something like that, they will surely like us more then."
+                [/message]
+            [/then]
+            [else]
+                [message]
+                    speaker=Rimaru
+                    message=_"They have interesting names. Maybe we could name ourself Doom Rampage Deathsquad or something similar, it will make us look more serious to them."
+                [/message]
+            [/else]
+        [/if]
         [message]
             speaker=Burke
             message=_"I think that we will never manage to hire Bloody Alliance, they are worshipping some kind of god of blood and all other bloody things of all kinds. They want to expand their territory, money will not have much effect on them. I am sure that we can't face them ourselves, but if we hire some of the three sovereign clans, or maybe all of them, we will be able to deal with them. But we may make them follow us and direct them at soldiers of Bloody Alliance."
         [/message]
-    [while]
-        [not]
-            [variable]
-                name=done
-                equals=yes
-            [/variable]
-        [/not]
-        [do]
-            [message]
-                speaker=Burke
-                message=_"Is there something else you want to know?"
-                [option]
-                message=_"Where are these bandits?"
-                [command]
-                    [message]
-                        speaker=Burke
-                        message=_"There is a lot of castles everywhere, I know. They are only in some of them, most castles are abandoned. It should be usually one clan per valley, they are hostile to each other and would fight too much if their borders weren't set by nature. Bloody Alliance is behind the valley that seems to be behind all mountains."
-                    [/message]
-                    [message]
-                        speaker=hired_swordsman
-                        message=_"This used to be the kingdom's borderland. Wars against orcs were fought here and the hills were an important defensive line. The orcs are now pushed far away, the southern ones were maybe even extinct, so the fortresses were abandoned and are now handy for bandits."
-                    [/message]
-                [/command]
-                [/option]
-                [option]
-                message=_"How much do you think they will demand for fighting for us?"
-                [command]
-                    [message]
-                        speaker=Rimaru
-                        message=_"Sixty seven gold pieces plus one and half for each dead on their side."
-                    [/message]
-                    [message]
-                        speaker=hired_swordsman
-                        message=_"You're joking or not?"
-                    [/message]
-                    [message]
-                        speaker=Rimaru
-                        message=_"Joking. No idea how much exactly will they want. I expect it to be somewhere between fifty pieces of gold and a hundred pieces of gold."
-                    [/message]
-                    [message]
-                        speaker=Burke
-                        message=_"And we must be careful, we may need to haggle with the price. It may cost us way too much if we simply accept their price, but if we offer less, they may refuse and get offended and refuse any cooperation."
-                    [/message]
-                    [message]
-                        speaker=bandit_merc
-                        message=_"We might consider the old trick to directly suggest a price before they have time to think about it, and the good price will seem huge to a single person and they'll accept. But they may also refuse without giving you time to make a second offer."
-                    [/message]
-                    [message]
-                        speaker=Rimaru
-                        message=_"Make sure that we'll have enough gold with us to hire them before the fight gets too hot. We can't offer promises. We can't offer deals during combat neither."
-                    [/message]
-                [/command]
-                [/option]
-                [option]
-                message=_"What is making that Bloody Alliance so dangerous?"
-                [command]
-                    [message]
-                        speaker=faithful_lieutenant
-                        message=_"They make bloody sacrifices of small children and possess incredibly wicked magic."
-                    [/message]
-                    [message]
-                        speaker=Rimaru
-                        message=_"They are told to be a cult that practices some wicked magic, but those are rumours, calm down."
-                    [/message]
-                    [message]
-                        speaker=Burke
-                        message=_"The problem I fear are their numbers. Several clans united under the flag of Bloody Alliance and now facing their full force is sheer insanity."
-                    [/message]
-                [/command]
-                [/option]
-                [option]
-                message=_"So many forests. Is this an elvish land?"
-                [show_if]
-                    [have_unit]
-                        id=elf_merc
-                    [/have_unit]
-                [/show_if]
-                [command]
-                    [message]
-                        speaker=elf_merc
-                        message=_"Definitely no. Elves live in untainted, pristine nature. This place is far far away from being pristine, there are roads, bridges, buildings, all kinds of human creations."
-                    [/message]
-                [/command]
-                [/option]
-                [option]
-                message=_"Enough planning, let's go!"
-                [command]
-                    {VARIABLE done yes}
-                [/command]
-                [/option]
-            [/message]
-        [/do]
-    [/while]
-    {CLEAR_VARIABLE done}
+        [while]
+            [not]
+                [variable]
+                    name=done
+                    equals=yes
+                [/variable]
+            [/not]
+            [do]
+                [message]
+                    speaker=Burke
+                    message=_"Is there something else you want to know?"
+                    [option]
+                        message=_"Where are these bandits?"
+                        [command]
+                            [message]
+                                speaker=Burke
+                                message=_"There is a lot of castles everywhere, I know. They are only in some of them, most castles are abandoned. It should be usually one clan per valley, they are hostile to each other and would fight too much if their borders weren't set by nature. Bloody Alliance is behind the valley that seems to be behind all mountains."
+                            [/message]
+                            [message]
+                                speaker=hired_swordsman
+                                message=_"This used to be the kingdom's borderland. Wars against orcs were fought here and the hills were an important defensive line. The orcs are now pushed far away, the southern ones were maybe even extinct, so the fortresses were abandoned and are now handy for bandits."
+                            [/message]
+                        [/command]
+                    [/option]
+                    [option]
+                        message=_"How much do you think they will demand for fighting for us?"
+                        [command]
+                            [message]
+                                speaker=Rimaru
+                                message=_"Sixty seven gold pieces plus one and half for each dead on their side."
+                            [/message]
+                            [message]
+                                speaker=hired_swordsman
+                                message=_"You're joking or not?"
+                            [/message]
+                            [message]
+                                speaker=Rimaru
+                                message=_"Joking. No idea how much exactly will they want. I expect it to be somewhere between fifty pieces of gold and a hundred pieces of gold."
+                            [/message]
+                            [message]
+                                speaker=Burke
+                                message=_"And we must be careful, we may need to haggle with the price. It may cost us way too much if we simply accept their price, but if we offer less, they may refuse and get offended and refuse any cooperation."
+                            [/message]
+                            [message]
+                                speaker=bandit_merc
+                                message=_"We might consider the old trick to directly suggest a price before they have time to think about it, and the good price will seem huge to a single person and they'll accept. But they may also refuse without giving you time to make a second offer."
+                            [/message]
+                            [message]
+                                speaker=Rimaru
+                                message=_"Make sure that we'll have enough gold with us to hire them before the fight gets too hot. We can't offer promises. We can't offer deals during combat neither."
+                            [/message]
+                        [/command]
+                    [/option]
+                    [option]
+                        message=_"What is making that Bloody Alliance so dangerous?"
+                        [command]
+                            [message]
+                                speaker=faithful_lieutenant
+                                message=_"They make bloody sacrifices of small children and possess incredibly wicked magic."
+                            [/message]
+                            [message]
+                                speaker=Rimaru
+                                message=_"They are told to be a cult that practices some wicked magic, but those are rumours, calm down."
+                            [/message]
+                            [message]
+                                speaker=Burke
+                                message=_"The problem I fear are their numbers. Several clans united under the flag of Bloody Alliance and now facing their full force is sheer insanity."
+                            [/message]
+                        [/command]
+                    [/option]
+                    [option]
+                        message=_"So many forests. Is this an elvish land?"
+                        [show_if]
+                            [have_unit]
+                                id=elf_merc
+                            [/have_unit]
+                        [/show_if]
+                        [command]
+                            [message]
+                                speaker=elf_merc
+                                message=_"Definitely no. Elves live in untainted, pristine nature. This place is far far away from being pristine, there are roads, bridges, buildings, all kinds of human creations."
+                            [/message]
+                        [/command]
+                    [/option]
+                    [option]
+                        message=_"Enough planning, let's go!"
+                        [command]
+                            {VARIABLE done yes}
+                        [/command]
+                    [/option]
+                [/message]
+            [/do]
+        [/while]
+        {CLEAR_VARIABLE done}
     [/event]
 
     [event]
-    name=moveto
-    [filter]
-        side=1
-        x,y=27-55,13-28
-    [/filter]
-    [unit]
-        side=2
-        x,y=44,26
-        type=Shadowalker
-        canrecruit=yes
-    [/unit]
-    [modify_side]
-        side=2
-        {INCOME 20 25 30}
-    [/modify_side]
-    {GENERIC_UNIT 2 Bandit 42 24}
-    {GENERIC_UNIT 2 Trapper 48 24}
-    {GENERIC_UNIT 2 Fugitive 51 24}
+        name=moveto
+        [filter]
+            side=1
+            x,y=27-55,13-28
+        [/filter]
+        [unit]
+            side=2
+            x,y=44,26
+            type=Shadowalker
+            canrecruit=yes
+        [/unit]
+        [modify_side]
+            side=2
+            {INCOME 20 25 30}
+        [/modify_side]
+        {GENERIC_UNIT 2 Bandit 42 24}
+        {GENERIC_UNIT 2 Trapper 48 24}
+        {GENERIC_UNIT 2 Fugitive 51 24}
     [/event]
 
     [event]
-    name=moveto
-    [filter]
-        side=1
-        x,y=19-46,1-16
-    [/filter]
-    [unit]
-        side=3
-        x,y=26,5
-        type=Highwayman
-        canrecruit=yes
-    [/unit]
-    [modify_side]
-        side=3
-        {INCOME 20 25 30}
-    [/modify_side]
-    {GENERIC_UNIT 3 Rogue 38 6}
-    {GENERIC_UNIT 3 Thief 33 15}
-    {GENERIC_UNIT 3 Assassin 34 2}
+        name=moveto
+        [filter]
+            side=1
+            x,y=19-46,1-16
+        [/filter]
+        [unit]
+            side=3
+            x,y=26,5
+            type=Highwayman
+            canrecruit=yes
+        [/unit]
+        [modify_side]
+            side=3
+            {INCOME 20 25 30}
+        [/modify_side]
+        {GENERIC_UNIT 3 Rogue 38 6}
+        {GENERIC_UNIT 3 Thief 33 15}
+        {GENERIC_UNIT 3 Assassin 34 2}
     [/event]
 
-
     [event]
-    name=moveto
-    [filter]
-        side=1
-        x,y=9-35,21-28
-    [/filter]
-    [unit]
-        side=4
-        x,y=28,26
-        type=Assassin
-        canrecruit=yes
-    [/unit]
-    [modify_side]
-        side=4
-        {INCOME 20 25 30}
-    [/modify_side]
-    {GENERIC_UNIT 3 Bandit 30 22}
-    {GENERIC_UNIT 3 Bandit 35 24}
-    {GENERIC_UNIT 3 Huntsman 15 23}
+        name=moveto
+        [filter]
+            side=1
+            x,y=9-35,21-28
+        [/filter]
+        [unit]
+            side=4
+            x,y=28,26
+            type=Assassin
+            canrecruit=yes
+        [/unit]
+        [modify_side]
+            side=4
+            {INCOME 20 25 30}
+        [/modify_side]
+        {GENERIC_UNIT 3 Bandit 30 22}
+        {GENERIC_UNIT 3 Bandit 35 24}
+        {GENERIC_UNIT 3 Huntsman 15 23}
     [/event]
 
-
     [event]
-    name=moveto
-    [filter]
-        side=1
-        x,y=1-36,1-20
-    [/filter]
-    [unit]
-        side=5
-        x,y=25,18
-        type=Exterminator
-        canrecruit=yes
-    [/unit]
-    [unit]
-        side=6
-        x,y=18,11
-        type=Dark Sorcerer
-        canrecruit=yes
-    [/unit]
-    [unit]
-        side=7
-        x,y=7,13
-        type=Exalted Blackguard
-        id=boss
-        canrecruit=yes
-    [/unit]
-    [modify_side]
-        side=5
-        {INCOME 15 20 25}
-    [/modify_side]
-    [modify_side]
-        side=6
-        {INCOME 15 20 25}
-    [/modify_side]
-    [modify_side]
-        side=7
-        {INCOME 20 25 30}
-    [/modify_side]
-    {GENERIC_UNIT 5 Bandit 27 15}
-    {GENERIC_UNIT 5 Bandit 20 9}
-    {GENERIC_UNIT 6 Huntsman 12 19}
-    {GENERIC_UNIT 6 Huntsman 9 3}
-    {GENERIC_UNIT 7 Huntsman 10 3}
-    {GENERIC_UNIT 7 Huntsman 28 15}
+        name=moveto
+        [filter]
+            side=1
+            x,y=1-36,1-20
+        [/filter]
+        [unit]
+            side=5
+            x,y=25,18
+            type=Exterminator
+            canrecruit=yes
+        [/unit]
+        [unit]
+            side=6
+            x,y=18,11
+            type=Dark Sorcerer
+            canrecruit=yes
+        [/unit]
+        [unit]
+            side=7
+            x,y=7,13
+            type=Exalted Blackguard
+            id=boss
+            canrecruit=yes
+        [/unit]
+        [modify_side]
+            side=5
+            {INCOME 15 20 25}
+        [/modify_side]
+        [modify_side]
+            side=6
+            {INCOME 15 20 25}
+        [/modify_side]
+        [modify_side]
+            side=7
+            {INCOME 20 25 30}
+        [/modify_side]
+        {GENERIC_UNIT 5 Bandit 27 15}
+        {GENERIC_UNIT 5 Bandit 20 9}
+        {GENERIC_UNIT 6 Huntsman 12 19}
+        {GENERIC_UNIT 6 Huntsman 9 3}
+        {GENERIC_UNIT 7 Huntsman 10 3}
+        {GENERIC_UNIT 7 Huntsman 28 15}
     [/event]
 
 #define FIRST_ENCOUNTER_EVENT SIDE
     [event]
-    name=attack
-    [filter]
-        side=1
-    [/filter]
-    [filter_second]
-        side={SIDE}
-    [/filter_second]
-    [fire_event]
-        name=encounter_side_{SIDE}
-        [primary_unit]
-            find_in=unit
-        [/primary_unit]
-        [secondary_unit]
-            find_in=second_unit
-        [/secondary_unit]
-    [/fire_event]
+        name=attack
+        [filter]
+            side=1
+        [/filter]
+        [filter_second]
+            side={SIDE}
+        [/filter_second]
+        [fire_event]
+            name=encounter_side_{SIDE}
+            [primary_unit]
+                find_in=unit
+            [/primary_unit]
+            [secondary_unit]
+                find_in=second_unit
+            [/secondary_unit]
+        [/fire_event]
     [/event]
     [event]
-    name=attack
-    [filter]
-        side={SIDE}
-    [/filter]
-    [filter_second]
-        side=1
-    [/filter_second]
-    [fire_event]
-        name=encounter_side_{SIDE}
-        [primary_unit]
-            find_in=second_unit
-        [/primary_unit]
-        [secondary_unit]
-            find_in=unit
-        [/secondary_unit]
-    [/fire_event]
+        name=attack
+        [filter]
+            side={SIDE}
+        [/filter]
+        [filter_second]
+            side=1
+        [/filter_second]
+        [fire_event]
+            name=encounter_side_{SIDE}
+            [primary_unit]
+                find_in=second_unit
+            [/primary_unit]
+            [secondary_unit]
+                find_in=unit
+            [/secondary_unit]
+        [/fire_event]
     [/event]
 #enddef
 
@@ -456,352 +453,455 @@
 #undef FIRST_ENCOUNTER_EVENT
 
 #define JOIN_PLAYER SIDE COST
-[modify_side]
-    side={SIDE}
-    team_name=good
-[/modify_side]
-[gold]
-    side=1
-    amount=-{COST}
-[/gold]
+    [modify_side]
+        side={SIDE}
+        team_name=good
+    [/modify_side]
+    [gold]
+        side=1
+        amount=-{COST}
+    [/gold]
 #enddef
 
     [event]
-    name=encounter_side_2
-    [store_gold]
-        side=1
-        variable=gold
-    [/store_gold]
+        name=encounter_side_2
+        [store_gold]
+            side=1
+            variable=gold
+        [/store_gold]
         [message]
             speaker=second_unit
             message=_"Hey, you! What do you want from Blood Reavers? To die by our hands, hahaha?"
-        [option]
-        message=_"We want to hire your clan's military services."
-        [command]
-            [message]
-                speaker=second_unit
-                message=_"We like mercenary work too. What do you want to do?"
-            [/message]
-            [message]
-                speaker=unit
-                message=_"We need to clear these mountains of criminal lowlifes who will not cooperate even for money. Especially the Bloody Alliance."
-            [/message]
-            [message]
-                speaker=second_unit
-                message=_"We demand 80 gold for that."
-                [option]
-                message=_"Very well. Here you go."
-                [show_if]
-                    [variable]
-                        name=gold
-                        greater_than_equal_to=80
-                    [/variable]
-                [/show_if]
+            [option]
+                message=_"We want to hire your clan's military services."
                 [command]
-                    {JOIN_PLAYER 2 80}
+                    [message]
+                        speaker=second_unit
+                        message=_"We like mercenary work too. What do you want to do?"
+                    [/message]
+                    [message]
+                        speaker=unit
+                        message=_"We need to clear these mountains of criminal lowlifes who will not cooperate even for money. Especially the Bloody Alliance."
+                    [/message]
+                    [message]
+                        speaker=second_unit
+                        message=_"We demand 80 gold for that."
+                        [option]
+                            message=_"Very well. Here you go."
+                            [show_if]
+                                [variable]
+                                    name=gold
+                                    greater_than_equal_to=80
+                                [/variable]
+                            [/show_if]
+                            [command]
+                                {JOIN_PLAYER 2 80}
+                            [/command]
+                        [/option]
+                        [option]
+                            message=_"We'll pay you only 65 gold for that. The quest is not so hard and we don't have much monetary reserves."
+                            [show_if]
+                                [variable]
+                                    name=gold
+                                    greater_than_equal_to=65
+                                [/variable]
+                            [/show_if]
+                            [command]
+                                [message]
+                                    speaker=second_unit
+                                    message=_"We should have asked for 100 gold, so that we would get 80 gold after this discount you want. But well, it's still profitable."
+                                [/message]
+                                {JOIN_PLAYER 2 65}
+                            [/command]
+                        [/option]
+                        [option]
+                            message=_"We'll pay you only 50 gold for that. We don't need so much from your side and our resources are scarce."
+                            [show_if]
+                                [variable]
+                                    name=gold
+                                    greater_than_equal_to=50
+                                [/variable]
+                            [/show_if]
+                            [command]
+                                [message]
+                                    speaker=second_unit
+                                    message=_"No, no. That's way too little. I can go down to 70, but you will not buy our services for less than that."
+                                    [option]
+                                        message=_"Darn. Here, have the 70 gold."
+                                        [show_if]
+                                            [variable]
+                                                name=gold
+                                                greater_than_equal_to=70
+                                            [/variable]
+                                        [/show_if]
+                                        [command]
+                                            {JOIN_PLAYER 2 70}
+                                        [/command]
+                                    [/option]
+                                    [option]
+                                        message=_"That's too much, we'll just kill you instead, that will be cheaper."
+                                        [command]
+                                        [/command]
+                                    [/option]
+                                [/message]
+                            [/command]
+                        [/option]
+                        [option]
+                            message=_"You demand too much, there will be no alliance!"
+                            [command]
+                            [/command]
+                        [/option]
+                    [/message]
                 [/command]
-                [/option]
-                [option]
-                message=_"We'll pay you only 65 gold for that. The quest is not so hard and we don't have much monetary reserves."
+            [/option]
+            [option]
+                message=_"We'll pay you 60 gold if you and your clan will help us attack other bandit clans, including Bloody Alliance."
                 [show_if]
                     [variable]
                         name=gold
-                        greater_than_equal_to=65
+                        greater_than_equal_to=60
                     [/variable]
                 [/show_if]
                 [command]
                     [message]
                         speaker=second_unit
-                        message=_"We should have asked for 100 gold, so that we would get 80 gold after this discount you want. But well, it's still profitable."
+                        message=_"Excellent. We will help you fight your enemies, we hate Bloody Alliance and other clans are definitely not our friends."
                     [/message]
-                    {JOIN_PLAYER 2 65}
+                    {JOIN_PLAYER 2 60}
                 [/command]
-                [/option]
-                [option]
-                message=_"We'll pay you only 50 gold for that. We don't need so much from your side and our resources are scarce."
-                [show_if]
-                    [variable]
-                        name=gold
-                        greater_than_equal_to=50
-                    [/variable]
-                [/show_if]
-                [command]
-                    [message]
-                        speaker=second_unit
-                        message=_"No, no. That's way too little. I can go down to 70, but you will not buy our services for less than that."
-                        [option]
-                        message=_"Darn. Here, have the 70 gold."
-                        [show_if]
-                            [variable]
-                                name=gold
-                                greater_than_equal_to=70
-                            [/variable]
-                        [/show_if]
-                        [command]
-                            {JOIN_PLAYER 2 70}
-                        [/command]
-                        [/option]
-                        [option]
-                        message=_"That's too much, we'll just kill you instead, that will be cheaper."
-                        [command]
-                        [/command]
-                        [/option]
-                    [/message]
-                [/command]
-                [/option]
-                [option]
-                message=_"You demand too much, there will be no alliance!"
+            [/option]
+            [option]
+                message=_"Die, scamp!"
                 [command]
                 [/command]
-                [/option]
-            [/message]
-        [/command]
-        [/option]
-        [option]
-        message=_"We'll pay you 60 gold if you and your clan will help us attack other bandit clans, including Bloody Alliance."
-        [show_if]
-            [variable]
-                name=gold
-                greater_than_equal_to=60
-            [/variable]
-        [/show_if]
-        [command]
-            [message]
-                speaker=second_unit
-                message=_"Excellent. We will help you fight your enemies, we hate Bloody Alliance and other clans are definitely not our friends."
-            [/message]
-            {JOIN_PLAYER 2 60}
-        [/command]
-        [/option]
-        [option]
-        message=_"Die, scamp!"
-        [command]
-        [/command]
-        [/option]
+            [/option]
         [/message]
-    {CLEAR_VARIABLE gold}
+        {CLEAR_VARIABLE gold}
     [/event]
 
     [event]
-    name=encounter_side_3
-    [store_gold]
-        side=1
-        variable=gold
-    [/store_gold]
+        name=encounter_side_3
+        [store_gold]
+            side=1
+            variable=gold
+        [/store_gold]
         [message]
             speaker=second_unit
             message=_"You! Yes, you, I am talking to you! This land belongs to the Deathraptors. Are you bringing some message or are you coming to get yourself killed?"
-        [option]
-        message=_"Would you like to do some mercenary work?"
-        [command]
-            [message]
-                speaker=second_unit
-                message=_"We prefer working on our own, but all depends on the amount of gold you'll pay. What kind of work do you need?"
-            [/message]
-            [message]
-                speaker=unit
-                message=_"We need help defeating other bandit clans, especially those who don't wish to be hired. And Bloody Alliance."
-            [/message]
-            [message]
-                speaker=second_unit
-                message=_"Bloody Alliance! These malefactors will never cooperate with anybody who will not obey their Blood Lord. How we wish them dead! We demand 100 gold for our support, our warriors are strong and well worth the money."
-                [option]
-                message=_"Very well. Here you go."
-                [show_if]
-                    [variable]
-                        name=gold
-                        greater_than_equal_to=100
-                    [/variable]
-                [/show_if]
-                [command]
-                    {JOIN_PLAYER 3 100}
-                [/command]
-                [/option]
-                [option]
-                message=_"We'll pay you only 80 gold for that, you want them dead too as far as I know."
-                [show_if]
-                    [variable]
-                        name=gold
-                        greater_than_equal_to=80
-                    [/variable]
-                [/show_if]
+            [option]
+                message=_"Would you like to do some mercenary work?"
                 [command]
                     [message]
                         speaker=second_unit
-                        message=_"Yes, but the battle would cost us money and so we need money for the fight. The money you're offering will hardly cover the cost."
+                        message=_"We prefer working on our own, but all depends on the amount of gold you'll pay. What kind of work do you need?"
                     [/message]
                     [message]
                         speaker=unit
-                        message=_"You're lying. You have all that you need, you don't need to buy any new weapons or armour."
+                        message=_"We need help defeating other bandit clans, especially those who don't wish to be hired. And Bloody Alliance."
                     [/message]
                     [message]
                         speaker=second_unit
-                        message=_"It's not true, but I see that I will not get a better deal from you, scrooges."
+                        message=_"Bloody Alliance! These malefactors will never cooperate with anybody who will not obey their Blood Lord. How we wish them dead! We demand 100 gold for our support, our warriors are strong and well worth the money."
+                        [option]
+                            message=_"Very well. Here you go."
+                            [show_if]
+                                [variable]
+                                    name=gold
+                                    greater_than_equal_to=100
+                                [/variable]
+                            [/show_if]
+                            [command]
+                                {JOIN_PLAYER 3 100}
+                            [/command]
+                        [/option]
+                        [option]
+                            message=_"We'll pay you only 80 gold for that, you want them dead too as far as I know."
+                            [show_if]
+                                [variable]
+                                    name=gold
+                                    greater_than_equal_to=80
+                                [/variable]
+                            [/show_if]
+                            [command]
+                                [message]
+                                    speaker=second_unit
+                                    message=_"Yes, but the battle would cost us money and so we need money for the fight. The money you're offering will hardly cover the cost."
+                                [/message]
+                                [message]
+                                    speaker=unit
+                                    message=_"You're lying. You have all that you need, you don't need to buy any new weapons or armour."
+                                [/message]
+                                [message]
+                                    speaker=second_unit
+                                    message=_"It's not true, but I see that I will not get a better deal from you, scrooges."
+                                [/message]
+                                {JOIN_PLAYER 3 80}
+                            [/command]
+                        [/option]
+                        [option]
+                            message=_"We'll pay you only 60 gold for that. We can't afford paying more and you need to kill them too. This is rather a cooperation, as you said."
+                            [show_if]
+                                [variable]
+                                    name=gold
+                                    greater_than_equal_to=60
+                                [/variable]
+                            [/show_if]
+                            [command]
+                                [message]
+                                    speaker=second_unit
+                                    message=_"We are willing to tolerate their presence, you aren't. You must pay us to go to war against them. And more than mere 60 pieces of gold. We want at least 90 pieces of gold. I am already making you a bargain."
+                                    [option]
+                                        message=_"Here, have the 90 gold, we need you."
+                                        [show_if]
+                                            [variable]
+                                                name=gold
+                                                greater_than_equal_to=90
+                                            [/variable]
+                                        [/show_if]
+                                        [command]
+                                            [message]
+                                                speaker=second_unit
+                                                message=_"Very well."
+                                            [/message]
+                                            {JOIN_PLAYER 3 90}
+                                        [/command]
+                                    [/option]
+                                    [option]
+                                        message=_"How about 75 gold, a compromise? If you refuse, we will hang you from a tree. We are numerous and capable of facing a single bandit clan."
+                                        [show_if]
+                                            [variable]
+                                                name=gold
+                                                greater_than_equal_to=75
+                                            [/variable]
+                                        [/show_if]
+                                        [command]
+                                            [message]
+                                                speaker=second_unit
+                                                message=_"75 gold? That is not much, but I guess that it's better than nothing. But if I refuse, your battle will be over. Defeating one clan will not win your war."
+                                            [/message]
+                                            [message]
+                                                speaker=player
+                                                message=_"It will not, but it will scare the rest and make them less aggressive, trying to appease us. And we'll send better trained soldiers here after some time, to defeat you all."
+                                            [/message]
+                                            [message]
+                                                speaker=second_unit
+                                                message=_"Damn, you've won. The best option for us is alliance. Deal."
+                                            [/message]
+                                            {JOIN_PLAYER 3 75}
+                                        [/command]
+                                    [/option]
+                                    [option]
+                                        message=_"I am fed up of your silly haggling, I decided that we will just hang you from a tree."
+                                        [command]
+                                        [/command]
+                                    [/option]
+                                [/message]
+                            [/command]
+                        [/option]
+                        [option]
+                            message=_"We'll pay you 40 gold. That should be enough. You want to kill them anyway."
+                            [show_if]
+                                [variable]
+                                    name=gold
+                                    greater_than_equal_to=40
+                                [/variable]
+                            [/show_if]
+                            [command]
+                                [message]
+                                    speaker=second_unit
+                                    message=_"40 gold? That is an insult! There will be no alliance between us!"
+                                [/message]
+                            [/command]
+                        [/option]
+                        [option]
+                            message=_"100 gold? That's not worth it, we'll just kill you all, filthy scum."
+                            [command]
+                            [/command]
+                        [/option]
                     [/message]
-                    {JOIN_PLAYER 3 80}
                 [/command]
-                [/option]
-                [option]
-                message=_"We'll pay you only 60 gold for that. We can't afford paying more and you need to kill them too. This is rather a cooperation, as you said."
+            [/option]
+            [option]
+                message=_"We'll pay you 75 gold if you and other Deathraptors will help us attack your nearby enemies, including Bloody Alliance."
                 [show_if]
                     [variable]
                         name=gold
-                        greater_than_equal_to=60
+                        greater_than_equal_to=75
                     [/variable]
                 [/show_if]
                 [command]
                     [message]
                         speaker=second_unit
-                        message=_"We are willing to tolerate their presence, you aren't. You must pay us to go to war against them. And more than mere 60 pieces of gold. We want at least 90 pieces of gold. I am already making you a bargain."
-                        [option]
-                        message=_"Here, have the 90 gold, we need you."
-                        [show_if]
-                            [variable]
-                                name=gold
-                                greater_than_equal_to=90
-                            [/variable]
-                        [/show_if]
-                        [command]
-                            [message]
-                                speaker=second_unit
-                                message=_"Very well."
-                            [/message]
-                            {JOIN_PLAYER 3 90}
-                        [/command]
-                        [/option]
-                        [option]
-                        message=_"How about 75 gold, a compromise? If you refuse, we will hang you from a tree. We are numerous and capable of facing a single bandit clan."
-                        [show_if]
-                            [variable]
-                                name=gold
-                                greater_than_equal_to=75
-                            [/variable]
-                        [/show_if]
-                        [command]
-                            [message]
-                                speaker=second_unit
-                                message=_"75 gold? That is not much, but I guess that it's better than nothing. But if I refuse, your battle will be over. Defeating one clan will not win your war."
-                            [/message]
-                            [message]
-                                speaker=player
-                                message=_"It will not, but it will scare the rest and make them less aggressive, trying to appease us. And we'll send better trained soldiers here after some time, to defeat you all."
-                            [/message]
-                            [message]
-                                speaker=second_unit
-                                message=_"Damn, you've won. The best option for us is alliance. Deal."
-                            [/message]
-                            {JOIN_PLAYER 3 75}
-                        [/command]
-                        [/option]
-                        [option]
-                        message=_"I am fed up of your silly haggling, I decided that we will just hang you from a tree."
-                        [command]
-                        [/command]
-                        [/option]
+                        message=_"Well, I must tell that I like your offer."
                     [/message]
+                    {JOIN_PLAYER 3 75}
                 [/command]
-                [/option]
-                [option]
-                message=_"We'll pay you 40 gold. That should be enough. You want to kill them anyway."
-                [show_if]
-                    [variable]
-                        name=gold
-                        greater_than_equal_to=40
-                    [/variable]
-                [/show_if]
-                [command]
-                    [message]
-                        speaker=second_unit
-                        message=_"40 gold? That is an insult! There will be no alliance between us!"
-                    [/message]
-                [/command]
-                [/option]
-                [option]
-                message=_"100 gold? That's not worth it, we'll just kill you all, filthy scum."
+            [/option]
+            [option]
+                message=_"We will kill you, filthy low-born scum!"
                 [command]
                 [/command]
-                [/option]
-            [/message]
-        [/command]
-        [/option]
-        [option]
-        message=_"We'll pay you 75 gold if you and other Deathraptors will help us attack your nearby enemies, including Bloody Alliance."
-        [show_if]
-            [variable]
-                name=gold
-                greater_than_equal_to=75
-            [/variable]
-        [/show_if]
-        [command]
-            [message]
-                speaker=second_unit
-                message=_"Well, I must tell that I like your offer."
-            [/message]
-            {JOIN_PLAYER 3 75}
-        [/command]
-        [/option]
-        [option]
-        message=_"We will kill you, filthy low-born scum!"
-        [command]
-        [/command]
-        [/option]
+            [/option]
         [/message]
-    {CLEAR_VARIABLE gold}
+        {CLEAR_VARIABLE gold}
     [/event]
 
     [event]
-    name=encounter_side_4
-    [store_gold]
-        side=1
-        variable=gold
-    [/store_gold]
-    [message]
-        speaker=second_unit
-        message=_"I'll kill you!"
-    [/message]
-    [message]
-        speaker=unit
-        message=_"Calm down, we are considering some business with you."
-    [/message]
+        name=encounter_side_4
+        [store_gold]
+            side=1
+            variable=gold
+        [/store_gold]
+        [message]
+            speaker=second_unit
+            message=_"I'll kill you!"
+        [/message]
+        [message]
+            speaker=unit
+            message=_"Calm down, we are considering some business with you."
+        [/message]
         [message]
             speaker=second_unit
             message=_"What business?"
-        [option]
-        message=_"I wonder if you would like to be hired as mercenaries. You look like a nice group of people, and if you helped us secure these hills, we might actually knight some of you."
-        [command]
-            [message]
-                speaker=second_unit
-                message=_"The question is, how much are you willing to pay? Some knight titles and some protection from you isn't much. We want 80 gold."
-                [option]
-                message=_"Fine. You can have them."
-                [show_if]
-                    [variable]
-                        name=gold
-                        greater_than_equal_to=80
-                    [/variable]
-                [/show_if]
+            [option]
+                message=_"I wonder if you would like to be hired as mercenaries. You look like a nice group of people, and if you helped us secure these hills, we might actually knight some of you."
                 [command]
-                    {JOIN_PLAYER 3 60}
+                    [message]
+                        speaker=second_unit
+                        message=_"The question is, how much are you willing to pay? Some knight titles and some protection from you isn't much. We want 80 gold."
+                        [option]
+                            message=_"Fine. You can have them."
+                            [show_if]
+                                [variable]
+                                    name=gold
+                                    greater_than_equal_to=80
+                                [/variable]
+                            [/show_if]
+                            [command]
+                                {JOIN_PLAYER 3 60}
+                            [/command]
+                        [/option]
+                        [option]
+                            message=_"As knights, you will be allowed to eat and drink in taverns for free. That is a huge advantage. I'll pay 60 gold, the other benefits should do the rest."
+                            [show_if]
+                                [variable]
+                                    name=gold
+                                    greater_than_equal_to=60
+                                [/variable]
+                            [/show_if]
+                            [command]
+                                [message]
+                                    speaker=second_unit
+                                    message=_"Knights can have food and drink for free? Nice, come on guys, let's help these men and we'll have free booze forever!"
+                                [/message]
+                                {JOIN_PLAYER 4 60}
+                            [/command]
+                        [/option]
+                        [option]
+                            message=_"We'll pay you only 40 gold for that. Knight titles are worth a lot. And peace with us should be priceless for you."
+                            [show_if]
+                                [variable]
+                                    name=gold
+                                    greater_than_equal_to=40
+                                [/variable]
+                            [/show_if]
+                            [command]
+                                [message]
+                                    speaker=second_unit
+                                    message=_"40 gold? That is an insult! We aren't so cheap!"
+                                    [option]
+                                        message=_"Here, have the 80 gold, we need you."
+                                        [show_if]
+                                            [variable]
+                                                name=gold
+                                                greater_than_equal_to=80
+                                            [/variable]
+                                        [/show_if]
+                                        [command]
+                                            [message]
+                                                speaker=second_unit
+                                                message=_"We want more! For apology!"
+                                                [option]
+                                                    message=_"Here, have 90 gold."
+                                                    [show_if]
+                                                        [variable]
+                                                            name=gold
+                                                            greater_than_equal_to=90
+                                                        [/variable]
+                                                    [/show_if]
+                                                    [command]
+                                                        [message]
+                                                            speaker=second_unit
+                                                            message=_"Thank you."
+                                                        [/message]
+                                                        {JOIN_PLAYER 4 90}
+                                                    [/command]
+                                                [/option]
+                                                [option]
+                                                    message=_"No, that will not go."
+                                                    [command]
+                                                        [message]
+                                                            speaker=second_unit
+                                                            message=_"Prepare to die, then!"
+                                                        [/message]
+                                                    [/command]
+                                                [/option]
+                                            [/message]
+                                        [/command]
+                                    [/option]
+                                    [option]
+                                        message=_"We will not pay so much."
+                                        [command]
+                                            [message]
+                                                speaker=second_unit
+                                                message=_"Then you'll die."
+                                            [/message]
+                                        [/command]
+                                    [/option]
+                                [/message]
+                            [/command]
+                        [/option]
+                        [option]
+                            message=_"We'll pay you 40 gold. That should be enough. You want to kill them anyway."
+                            [show_if]
+                                [variable]
+                                    name=gold
+                                    greater_than_equal_to=40
+                                [/variable]
+                            [/show_if]
+                            [command]
+                                [message]
+                                    speaker=unit
+                                    message=_"40 gold? That is an insult! There will be no alliance between us!"
+                                [/message]
+                            [/command]
+                        [/option]
+                        [option]
+                            message=_"100 gold? That's not worth it, we'll just kill you all, filthy scum."
+                            [command]
+                            [/command]
+                        [/option]
+                    [/message]
                 [/command]
-                [/option]
-                [option]
-                message=_"As knights, you will be allowed to eat and drink in taverns for free. That is a huge advantage. I'll pay 60 gold, the other benefits should do the rest."
+            [/option]
+            [option]
+                message=_"We'll pay Sons of Vice 70 gold if they help us fighting our enemies in this land."
                 [show_if]
                     [variable]
                         name=gold
-                        greater_than_equal_to=60
+                        greater_than_equal_to=70
                     [/variable]
                 [/show_if]
                 [command]
                     [message]
                         speaker=second_unit
-                        message=_"Knights can have food and drink for free? Nice, come on guys, let's help these men and we'll have free booze forever!"
+                        message=_"That is not a bad offer, I agree. We'll get rich and return to the society."
                     [/message]
-                    {JOIN_PLAYER 4 60}
+                    {JOIN_PLAYER 4 70}
                 [/command]
-                [/option]
-                [option]
-                message=_"We'll pay you only 40 gold for that. Knight titles are worth a lot. And peace with us should be priceless for you."
+            [/option]
+            [option]
+                message=_"We'll pay you 40 gold to Sons of Vice if they help us defeat the Bloody Alliance and possibly other enemies lurking around."
                 [show_if]
                     [variable]
                         name=gold
@@ -811,178 +911,78 @@
                 [command]
                     [message]
                         speaker=second_unit
-                        message=_"40 gold? That is an insult! We aren't so cheap!"
-                        [option]
-                        message=_"Here, have the 80 gold, we need you."
-                        [show_if]
-                            [variable]
-                                name=gold
-                                greater_than_equal_to=80
-                            [/variable]
-                        [/show_if]
-                        [command]
-                            [message]
-                                speaker=second_unit
-                                message=_"We want more! For apology!"
-                                [option]
-                                message=_"Here, have 90 gold."
-                                [show_if]
-                                    [variable]
-                                        name=gold
-                                        greater_than_equal_to=90
-                                    [/variable]
-                                [/show_if]
-                                [command]
-                                    [message]
-                                        speaker=second_unit
-                                        message=_"Thank you."
-                                    [/message]
-                                    {JOIN_PLAYER 4 90}
-                                [/command]
-                                [/option]
-                                [option]
-                                message=_"No, that will not go."
-                                [command]
-                                    [message]
-                                        speaker=second_unit
-                                        message=_"Prepare to die, then!"
-                                    [/message]
-                                [/command]
-                                [/option]
-                            [/message]
-                        [/command]
-                        [/option]
-                        [option]
-                        message=_"We will not pay so much."
-                        [command]
-                            [message]
-                                speaker=second_unit
-                                message=_"Then you'll die."
-                            [/message]
-                        [/command]
-                        [/option]
+                        message=_"That's not enough! You're offending us by considering us so cheap! There will be no business, only death!"
                     [/message]
                 [/command]
-                [/option]
-                [option]
-                message=_"We'll pay you 40 gold. That should be enough. You want to kill them anyway."
-                [show_if]
-                    [variable]
-                        name=gold
-                        greater_than_equal_to=40
-                    [/variable]
-                [/show_if]
-                [command]
-                    [message]
-                        speaker=unit
-                        message=_"40 gold? That is an insult! There will be no alliance between us!"
-                    [/message]
-                [/command]
-                [/option]
-                [option]
-                message=_"100 gold? That's not worth it, we'll just kill you all, filthy scum."
+            [/option]
+            [option]
+                message=_"No business. Death. Kill that bandit!"
                 [command]
                 [/command]
-                [/option]
-            [/message]
-        [/command]
-        [/option]
-        [option]
-        message=_"We'll pay Sons of Vice 70 gold if they help us fighting our enemies in this land."
-        [show_if]
-            [variable]
-                name=gold
-                greater_than_equal_to=70
-            [/variable]
-        [/show_if]
-        [command]
-            [message]
-                speaker=second_unit
-                message=_"That is not a bad offer, I agree. We'll get rich and return to the society."
-            [/message]
-            {JOIN_PLAYER 4 70}
-        [/command]
-        [/option]
-        [option]
-        message=_"We'll pay you 40 gold to Sons of Vice if they help us defeat the Bloody Alliance and possibly other enemies lurking around."
-        [show_if]
-            [variable]
-                name=gold
-                greater_than_equal_to=40
-            [/variable]
-        [/show_if]
-        [command]
-            [message]
-                speaker=second_unit
-                message=_"That's not enough! You're offending us by considering us so cheap! There will be no business, only death!"
-            [/message]
-        [/command]
-        [/option]
-        [option]
-        message=_"No business. Death. Kill that bandit!"
-        [command]
-        [/command]
-        [/option]
+            [/option]
         [/message]
-    {CLEAR_VARIABLE gold}
+        {CLEAR_VARIABLE gold}
     [/event]
 
 #undef JOIN_PLAYER
 
     [event]
-    name=side 1 turn
-    first_time_only=no
-    id=raining_blood_check
-    {FOREACH blood_rain i}
-        [if]
-            [have_unit]
-                [filter_location]
-                    x,y=$blood_rain[$i].x,$blood_rain[$i].y
-                    radius=1
-                [/filter_location]
-                side=$side_number
-            [/have_unit]
-            [then]
-                [scroll_to]
-                    x,y=$blood_rain[$i].x,$blood_rain[$i].y
-                [/scroll_to]
-                [fire_event]
-                    name=raining blood
-                [/fire_event]
-            [/then]
-        [/if]
-        {CLEAR_VARIABLE rain_side}
-    {NEXT i}
+        name=side 1 turn
+        first_time_only=no
+        id=raining_blood_check
+        [foreach]
+            array=blood_rain
+            [do]
+                [if]
+                    [have_unit]
+                        [filter_location]
+                            x,y=$blood_rain[$i].x,$blood_rain[$i].y
+                            radius=1
+                        [/filter_location]
+                        side=$side_number
+                    [/have_unit]
+                    [then]
+                        [scroll_to]
+                            x,y=$blood_rain[$i].x,$blood_rain[$i].y
+                        [/scroll_to]
+                        [fire_event]
+                            name=raining blood
+                        [/fire_event]
+                    [/then]
+                [/if]
+                {CLEAR_VARIABLE rain_side}
+            [/do]
+        [/foreach]
     [/event]
 
     [event]
-    name=raining blood
-    [remove_event]
-        id=raining_blood_check
-    [/remove_event]
+        name=raining blood
+        [remove_event]
+            id=raining_blood_check
+        [/remove_event]
         [message]
             speaker=Rimaru
             message=_"It's raining blood!"
-        scroll=no
+            scroll=no
         [/message]
-    [if]
-        [have_unit]
-            side=1
-            gender=female
-        [/have_unit]
-        [then]
-            [message]
+        [if]
+            [have_unit]
                 side=1
                 gender=female
-                message=_"Impossible! I had my period a few days ago!"
+            [/have_unit]
+            [then]
+                [message]
+                    side=1
+                    gender=female
+                    message=_"Impossible! I had my period a few days ago!"
                     scroll=no
-            [/message]
-            [message]
-                speaker=Rimaru
-                message=_"Look up there!"
-            [/message]
-        [/then]
-    [/if]
+                [/message]
+                [message]
+                    speaker=Rimaru
+                    message=_"Look up there!"
+                [/message]
+            [/then]
+        [/if]
         [message]
             speaker=Burke
             message=_"This dark cult is much a greater problem that I thought, thanks for the kick you gave me to finally deal with these bandits!"
@@ -991,14 +991,14 @@
             speaker=Rimaru
             message=_"I think that we'll need to lure him away from others so that we could attack him all at once and kill him before it debilitates us!"
         [/message]
-    {VARIABLE met_boss yes}
+        {VARIABLE met_boss yes}
     [/event]
 
     [event]
-    name=die
-    [filter]
-        id=boss
-    [/filter]
+        name=die
+        [filter]
+            id=boss
+        [/filter]
         [message]
             speaker=faithful_lieutenant
             message=_"Victory! The law prevails, as it always does."
@@ -1015,12 +1015,12 @@
             speaker=Burke
             message=_"Thank you for your help in this battle. I am starting to like you, I must confess."
         [/message]
-    {VARIABLE previous_scenario to_tame_a_land}
-    [disallow_recruit]
-        side=1
-        type=Spearman,Bowman,Cavalryman,Sergeant,Heavy Infantryman,Fencer
-    [/disallow_recruit]
-    {CLEAR_VARIABLE met_boss}
+        {VARIABLE previous_scenario to_tame_a_land}
+        [disallow_recruit]
+            side=1
+            type=Spearman,Bowman,Cavalryman,Sergeant,Heavy Infantryman,Fencer
+        [/disallow_recruit]
+        {CLEAR_VARIABLE met_boss}
         [endlevel]
             result=victory
             bonus=yes

--- a/spinoffs/The_Beautiful_Child/scenarios/08_Bringing_the_Light.cfg
+++ b/spinoffs/The_Beautiful_Child/scenarios/08_Bringing_the_Light.cfg
@@ -9,7 +9,6 @@
     {DEFAULT_MUSIC_PLAYLIST}
     {INDOORS}
 
-
     [side]
         type=Swordsman
         id=player
@@ -25,57 +24,63 @@
         fog=yes
     [/side]
     [side]
-    no_leader=yes
+        no_leader=yes
         side=2
         team_name=twisted_good
         user_team_name=_"Twisted Good"
-    village_gold=2
-    income=0
-    {GOLD 500 650 800}
-    recruit=Royal Guard,Halberdier,Iron Mauler,Master Bowman,Cavalier
-    [ai]
-        aggression=1
-    [/ai]
+        village_gold=2
+        income=0
+        {GOLD 500 650 800}
+        recruit=Royal Guard,Halberdier,Iron Mauler,Master Bowman,Cavalier
+        [ai]
+            aggression=1
+        [/ai]
     [/side]
     [side]
-    no_leader=yes
+        no_leader=yes
         side=3
         team_name=twisted_good
         user_team_name=_"Twisted Good"
-    gold=0
-    village_gold=2
-    income=-2
-    gold=0
-    recruit=Royal Guard,Halberdier,Iron Mauler,Master Bowman,Cavalier
-    [ai]
-        aggression=1
-    [/ai]
+        gold=0
+        village_gold=2
+        income=-2
+        gold=0
+        recruit=Royal Guard,Halberdier,Iron Mauler,Master Bowman,Cavalier
+        [ai]
+            aggression=1
+        [/ai]
     [/side]
 
     [event]
         name=prestart
-    [store_locations]
-        terrain=Rrc^Kov
-        variable=mausolea
-    [/store_locations]
-    {FOREACH mausolea i}
-        [item]
-            x,y=$mausolea[$i].x,$mausolea[$i].y
-            image=items/coffin-closed.png
-        [/item]
-    {NEXT i}
-    {CLEAR_VARIABLE mausolea}
-    [store_locations]
-        terrain=Iwr^Kov
-        variable=cairns
-    [/store_locations]
-    {FOREACH cairns i}
-        [item]
-            x,y=$cairns[$i].x,$cairns[$i].y
-            image=scenery/rock-cairn.png
-        [/item]
-    {NEXT i}
-    {CLEAR_VARIABLE cairns}
+        [store_locations]
+            terrain=Rrc^Kov
+            variable=mausolea
+        [/store_locations]
+        [foreach]
+            array=mausolea
+            [do]
+                [item]
+                    x,y=$this_item.x,$this_item.y
+                    image=items/coffin-closed.png
+                [/item]
+            [/do]
+        [/foreach]
+        {CLEAR_VARIABLE mausolea}
+        [store_locations]
+            terrain=Iwr^Kov
+            variable=cairns
+        [/store_locations]
+        [foreach]
+            array=cairns
+            [do]
+                [item]
+                    x,y=$this_item.x,$this_item.y
+                    image=scenery/rock-cairn.png
+                [/item]
+            [/do]
+        [/foreach]
+        {CLEAR_VARIABLE cairns}
         [objectives]
             side=1
             [objective]
@@ -91,44 +96,44 @@
                 condition=lose
             [/objective]
         [/objectives]
-    {TBC_RECALL_ALL 7 37}
-    [unit]
-        id=boss1
-        side=2
-        x,y=12,32
-        type=Prophet
-        canrecruit=yes
-        generate_name=yes
-        random_gender=no
-    [/unit]
-    {TBC_SPAWN_UNITS_NO_LEADER 2 1.3 "Swordsman,Spearman,Javelineer,Pikeman,Halberdier,Duelist,Master at Arms,Royal Guard,Lieutenant,General" 12 32}
-    {GUARDIAN_UNIT 3 Destroyer 46 20}
-    [+unit]
-        max_moves=3
-        id=guardian_1
-    [/unit]
-    {GUARDIAN_UNIT 3 Destroyer 48 20}
-    [+unit]
-        max_moves=3
-        id=guardian_2
-    [/unit]
-    [item]
-        x,y=46,17
-        image=items/altar-evil.png
-    [/item]
+        {TBC_RECALL_ALL 7 37}
+        [unit]
+            id=boss1
+            side=2
+            x,y=12,32
+            type=Prophet
+            canrecruit=yes
+            generate_name=yes
+            random_gender=no
+        [/unit]
+        {TBC_SPAWN_UNITS_NO_LEADER 2 1.3 "Swordsman,Spearman,Javelineer,Pikeman,Halberdier,Duelist,Master at Arms,Royal Guard,Lieutenant,General" 12 32}
+        {GUARDIAN_UNIT 3 Destroyer 46 20}
+        [+unit]
+            max_moves=3
+            id=guardian_1
+        [/unit]
+        {GUARDIAN_UNIT 3 Destroyer 48 20}
+        [+unit]
+            max_moves=3
+            id=guardian_2
+        [/unit]
+        [item]
+            x,y=46,17
+            image=items/altar-evil.png
+        [/item]
         {PLACE_IMAGE items/box.png 41 26}
         {PLACE_IMAGE items/box.png 50 23}
         {PLACE_IMAGE items/box.png 44 18}
-    {TBC_GOLD_CHEST 50 19 ziggurat_level_3_chest}
+        {TBC_GOLD_CHEST 50 19 ziggurat_level_3_chest}
         {PLACE_IMAGE scenery/bookshelf-1.png 24 24}
         {PLACE_IMAGE scenery/bookshelf-2.png 21 22}
         {PLACE_IMAGE scenery/bookshelf-3.png 26 17}
         {PLACE_IMAGE scenery/bookshelf-4.png 21 17}
         {PLACE_IMAGE scenery/bookshelf-5.png 31 18}
-    [item]
-        x,y=45,5
-        image=stairs-spiral.png
-    [/item]
+        [item]
+            x,y=45,5
+            image=stairs-spiral.png
+        [/item]
     [/event]
 
 #define STAIRS RANGE X1 Y1 X2 Y2 EVENT
@@ -154,9 +159,9 @@
             [/have_unit]
             [then]
                 [message]
-    [ai]
-        aggression=1
-    [/ai]
+                    [ai]
+                        aggression=1
+                    [/ai]
                     speaker=Rimaru
                     message=_"We can't go further with enemies behind our back!"
                 [/message]
@@ -225,12 +230,12 @@
     [/event]
 #enddef
 
-{STAIRS 1-21,27-39 18 28 28 38 room2}
-{STAIRS 25-42,28-39 39 30 37 21 room3}
-{STAIRS 37-51,17-27 38 19 33 22 room4}
-{STAIRS 19-33,15-25 20 17 3 15 room5}
-{STAIRS 2-16,7-18 2 13 23 9 room6}
-{STAIRS 22-32,5-13 31 9 45 13 room7}
+    {STAIRS 1-21,27-39 18 28 28 38 room2}
+    {STAIRS 25-42,28-39 39 30 37 21 room3}
+    {STAIRS 37-51,17-27 38 19 33 22 room4}
+    {STAIRS 19-33,15-25 20 17 3 15 room5}
+    {STAIRS 2-16,7-18 2 13 23 9 room6}
+    {STAIRS 22-32,5-13 31 9 45 13 room7}
 
 #undef STAIRS
 
@@ -269,20 +274,20 @@
 
     [event]
         name=room2
-    [gold]
-        side=2
-        {QUANTITY amount 400 550 700}
-    [/gold]
-    [unit]
-        id=boss2
-        side=2
-        x,y=34,33
-        type=Mage of Light
-        canrecruit=yes
-        generate_name=yes
-        random_gender=no
-    [/unit]
-    {TBC_SPAWN_UNITS_NO_LEADER 2 1 "Scythemaster,Swordmaster,Iron Mauler,Master at Arms" 34 33}
+        [gold]
+            side=2
+            {QUANTITY amount 400 550 700}
+        [/gold]
+        [unit]
+            id=boss2
+            side=2
+            x,y=34,33
+            type=Mage of Light
+            canrecruit=yes
+            generate_name=yes
+            random_gender=no
+        [/unit]
+        {TBC_SPAWN_UNITS_NO_LEADER 2 1 "Scythemaster,Swordmaster,Iron Mauler,Master at Arms" 34 33}
         [message]
             speaker=unit
             message=_"More enemies up here."
@@ -291,13 +296,13 @@
 
     [event]
         name=die
-    [filter]
-        id=boss_2
-    [/filter]
+        [filter]
+            id=boss_2
+        [/filter]
         [message]
             speaker=narrator
-        caption=_"???"
-        image=units/unknown-unit.png
+            caption=_"???"
+            image=units/unknown-unit.png
             message=_"Enemies have just shattered resistance on level 2. Assemble resistance on level 4. Repeating, assemble as many defenders as you can on level 4."
         [/message]
         [message]
@@ -308,21 +313,21 @@
 
     [event]
         name=room3
-    [gold]
-        side=2
-        {QUANTITY amount 500 650 700}
-    [/gold]
-    {TBC_SPAWN_UNITS_NO_LEADER 2 0.7 "Halberdier,Royal Guard,Destroyer,Warlock,Champion" 48 24}
+        [gold]
+            side=2
+            {QUANTITY amount 500 650 700}
+        [/gold]
+        {TBC_SPAWN_UNITS_NO_LEADER 2 0.7 "Halberdier,Royal Guard,Destroyer,Warlock,Champion" 48 24}
         [message]
             speaker=narrator
-        caption=_"Voice from afar"
-        image=units/unknown-unit.png
+            caption=_"Voice from afar"
+            image=units/unknown-unit.png
             message=_"The Bringer of Light is speaking. Assemble on level 3, we can't allow to take control of level 3. We cannot even risk having them entered level 4. Assemble on level 3!"
         [/message]
         [message]
             speaker=narrator
-        caption=_"Another voice from afar"
-        image=units/unknown-unit.png
+            caption=_"Another voice from afar"
+            image=units/unknown-unit.png
             message=_"They are already on level 3, they'll be holding their positions there while you'll be coming one by one. Don't listen to the fake Bringer of Light and assemble on level 4, dammit!"
         [/message]
         [message]
@@ -331,15 +336,14 @@
         [/message]
     [/event]
 
-
     [event]
         name=attack
-    [filter]
-        id=guardian_1
-        [or]
-            id=guardian_2
-        [/or]
-    [/filter]
+        [filter]
+            id=guardian_1
+            [or]
+                id=guardian_2
+            [/or]
+        [/filter]
         [message]
             speaker=unit
             message=_"You will never approach the dark altar. Terrible evils can be done with it!"
@@ -351,219 +355,219 @@
         [message]
             speaker=unit
             message=_"We can't trust you. You've done so many evil deeds that nobody would trust you that you'll keep your hands away from this."
-        [option]
-        message=_"If you will stand there and do nothing while we pass around this entrance, we will not approach the altar."
-        [command]
-            {TBC_DIPLOMACY_TRIED}
-            [message]
-                speaker=unit
-                message=_"I will not let you enter the library neither, heretic! There may be even worse secrets!"
-            [/message]
-        [/command]
-        [/option]
-        [option]
-        message=_"You'll have to trust us because attacking us will not prevent us from getting there."
-        [command]
-            [message]
-                speaker=unit
-                message=_"Ha, we can kill many of you!"
-            [/message]
-            [message]
-                speaker=player
-                message=_"Yes, but the rest of us will be free to reach the dark altar. I may promise you that we won't approach it."
-            [/message]
-            [message]
-                speaker=unit
-                message=_"Less heretics, less evil to be done. Kill them all!"
-            [/message]
-        [/command]
-        [/option]
-        [option]
-        message=_"Kill them, I wonder what is that secret they're protecting. It might be even the Child."
-        [command]
-            [message]
-                speaker=unit
-                message=_"We won't fall so easily."
-            [/message]
-        [/command]
-        [/option]
+            [option]
+                message=_"If you will stand there and do nothing while we pass around this entrance, we will not approach the altar."
+                [command]
+                    {TBC_DIPLOMACY_TRIED}
+                    [message]
+                        speaker=unit
+                        message=_"I will not let you enter the library neither, heretic! There may be even worse secrets!"
+                    [/message]
+                [/command]
+            [/option]
+            [option]
+                message=_"You'll have to trust us because attacking us will not prevent us from getting there."
+                [command]
+                    [message]
+                        speaker=unit
+                        message=_"Ha, we can kill many of you!"
+                    [/message]
+                    [message]
+                        speaker=player
+                        message=_"Yes, but the rest of us will be free to reach the dark altar. I may promise you that we won't approach it."
+                    [/message]
+                    [message]
+                        speaker=unit
+                        message=_"Less heretics, less evil to be done. Kill them all!"
+                    [/message]
+                [/command]
+            [/option]
+            [option]
+                message=_"Kill them, I wonder what is that secret they're protecting. It might be even the Child."
+                [command]
+                    [message]
+                        speaker=unit
+                        message=_"We won't fall so easily."
+                    [/message]
+                [/command]
+            [/option]
         [/message]
     [/event]
 
     [event]
         name=moveto
-    [filter]
-        side=1
-        x,y=46,17
-    [/filter]
+        [filter]
+            side=1
+            x,y=46,17
+        [/filter]
         [message]
             speaker=unit
             message=_"The dark altar is here. Demonic bodies are carved on its surface. There seems to be a drainage system on it. I conclude that it has something to do with blood sacrifices and demonic powers. I'll leave it alone, okay?"
-        [option]
-        message=_"Leave it alone. We can't risk summoning demons accidentally."
-        [command]
-            [message]
-                speaker=Rimaru
-                message=_"Wise choice. The demons would most likely kill us all, kidnap the Child and keep it as hostage, destroy the town and it would need armies to stop a squad of them. Supposing that they're as powerful as in the old stories, but that might be wrong."
-            [/message]
-        [/command]
-        [/option]
-        [option]
-        message=_"Nothing can break through the barrier between Inferno and this world, demons can't be simply summoned. This is just some old altar of some dark cult. Let it be, the cult's god is most likely gone."
-        [command]
-            [message]
-                speaker=unit
-                message=_"Okay, I'll leave it alone."
-            [/message]
-            [message]
-                speaker=Rimaru
-                message=_"I will study it later to see what is it and whether I should destroy it or keep it as a decoration."
-            [/message]
-            [message]
-                speaker=faithful_lieutenant
-                message=_"That would be a decoration of the most peculiar kind."
-            [/message]
-        [/command]
-        [/option]
-        [option]
-        message=_"Anything that our enemies fear is our ally. Pour some of your blood on it."
-        [command]
-            [message]
-                speaker=Rimaru
-                message=_"How can you be sure about that? There are some enemies that will turn your current enemies into allies!"
-            [/message]
-            [message]
-                speaker=unit
-                message=_"The blood is already pouring, no time to stop the ritual."
-            [/message]
-            {EARTHQUAKE ()}
-            [message]
-                speaker=Sicaria
-                message=_"Congratulations, you brought here some very grim mojo."
-            [/message]
-            {VARIABLE quests.talked_to_lilith yes}
-            [message]
-                speaker=narrator
-                caption=_"Voice from nowhere"
-                image=portraits/Lilith.png~O(50%)
-                message=_"It has been long since I have not looked upon this world."
-            [/message]
-            [message]
-                speaker=Rimaru
-                message=_"I thought that demons don't exist! Dammit, leave us, foul demon."
-            [/message]
-            [message]
-                speaker=narrator
-                caption=_"Voice from nowhere"
-                image=portraits/Lilith.png~O(50%)
-                message=_"I am not only a random demon. I am Lilith, the Destroyer of Worlds. I am the one who has destroyed the previous world of men."
-            [/message]
-            [message]
-                speaker=Rimaru
-                message=_"Leave us, foul demon."
-            [/message]
-            [message]
-                speaker=narrator
-                caption=_"Lilith"
-                image=portraits/Lilith.png~O(50%)
-                message=_"You should not be so afraid, I cannot enter this place directly... yet. My time will come, but at the moment, we can only talk. Do you want to discuss something? Trying to make a cult to venerate me and receive dark powers in reward?"
-                [option]
-                message=_"No, we only need information. Why did you corrupt the Brothers of Light?"
-                [command]
-                    [message]
-                        speaker=narrator
-                        caption=_"Voice from nowhere"
-                        image=portraits/Lilith.png~O(50%)
-                        message=_"It was not me. I need worshippers, not self-loving hypocrites."
-                    [/message]
-                    [message]
-                        speaker=Sicaria
-                        message=_"Good to know that Lilith isn't behind this. It might be far worse if she was. Of course, only if the Brothers' stories are true."
-                    [/message]
-                    [message]
-                        speaker=narrator
-                        caption=_"Voice from nowhere"
-                        image=portraits/Lilith.png~O(50%)
-                        message=_"Now, when you are done talking, I shall leave you. My time is precious."
-                    [/message]
-                    [message]
-                        speaker=Rimaru
-                        message=_"I am glad that nothing worse happened than a short chat with the arch-enemy of humans, other races, gods, Queen of Darkness and I don't know what else."
-                    [/message]
-                [/command]
-                [/option]
-                [option]
-                message=_"I want power. I need to kill a couple of guys that oppose me."
-                [command]
-                    [message]
-                        speaker=narrator
-                        caption=_"Voice from nowhere"
-                        image=portraits/Lilith.png~O(50%)
-                        message=_"Will you accept me as your god and worship me wholeheartedly and die while pronouncing my name with reverence?"
-                    [/message]
-                    [message]
-                        speaker=Sicaria
-                        message=_"And suffer eternally in Inferno after death? And be hated by any human being? And obey any ill-minded wish this wretch has?"
-                    [/message]
-                    [message]
-                        speaker=player
-                        message=_"That is a bit too much."
-                    [/message]
-                    [message]
-                        speaker=narrator
-                        caption=_"Voice from nowhere"
-                        image=portraits/Lilith.png~O(50%)
-                        message=_"So I shall not help you. I do not bestow gifts on those who are not willing to pay me in return. I shall see you when the day my invasion comes."
-                    [/message]
-                    [message]
-                        speaker=Rimaru
-                        message=_"Phew. I was afraid that this demon would bring doom upon us, but it seems that her influence was too weak."
-                    [/message]
-                [/command]
-                [/option]
-                [option]
-                message=_"Is there a way to kill her, Rimaru?"
+            [option]
+                message=_"Leave it alone. We can't risk summoning demons accidentally."
                 [command]
                     [message]
                         speaker=Rimaru
-                        message=_"No. According to legends, not even our gods could kill her. Furthermore, she is here only through some telepathic nexus, so only mind-affecting spells can harm her. Neither of us knows such spells and I doubt some humans have enough power to damage her that way. Lilith is an extremely potent magician."
+                        message=_"Wise choice. The demons would most likely kill us all, kidnap the Child and keep it as hostage, destroy the town and it would need armies to stop a squad of them. Supposing that they're as powerful as in the old stories, but that might be wrong."
+                    [/message]
+                [/command]
+            [/option]
+            [option]
+                message=_"Nothing can break through the barrier between Inferno and this world, demons can't be simply summoned. This is just some old altar of some dark cult. Let it be, the cult's god is most likely gone."
+                [command]
+                    [message]
+                        speaker=unit
+                        message=_"Okay, I'll leave it alone."
+                    [/message]
+                    [message]
+                        speaker=Rimaru
+                        message=_"I will study it later to see what is it and whether I should destroy it or keep it as a decoration."
+                    [/message]
+                    [message]
+                        speaker=faithful_lieutenant
+                        message=_"That would be a decoration of the most peculiar kind."
+                    [/message]
+                [/command]
+            [/option]
+            [option]
+                message=_"Anything that our enemies fear is our ally. Pour some of your blood on it."
+                [command]
+                    [message]
+                        speaker=Rimaru
+                        message=_"How can you be sure about that? There are some enemies that will turn your current enemies into allies!"
+                    [/message]
+                    [message]
+                        speaker=unit
+                        message=_"The blood is already pouring, no time to stop the ritual."
+                    [/message]
+                    {EARTHQUAKE ()}
+                    [message]
+                        speaker=Sicaria
+                        message=_"Congratulations, you brought here some very grim mojo."
+                    [/message]
+                    {VARIABLE quests.talked_to_lilith yes}
+                    [message]
+                        speaker=narrator
+                        caption=_"Voice from nowhere"
+                        image=portraits/Lilith.png~O(50%)
+                        message=_"It has been long since I have not looked upon this world."
+                    [/message]
+                    [message]
+                        speaker=Rimaru
+                        message=_"I thought that demons don't exist! Dammit, leave us, foul demon."
                     [/message]
                     [message]
                         speaker=narrator
                         caption=_"Voice from nowhere"
                         image=portraits/Lilith.png~O(50%)
-                        message=_"If I was truly here, you would be all dead. Your only luck is that I am not really here. And I am accepting the challenge, if we meet, I will have a duel with you."
+                        message=_"I am not only a random demon. I am Lilith, the Destroyer of Worlds. I am the one who has destroyed the previous world of men."
                     [/message]
                     [message]
-                        speaker=Sicaria
-                        message=_"Well, good that she's gone."
+                        speaker=Rimaru
+                        message=_"Leave us, foul demon."
+                    [/message]
+                    [message]
+                        speaker=narrator
+                        caption=_"Lilith"
+                        image=portraits/Lilith.png~O(50%)
+                        message=_"You should not be so afraid, I cannot enter this place directly... yet. My time will come, but at the moment, we can only talk. Do you want to discuss something? Trying to make a cult to venerate me and receive dark powers in reward?"
+                        [option]
+                            message=_"No, we only need information. Why did you corrupt the Brothers of Light?"
+                            [command]
+                                [message]
+                                    speaker=narrator
+                                    caption=_"Voice from nowhere"
+                                    image=portraits/Lilith.png~O(50%)
+                                    message=_"It was not me. I need worshippers, not self-loving hypocrites."
+                                [/message]
+                                [message]
+                                    speaker=Sicaria
+                                    message=_"Good to know that Lilith isn't behind this. It might be far worse if she was. Of course, only if the Brothers' stories are true."
+                                [/message]
+                                [message]
+                                    speaker=narrator
+                                    caption=_"Voice from nowhere"
+                                    image=portraits/Lilith.png~O(50%)
+                                    message=_"Now, when you are done talking, I shall leave you. My time is precious."
+                                [/message]
+                                [message]
+                                    speaker=Rimaru
+                                    message=_"I am glad that nothing worse happened than a short chat with the arch-enemy of humans, other races, gods, Queen of Darkness and I don't know what else."
+                                [/message]
+                            [/command]
+                        [/option]
+                        [option]
+                            message=_"I want power. I need to kill a couple of guys that oppose me."
+                            [command]
+                                [message]
+                                    speaker=narrator
+                                    caption=_"Voice from nowhere"
+                                    image=portraits/Lilith.png~O(50%)
+                                    message=_"Will you accept me as your god and worship me wholeheartedly and die while pronouncing my name with reverence?"
+                                [/message]
+                                [message]
+                                    speaker=Sicaria
+                                    message=_"And suffer eternally in Inferno after death? And be hated by any human being? And obey any ill-minded wish this wretch has?"
+                                [/message]
+                                [message]
+                                    speaker=player
+                                    message=_"That is a bit too much."
+                                [/message]
+                                [message]
+                                    speaker=narrator
+                                    caption=_"Voice from nowhere"
+                                    image=portraits/Lilith.png~O(50%)
+                                    message=_"So I shall not help you. I do not bestow gifts on those who are not willing to pay me in return. I shall see you when the day my invasion comes."
+                                [/message]
+                                [message]
+                                    speaker=Rimaru
+                                    message=_"Phew. I was afraid that this demon would bring doom upon us, but it seems that her influence was too weak."
+                                [/message]
+                            [/command]
+                        [/option]
+                        [option]
+                            message=_"Is there a way to kill her, Rimaru?"
+                            [command]
+                                [message]
+                                    speaker=Rimaru
+                                    message=_"No. According to legends, not even our gods could kill her. Furthermore, she is here only through some telepathic nexus, so only mind-affecting spells can harm her. Neither of us knows such spells and I doubt some humans have enough power to damage her that way. Lilith is an extremely potent magician."
+                                [/message]
+                                [message]
+                                    speaker=narrator
+                                    caption=_"Voice from nowhere"
+                                    image=portraits/Lilith.png~O(50%)
+                                    message=_"If I was truly here, you would be all dead. Your only luck is that I am not really here. And I am accepting the challenge, if we meet, I will have a duel with you."
+                                [/message]
+                                [message]
+                                    speaker=Sicaria
+                                    message=_"Well, good that she's gone."
+                                [/message]
+                            [/command]
+                        [/option]
                     [/message]
                 [/command]
-                [/option]
-            [/message]
-        [/command]
-        [/option]
+            [/option]
         [/message]
     [/event]
 
     [event]
         name=room4
-    {TBC_SPAWN_UNITS_NO_LEADER 2 1.2 "Halberdier,Royal Guard,Iron Mauler,Mage of Light,Master Bowman" 26 23}
-    {VARIABLE quantity 10}
-    [while]
-        [variable]
-            name=quantity
-            {QUANTITY greater_than 4 2 0}
-        [/variable]
-        [do]
-            {VARIABLE_OP unit_type rand "Duelist,Master at Arms,Iron Mauler,Shock Trooper,Master Bowman,Royal Guard,White Mage,Pikeman"}
-            {GENERIC_UNIT 2 $unit_type 21 20}
-            {GENERIC_UNIT 2 $unit_type 26 20}
-            {GENERIC_UNIT 2 $unit_type 26 23}
-            {VARIABLE_OP quantity sub 1}
-        [/do]
-    [/while]
-    {CLEAR_VARIABLE quantity,unit_type}
+        {TBC_SPAWN_UNITS_NO_LEADER 2 1.2 "Halberdier,Royal Guard,Iron Mauler,Mage of Light,Master Bowman" 26 23}
+        {VARIABLE quantity 10}
+        [while]
+            [variable]
+                name=quantity
+                {QUANTITY greater_than 4 2 0}
+            [/variable]
+            [do]
+                {VARIABLE_OP unit_type rand "Duelist,Master at Arms,Iron Mauler,Shock Trooper,Master Bowman,Royal Guard,White Mage,Pikeman"}
+                {GENERIC_UNIT 2 $unit_type 21 20}
+                {GENERIC_UNIT 2 $unit_type 26 20}
+                {GENERIC_UNIT 2 $unit_type 26 23}
+                {VARIABLE_OP quantity sub 1}
+            [/do]
+        [/while]
+        {CLEAR_VARIABLE quantity,unit_type}
         [message]
             speaker=unit
             message=_"A lot of enemies have assembled here, we need the undead."
@@ -572,404 +576,364 @@
 
     [event]
         name=moveto
-    [filter]
-        side=1
-        x,y=24,24
-    [/filter]
-    [message]
-        speaker=narrator
-        caption=_"Necromancy"
-        image=items/book5.png
-        message=_"The dark art of necromancy brings dread to humans. Slayers of necromancers are revered as heroes, those who fell by the rotting hands of necromancers are pitied and anybody who is seen talking to a necromancer is shunned by the society. Yet, necromancy is not forbidden. Why is that? The answer is that the powers of darkness can be useful. Nothing can stop a group of vicious orcish invaders better than a group of skeletons that feel no pain."
-    [/message]
-    [message]
-        speaker=narrator
-        caption=_"Necromancy"
-        image=items/book5.png
-        message=_"In battles, the good men who defend their homeland from wicked invaders suffer. Being slashed by a sword causes incredible pain and can cause deadly inflammations. Killing a human being, seeing a comrade fall or having closely escaped death can change a man forever, and usually to worse. Employing skeletons and other undead in cases like this is one of the ways how Darkness and Light can help each other. Because of this, the necromantic lore must be preserved."
-    [/message]
-    [message]
-        speaker=narrator
-        caption=_"Necromancy"
-        image=items/book5.png
-        message=_"Yet, necromancy brings huge power that can corrupt people, so it is discouraged to teach it in classes. One master necromancer can teach one or two apprentices and teach them also the morals required to prevent the apprentices from using it to terrorise people for personal enrichment. If there is a class full of students, making sure that they will not misuse it is impossible. That is why most magic schools don't teach necromancy and forbid its use to all of their members."
-    [/message]
-    [message]
-        speaker=narrator
-        caption=_"Necromancy"
-        image=items/book5.png
-        message=_"Here comes the difference between good necromancers and bad necromancers. Good necromancers serve a lord's court, work on bodies of executed criminals, defend their lords from creatures of darkness they know very well, offer squads if suicidal missions are needed and train apprentices who will continue in their craft. Although they are allied with Darkness, their work serves the cause of Good."
-    [/message]
-    [message]
-        speaker=narrator
-        caption=_"Necromancy"
-        image=items/book5.png
-        message=_"Evil necromancers inhabit forgotten graveyards, raise any dead corpse they find, train large groups of apprentices without caring about their morals, murder anyone who wanders around to have more corpses, invade villages for more corpses and apprentices, spreading their dark reign until they become powerful enough to conquer a town and rule it tyrannically until they are defeated. Their crime is not necromancy that is not a crime, their crimes are murder, larceny, desecration of corpses and treason."
-    [/message]
+        [filter]
+            side=1
+            x,y=24,24
+        [/filter]
+        [message]
+            speaker=narrator
+            caption=_"Necromancy"
+            image=items/book5.png
+            message=_"The dark art of necromancy brings dread to humans. Slayers of necromancers are revered as heroes, those who fell by the rotting hands of necromancers are pitied and anybody who is seen talking to a necromancer is shunned by the society. Yet, necromancy is not forbidden. Why is that? The answer is that the powers of darkness can be useful. Nothing can stop a group of vicious orcish invaders better than a group of skeletons that feel no pain."
+        [/message]
+        [message]
+            speaker=narrator
+            caption=_"Necromancy"
+            image=items/book5.png
+            message=_"In battles, the good men who defend their homeland from wicked invaders suffer. Being slashed by a sword causes incredible pain and can cause deadly inflammations. Killing a human being, seeing a comrade fall or having closely escaped death can change a man forever, and usually to worse. Employing skeletons and other undead in cases like this is one of the ways how Darkness and Light can help each other. Because of this, the necromantic lore must be preserved."
+        [/message]
+        [message]
+            speaker=narrator
+            caption=_"Necromancy"
+            image=items/book5.png
+            message=_"Yet, necromancy brings huge power that can corrupt people, so it is discouraged to teach it in classes. One master necromancer can teach one or two apprentices and teach them also the morals required to prevent the apprentices from using it to terrorise people for personal enrichment. If there is a class full of students, making sure that they will not misuse it is impossible. That is why most magic schools don't teach necromancy and forbid its use to all of their members."
+        [/message]
+        [message]
+            speaker=narrator
+            caption=_"Necromancy"
+            image=items/book5.png
+            message=_"Here comes the difference between good necromancers and bad necromancers. Good necromancers serve a lord's court, work on bodies of executed criminals, defend their lords from creatures of darkness they know very well, offer squads if suicidal missions are needed and train apprentices who will continue in their craft. Although they are allied with Darkness, their work serves the cause of Good."
+        [/message]
+        [message]
+            speaker=narrator
+            caption=_"Necromancy"
+            image=items/book5.png
+            message=_"Evil necromancers inhabit forgotten graveyards, raise any dead corpse they find, train large groups of apprentices without caring about their morals, murder anyone who wanders around to have more corpses, invade villages for more corpses and apprentices, spreading their dark reign until they become powerful enough to conquer a town and rule it tyrannically until they are defeated. Their crime is not necromancy that is not a crime, their crimes are murder, larceny, desecration of corpses and treason."
+        [/message]
     [/event]
 
     [event]
         name=moveto
-    [filter]
-        side=1
-        x,y=21,22
-    [/filter]
-    [message]
-        speaker=narrator
-        caption=_"Our Gods and Other Gods"
-        image=items/book1.png
-        message=_"By definition, any being that is worshipped by others is a god. We worship our gods, but other nations may worship some other gods or even other humans. Worship gives power to the worshipped entity, but it needs hundreds of worshippers to give power that is comparable to the power of a powerful wizard. We call an entity a god if it is the most known for being a god, Lilith is a demon and is worshipped at times, but she is primarily known as a demon so we call her a demon."
-    [/message]
-    [message]
-        speaker=narrator
-        caption=_"Our Gods and Other Gods"
-        image=items/book1.png
-        message=_"Numerous humans are known to have successfully built cults to worship themselves. Those who are known for being humans who eventually obtained divine powers from worship are still considered humans by many. Those who walk the world with divine powers and their human past is long forgotten are gods, even though they are still known to originate from humans their powers cannot match the powers of our gods. It is possible that some of them come from before the creation of our world."
-    [/message]
-    [message]
-        speaker=narrator
-        caption=_"Our Gods and Other Gods"
-        image=items/book1.png
-        message=_"These other gods have not created our world, they cannot save us from the worst of perils. Some may call them false gods. But it might be good to reserve the term false gods for those who pretend to be our gods, and do not use it on those who turn the faith from our gods themselves because they think that they can be better. Many of these lesser gods are not evil; they merely think that our gods are not worth worship for neglecting their duties or that they do not exist and want to replace them."
-    [/message]
-    [message]
-        speaker=narrator
-        caption=_"Our Gods and Other Gods"
-        image=items/book1.png
-        message=_"Because of that, pagans are not inherently evil. They may deny our gods, but that does not make them evil, only misguided. Their gods are not to be hated neither, because they are trying to follow the steps of our gods. However, because our gods lose power when they lose worshippers, pagans should be turned if it can be done peacefully. Another case are pagans who worship evil gods and selfish gods, they should better be killed than left to continue their dark worship."
-    [/message]
+        [filter]
+            side=1
+            x,y=21,22
+        [/filter]
+        [message]
+            speaker=narrator
+            caption=_"Our Gods and Other Gods"
+            image=items/book1.png
+            message=_"By definition, any being that is worshipped by others is a god. We worship our gods, but other nations may worship some other gods or even other humans. Worship gives power to the worshipped entity, but it needs hundreds of worshippers to give power that is comparable to the power of a powerful wizard. We call an entity a god if it is the most known for being a god, Lilith is a demon and is worshipped at times, but she is primarily known as a demon so we call her a demon."
+        [/message]
+        [message]
+            speaker=narrator
+            caption=_"Our Gods and Other Gods"
+            image=items/book1.png
+            message=_"Numerous humans are known to have successfully built cults to worship themselves. Those who are known for being humans who eventually obtained divine powers from worship are still considered humans by many. Those who walk the world with divine powers and their human past is long forgotten are gods, even though they are still known to originate from humans their powers cannot match the powers of our gods. It is possible that some of them come from before the creation of our world."
+        [/message]
+        [message]
+            speaker=narrator
+            caption=_"Our Gods and Other Gods"
+            image=items/book1.png
+            message=_"These other gods have not created our world, they cannot save us from the worst of perils. Some may call them false gods. But it might be good to reserve the term false gods for those who pretend to be our gods, and do not use it on those who turn the faith from our gods themselves because they think that they can be better. Many of these lesser gods are not evil; they merely think that our gods are not worth worship for neglecting their duties or that they do not exist and want to replace them."
+        [/message]
+        [message]
+            speaker=narrator
+            caption=_"Our Gods and Other Gods"
+            image=items/book1.png
+            message=_"Because of that, pagans are not inherently evil. They may deny our gods, but that does not make them evil, only misguided. Their gods are not to be hated neither, because they are trying to follow the steps of our gods. However, because our gods lose power when they lose worshippers, pagans should be turned if it can be done peacefully. Another case are pagans who worship evil gods and selfish gods, they should better be killed than left to continue their dark worship."
+        [/message]
     [/event]
 
     [event]
         name=moveto
-    [filter]
-        side=1
-        x,y=26,17
-    [/filter]
-    [message]
-        speaker=narrator
-        caption=_"The Queen of Darkness"
-        image=items/book2.png
-        message=_"The Queen of Darkness is an ancient enemy of mankind. She is seen by most of us as the cause of all suffering and all paranoiacs see her behind anything that looks like a scheme. She is most likely really preparing schemes, but a good scheme needs a long time to initiate, especially if you are only a single person. Between each outbreak, generations pass and her appearance and tricks are forgotten. Her plots are mostly attempts to seize power and many of them are successful, though usually a revolution ends her rule quickly."
-    [/message]
-    [message]
-        speaker=narrator
-        caption=_"The Queen of Darkness"
-        image=items/book2.png
-        message=_"She is a formidable enemy. She can handle many powerful opponents at once, face large armies alone because she will drain more energy from the weak than she spends. But that is not the biggest problem. She can possess most humans except the most strong-minded, though only one person can be possessed at once. When possessing someone, she can make her host use all spells and combat tricks she can use. People possessed by her are as dangerous as herself and it can be anybody."
-    [/message]
-    [message]
-        speaker=narrator
-        caption=_"The Queen of Darkness"
-        image=items/book2.png
-        message=_"As a result, it happens that various rulers, warlords or arch mages suddenly become hosts of the Queen of Darkness. Possession is nothing hard for her, so she can easily gain any position she desires. A drawback is that she does not inherit the behavioural traits of her hosts, so she can be identified if the possession is not prepared correctly. It happened that a queen recognised that her husband suddenly became less violent and it was discovered that he was possessed."
-    [/message]
-    [message]
-        speaker=narrator
-        caption=_"The Queen of Darkness"
-        image=items/book2.png
-        message=_"Queen of Darkness has the appearance of a beautiful woman, with blonde hair and green eyes. People enjoy her company because of her centuries-long experience in dealing with humans. Rumours say that she is a noble with a seemingly unimportant life and this idyllic life is a refuge where she can return at any time when her plans fail. It is possible that she is using a magical disguise and looks differently."
-    [/message]
-    [message]
-        speaker=narrator
-        caption=_"The Queen of Darkness"
-        image=items/book2.png
-        message=_"Her schemes are far more dangerous than her power. They vary a lot and no scheme is the same as another. It usually starts when she possesses an important person, usually somebody who is not known well by his surroundings. To enhance her social powers, she uses assassinations, possessions of others, terror, false enemies, pretended love or even the fear her name causes. Armed with her wit, magical power and experience, the person becomes far more important than before and tries to become a permanent tyrant, her ultimate goal."
-    [/message]
-    [message]
-        speaker=narrator
-        caption=_"The Queen of Darkness"
-        image=items/book2.png
-        message=_"Legends say that Queen of Darkness is the evil part of our goddess that she shrug off when she ascended into godhood. She looks similar and has similar knowledge. Initially, she was far more powerful, created a monstrous army to conquer the world, but our gods defeated her and stripped her of her power. Later, she helped our gods to fight demons and Lilith, claiming that the world must exist if she wants to rule it. It is not known why our god did not leave his evil part, but some people fear that this hypothetical King of Darkness might come one day."
-    [/message]
+        [filter]
+            side=1
+            x,y=26,17
+        [/filter]
+        [message]
+            speaker=narrator
+            caption=_"The Queen of Darkness"
+            image=items/book2.png
+            message=_"The Queen of Darkness is an ancient enemy of mankind. She is seen by most of us as the cause of all suffering and all paranoiacs see her behind anything that looks like a scheme. She is most likely really preparing schemes, but a good scheme needs a long time to initiate, especially if you are only a single person. Between each outbreak, generations pass and her appearance and tricks are forgotten. Her plots are mostly attempts to seize power and many of them are successful, though usually a revolution ends her rule quickly."
+        [/message]
+        [message]
+            speaker=narrator
+            caption=_"The Queen of Darkness"
+            image=items/book2.png
+            message=_"She is a formidable enemy. She can handle many powerful opponents at once, face large armies alone because she will drain more energy from the weak than she spends. But that is not the biggest problem. She can possess most humans except the most strong-minded, though only one person can be possessed at once. When possessing someone, she can make her host use all spells and combat tricks she can use. People possessed by her are as dangerous as herself and it can be anybody."
+        [/message]
+        [message]
+            speaker=narrator
+            caption=_"The Queen of Darkness"
+            image=items/book2.png
+            message=_"As a result, it happens that various rulers, warlords or arch mages suddenly become hosts of the Queen of Darkness. Possession is nothing hard for her, so she can easily gain any position she desires. A drawback is that she does not inherit the behavioural traits of her hosts, so she can be identified if the possession is not prepared correctly. It happened that a queen recognised that her husband suddenly became less violent and it was discovered that he was possessed."
+        [/message]
+        [message]
+            speaker=narrator
+            caption=_"The Queen of Darkness"
+            image=items/book2.png
+            message=_"Queen of Darkness has the appearance of a beautiful woman, with blonde hair and green eyes. People enjoy her company because of her centuries-long experience in dealing with humans. Rumours say that she is a noble with a seemingly unimportant life and this idyllic life is a refuge where she can return at any time when her plans fail. It is possible that she is using a magical disguise and looks differently."
+        [/message]
+        [message]
+            speaker=narrator
+            caption=_"The Queen of Darkness"
+            image=items/book2.png
+            message=_"Her schemes are far more dangerous than her power. They vary a lot and no scheme is the same as another. It usually starts when she possesses an important person, usually somebody who is not known well by his surroundings. To enhance her social powers, she uses assassinations, possessions of others, terror, false enemies, pretended love or even the fear her name causes. Armed with her wit, magical power and experience, the person becomes far more important than before and tries to become a permanent tyrant, her ultimate goal."
+        [/message]
+        [message]
+            speaker=narrator
+            caption=_"The Queen of Darkness"
+            image=items/book2.png
+            message=_"Legends say that Queen of Darkness is the evil part of our goddess that she shrug off when she ascended into godhood. She looks similar and has similar knowledge. Initially, she was far more powerful, created a monstrous army to conquer the world, but our gods defeated her and stripped her of her power. Later, she helped our gods to fight demons and Lilith, claiming that the world must exist if she wants to rule it. It is not known why our god did not leave his evil part, but some people fear that this hypothetical King of Darkness might come one day."
+        [/message]
     [/event]
 
     [event]
         name=moveto
-    [filter]
-        side=1
-        x,y=21,17
-    [/filter]
-    [message]
-        speaker=narrator
-        caption=_"Our gods: Brief summary for pagans"
-        image=items/book3.png
-        message=_"Some heathens may have difficulties to understand us, so here, the information about our gods is presented. We don't believe that our are eternal or originating from some higher realms of existence. They were born as mortals, he was a human, she was an elf. Horrible events led them to a path of necromancy that they walked for ages, but all of their deeds were done in the name of good. They were necromancers, but they used their powers wisely."
-    [/message]
-    [message]
-        speaker=narrator
-        caption=_"Our gods: Brief summary for pagans"
-        image=items/book3.png
-        message=_"They also found an interesting way to punish their enemies, instead of killing them, they took them into their own minds where they created a peaceful world for them to live in. Inside their mind, most of their enemies eventually started worshipping the creators of their peaceful world. This gave them the first bits of divine power. Over centuries, the number of various enemies consumed this way became sufficient for them to cast spells far beyond anything any human could."
-    [/message]
-    [message]
-        speaker=narrator
-        caption=_"Our gods: Brief summary for pagans"
-        image=items/book3.png
-        message=_"At some point of time, unwise but potent mages started creating additional suns. The first sun they created caused great weather problems and our gods had to steal the throne to fight the climate change. But then, they went on and attempted to raise another sun. That attempt was thwarted by our gods, but that attempt was suicidal. The new sun fell on them and only their divine power saved them from total destruction."
-    [/message]
-    [message]
-        speaker=narrator
-        caption=_"Our gods: Brief summary for pagans"
-        image=items/book3.png
-        message=_"They awoke eons ago, in a world greatly changed by the presence of the second sun and nobody to counter its bad influence. They had enough of their undeath, so they found a way to return back to life. They succeeded and the technique also purified them from the necromantic evil that accumulated within them. However, their awakening was not unnoticed. One of their former enemies who was too powerful to be consumed, a demoness named Lilith, decided to learn their powers."
-    [/message]
-    [message]
-        speaker=narrator
-        caption=_"Our gods: Brief summary for pagans"
-        image=items/book3.png
-        message=_"Lilith entered their world with an army of demons so large that nobody could defeat them. Our gods entered Inferno, the place where the demons went from and destroyed Lilith's base and war camps. They even managed to strip Lilith of the most potent of her powers, but Lilith survived and the demons in their world remained. Seeing their world destroyed by the demons, they had no other option but to create a new world and take all humans there."
-    [/message]
-    [message]
-        speaker=narrator
-        caption=_"Our gods: Brief summary for pagans"
-        image=items/book3.png
-        message=_"We are living in the world they created. Inside, their power is limitless because they can alter their creation at any time. They remain in their world, fighting the demons and repairing their old world. Once, we will be able to return there, but it still needs a lot of time. The greatest of warriors are allowed to join them in their fight."
-    [/message]
+        [filter]
+            side=1
+            x,y=21,17
+        [/filter]
+        [message]
+            speaker=narrator
+            caption=_"Our gods: Brief summary for pagans"
+            image=items/book3.png
+            message=_"Some heathens may have difficulties to understand us, so here, the information about our gods is presented. We don't believe that our are eternal or originating from some higher realms of existence. They were born as mortals, he was a human, she was an elf. Horrible events led them to a path of necromancy that they walked for ages, but all of their deeds were done in the name of good. They were necromancers, but they used their powers wisely."
+        [/message]
+        [message]
+            speaker=narrator
+            caption=_"Our gods: Brief summary for pagans"
+            image=items/book3.png
+            message=_"They also found an interesting way to punish their enemies, instead of killing them, they took them into their own minds where they created a peaceful world for them to live in. Inside their mind, most of their enemies eventually started worshipping the creators of their peaceful world. This gave them the first bits of divine power. Over centuries, the number of various enemies consumed this way became sufficient for them to cast spells far beyond anything any human could."
+        [/message]
+        [message]
+            speaker=narrator
+            caption=_"Our gods: Brief summary for pagans"
+            image=items/book3.png
+            message=_"At some point of time, unwise but potent mages started creating additional suns. The first sun they created caused great weather problems and our gods had to steal the throne to fight the climate change. But then, they went on and attempted to raise another sun. That attempt was thwarted by our gods, but that attempt was suicidal. The new sun fell on them and only their divine power saved them from total destruction."
+        [/message]
+        [message]
+            speaker=narrator
+            caption=_"Our gods: Brief summary for pagans"
+            image=items/book3.png
+            message=_"They awoke eons ago, in a world greatly changed by the presence of the second sun and nobody to counter its bad influence. They had enough of their undeath, so they found a way to return back to life. They succeeded and the technique also purified them from the necromantic evil that accumulated within them. However, their awakening was not unnoticed. One of their former enemies who was too powerful to be consumed, a demoness named Lilith, decided to learn their powers."
+        [/message]
+        [message]
+            speaker=narrator
+            caption=_"Our gods: Brief summary for pagans"
+            image=items/book3.png
+            message=_"Lilith entered their world with an army of demons so large that nobody could defeat them. Our gods entered Inferno, the place where the demons went from and destroyed Lilith's base and war camps. They even managed to strip Lilith of the most potent of her powers, but Lilith survived and the demons in their world remained. Seeing their world destroyed by the demons, they had no other option but to create a new world and take all humans there."
+        [/message]
+        [message]
+            speaker=narrator
+            caption=_"Our gods: Brief summary for pagans"
+            image=items/book3.png
+            message=_"We are living in the world they created. Inside, their power is limitless because they can alter their creation at any time. They remain in their world, fighting the demons and repairing their old world. Once, we will be able to return there, but it still needs a lot of time. The greatest of warriors are allowed to join them in their fight."
+        [/message]
     [/event]
 
     [event]
         name=moveto
-    [filter]
-        side=1
-        x,y=31,18
-    [/filter]
-    [message]
-        speaker=narrator
-        caption=_"Ancient Enemies"
-        image=items/book4.png
-        message=_"Argan the Lich Lord used to accompany our gods ages ago, long before they became gods. At some point, he decided to betray them for petty vengeance. From then, he became fond of raising armies of various monsters of his creation. He is powerful enough to return once he dies and nobody knows how to kill him forever. As an enemy, he is quite dangerous but his knowledge of destructive magic is very limited. He frequently tries to conquer kingdoms using his undead armies."
-    [/message]
-    [message]
-        speaker=narrator
-        caption=_"Ancient Enemies"
-        image=items/book4.png
-        message=_"Argan is also known for being a frequent ally of the Queen of Darkness. She serves as his general or diplomat while he sits on his throne of bones, creating more monstrous soldiers. It is not known how he imagines his rule, because undead are not those most rulers would want to control and humans would rarely accept undead as their rulers. One theory suggests that he wants to turn everybody to necromancers."
-    [/message]
-    [message]
-        speaker=narrator
-        caption=_"Ancient Enemies"
-        image=items/book4.png
-        message=_"Niflheim the Horror from the Northern Wastelands is an ancient enemy of our gods. He is far older. Niflheim is an icy dracolich, empowered by various cold and necromantic spells. He is capable of using powerful magic, can summon dangerous undead of all kinds and is quite adept at diplomacy, but he prefers rampaging using his own strength and freezing breath that can turn humans into icy undead. Because of his size, the only good way to survive an encounter with Niflheim is flight."
-    [/message]
-    [message]
-        speaker=narrator
-        caption=_"Ancient Enemies"
-        image=items/book4.png
-        message=_"Lilith is the arch-enemy of gods, extremely wicked and deceptive. Her only goal is to become even more powerful, she cares not about conquest. Through dark deception, she learned how to consume souls from our gods, but she uses this power on anybody and the place she takes them is a flaming hell. Legends say that once she was weak, but over millennia she assembled magical artifacts, knowledge and strange powers that made her powerful. Lilith's main strength is her intelligence, but her knowledge of magic and experience from long life should be considered."
-    [/message]
+        [filter]
+            side=1
+            x,y=31,18
+        [/filter]
+        [message]
+            speaker=narrator
+            caption=_"Ancient Enemies"
+            image=items/book4.png
+            message=_"Argan the Lich Lord used to accompany our gods ages ago, long before they became gods. At some point, he decided to betray them for petty vengeance. From then, he became fond of raising armies of various monsters of his creation. He is powerful enough to return once he dies and nobody knows how to kill him forever. As an enemy, he is quite dangerous but his knowledge of destructive magic is very limited. He frequently tries to conquer kingdoms using his undead armies."
+        [/message]
+        [message]
+            speaker=narrator
+            caption=_"Ancient Enemies"
+            image=items/book4.png
+            message=_"Argan is also known for being a frequent ally of the Queen of Darkness. She serves as his general or diplomat while he sits on his throne of bones, creating more monstrous soldiers. It is not known how he imagines his rule, because undead are not those most rulers would want to control and humans would rarely accept undead as their rulers. One theory suggests that he wants to turn everybody to necromancers."
+        [/message]
+        [message]
+            speaker=narrator
+            caption=_"Ancient Enemies"
+            image=items/book4.png
+            message=_"Niflheim the Horror from the Northern Wastelands is an ancient enemy of our gods. He is far older. Niflheim is an icy dracolich, empowered by various cold and necromantic spells. He is capable of using powerful magic, can summon dangerous undead of all kinds and is quite adept at diplomacy, but he prefers rampaging using his own strength and freezing breath that can turn humans into icy undead. Because of his size, the only good way to survive an encounter with Niflheim is flight."
+        [/message]
+        [message]
+            speaker=narrator
+            caption=_"Ancient Enemies"
+            image=items/book4.png
+            message=_"Lilith is the arch-enemy of gods, extremely wicked and deceptive. Her only goal is to become even more powerful, she cares not about conquest. Through dark deception, she learned how to consume souls from our gods, but she uses this power on anybody and the place she takes them is a flaming hell. Legends say that once she was weak, but over millennia she assembled magical artifacts, knowledge and strange powers that made her powerful. Lilith's main strength is her intelligence, but her knowledge of magic and experience from long life should be considered."
+        [/message]
     [/event]
 
     [event]
         name=room5
-    [gold]
-        side=2
-        {QUANTITY amount 500 650 700}
-    [/gold]
-    [unit]
-        id=boss3
-        side=2
-        x,y=3,12
-        type=Destroyer
-        canrecruit=yes
-        generate_name=yes
-        random_gender=no
-    [/unit]
-    {TBC_SPAWN_UNITS_NO_LEADER 2 1 "Champion Bowman,Royal Guard,Scythemaster,Shadowalker,Iron Mauler,Destroyer" 13 12}
+        [gold]
+            side=2
+            {QUANTITY amount 500 650 700}
+        [/gold]
+        [unit]
+            id=boss3
+            side=2
+            x,y=3,12
+            type=Destroyer
+            canrecruit=yes
+            generate_name=yes
+            random_gender=no
+        [/unit]
+        {TBC_SPAWN_UNITS_NO_LEADER 2 1 "Champion Bowman,Royal Guard,Scythemaster,Shadowalker,Iron Mauler,Destroyer" 13 12}
         [message]
             speaker=narrator
-        caption=_"Voice from afar"
-        image=units/unknown-unit.png
+            caption=_"Voice from afar"
+            image=units/unknown-unit.png
             message=_"Our defensive efforts were crushed on level 4. Everybody, come to level 5 and make a final stand. I will be praying for you."
         [/message]
         [message]
             speaker=narrator
-        caption=_"Another voice from afar"
-        image=units/unknown-unit.png
+            caption=_"Another voice from afar"
+            image=units/unknown-unit.png
             message=_"Me too."
         [/message]
         [message]
             speaker=narrator
-        caption=_"Voice from afar"
-        image=units/unknown-unit.png
+            caption=_"Voice from afar"
+            image=units/unknown-unit.png
             message=_"For Lilith's hooves, go fight them, one man who prays for all is enough."
         [/message]
     [/event]
 
     [event]
         name=room6
-    [message]
-        speaker=unit
-        message=_"I see no enemies up here. Maybe they were all defeated and only the two talkers remain."
-    [/message]
+        [message]
+            speaker=unit
+            message=_"I see no enemies up here. Maybe they were all defeated and only the two talkers remain."
+        [/message]
     [/event]
 
     [event]
         name=room7
-    [unit]
-        id=second_bringer
-        side=2
-        x,y=42,8
-        type=Bringer of Light2
-        canrecruit=yes
-        name=_"Einhard, the Bringer of Light"
-        gender=male
-    [/unit]
-    [unit]
-        id=third_bringer
-        side=2
-        x,y=48,9
-        type=Bringer of Light2
-        canrecruit=yes
-        name=_"Darzivalgur, the Bringer of Light"
-        gender=male
-    [/unit]
-    [message]
-        speaker=second_bringer
-        message=_"You will not try to give commands to the soldiers anymore, you are merely creating confusion."
-    [/message]
-    [message]
-        speaker=third_bringer
-        message=_"I am the Bringer of Light, you shall not tell what I have to do. Kneel before me so that I could bless your weapon for battle."
-    [/message]
-    [message]
-        speaker=second_bringer
-        message=_"How do you dare to call yourself the Bringer of Light? I am your master!"
-    [/message]
-    [message]
-        speaker=third_bringer
-        message=_"You are my former master. My apprenticeship is over, because I am already more powerful than you are."
-    [/message]
-    [message]
-        speaker=second_bringer
-        message=_"Look, our enemies reached level 7. Destroy them if you feel so mighty while I take care of Reezer, our golden mine of power."
-    [/message]
-    [message]
-        speaker=third_bringer
-        message=_"We will stay here both. These are the same warriors as those who murdered Luke. Luke was more powerful than we are, so neither of us can handle them alone."
-    [/message]
-    [message]
-        speaker=second_bringer
-        message=_"That is right. Either we both defeat them, or we both die."
-    [/message]
-    [/event]
-
-    [event]
-    name=last breath
-    [filter]
-        id=second_bringer
-    [/filter]
-    [filter_condition]
-        [have_unit]
-            id=third_bringer
-        [/have_unit]
-    [/filter_condition]
-    [message]
-        speaker=second_unit
-        message=_"Take that, villain!"
-    [/message]
-    [message]
-        speaker=third_bringer
-        message=_"Darn, I can't face them alone! Come back!"
-    [/message]
-    [message]
-        speaker=second_unit
-        message=_"Heh heh, you're next!"
-    [/message]
-    [/event]
-    [event]
-    name=last breath
-    [filter]
-        id=third_bringer
-    [/filter]
-    [filter_condition]
-        [have_unit]
+        [unit]
             id=second_bringer
-        [/have_unit]
-    [/filter_condition]
-    [message]
-        speaker=third_bringer
-        message=_"Everything is doomed now."
-    [/message]
-    [message]
-        speaker=second_bringer
-        message=_"Not really. I am still alive, my rival is dead and all I need for glory is finishing these few enemies."
-    [/message]
-    [/event]
-
-    [event]
-    name=last breath
-    [filter]
-        id=third_bringer
-    [/filter]
-    [filter_condition]
-        [not]
-            [have_unit]
-                id=second_bringer
-            [/have_unit]
-        [/not]
-    [/filter_condition]
-    [message]
-        speaker=third_bringer
-        message=_"You will never catch me!"
-    [/message]
-    [move_unit]
-        id=third_bringer
-        to_x=45
-        to_y=5
-        fire_event=no
-    [/move_unit]
-    [store_unit]
-        [filter]
+            side=2
+            x,y=42,8
+            type=Bringer of Light2
+            canrecruit=yes
+            name=_"Einhard, the Bringer of Light"
+            gender=male
+        [/unit]
+        [unit]
             id=third_bringer
-        [/filter]
-        variable=bringer
-        kill=yes
-    [/store_unit]
-    [message]
-        speaker=Burke
-        message=_"Catch him, he's on a dead end road!"
-    [/message]
-        [endlevel]
-            result=victory
-            bonus=yes
-            {NEW_GOLD_CARRYOVER 100}
-        [/endlevel]
+            side=2
+            x,y=48,9
+            type=Bringer of Light2
+            canrecruit=yes
+            name=_"Darzivalgur, the Bringer of Light"
+            gender=male
+        [/unit]
+        [message]
+            speaker=second_bringer
+            message=_"You will not try to give commands to the soldiers anymore, you are merely creating confusion."
+        [/message]
+        [message]
+            speaker=third_bringer
+            message=_"I am the Bringer of Light, you shall not tell what I have to do. Kneel before me so that I could bless your weapon for battle."
+        [/message]
+        [message]
+            speaker=second_bringer
+            message=_"How do you dare to call yourself the Bringer of Light? I am your master!"
+        [/message]
+        [message]
+            speaker=third_bringer
+            message=_"You are my former master. My apprenticeship is over, because I am already more powerful than you are."
+        [/message]
+        [message]
+            speaker=second_bringer
+            message=_"Look, our enemies reached level 7. Destroy them if you feel so mighty while I take care of Reezer, our golden mine of power."
+        [/message]
+        [message]
+            speaker=third_bringer
+            message=_"We will stay here both. These are the same warriors as those who murdered Luke. Luke was more powerful than we are, so neither of us can handle them alone."
+        [/message]
+        [message]
+            speaker=second_bringer
+            message=_"That is right. Either we both defeat them, or we both die."
+        [/message]
     [/event]
 
     [event]
-    name=last breath
-    [filter]
-        id=second_bringer
-    [/filter]
-    [filter_condition]
-        [not]
+        name=last breath
+        [filter]
+            id=second_bringer
+        [/filter]
+        [filter_condition]
             [have_unit]
                 id=third_bringer
             [/have_unit]
-        [/not]
-    [/filter_condition]
-    [message]
-        speaker=second_bringer
-        message=_"Catch me if you can."
-    [/message]
-    [move_unit]
-        id=second_bringer
-        to_x=45
-        to_y=5
-        fire_event=no
-    [/move_unit]
-    [store_unit]
+        [/filter_condition]
+        [message]
+            speaker=second_unit
+            message=_"Take that, villain!"
+        [/message]
+        [message]
+            speaker=third_bringer
+            message=_"Darn, I can't face them alone! Come back!"
+        [/message]
+        [message]
+            speaker=second_unit
+            message=_"Heh heh, you're next!"
+        [/message]
+    [/event]
+    [event]
+        name=last breath
         [filter]
-            id=second_bringer
+            id=third_bringer
         [/filter]
-        variable=bringer
-        kill=yes
-    [/store_unit]
-    [message]
-        speaker=Burke
-        message=_"Catch that lowlife, he has nowhere to run!"
-    [/message]
+        [filter_condition]
+            [have_unit]
+                id=second_bringer
+            [/have_unit]
+        [/filter_condition]
+        [message]
+            speaker=third_bringer
+            message=_"Everything is doomed now."
+        [/message]
+        [message]
+            speaker=second_bringer
+            message=_"Not really. I am still alive, my rival is dead and all I need for glory is finishing these few enemies."
+        [/message]
+    [/event]
+
+    [event]
+        name=last breath
+        [filter]
+            id=third_bringer
+        [/filter]
+        [filter_condition]
+            [not]
+                [have_unit]
+                    id=second_bringer
+                [/have_unit]
+            [/not]
+        [/filter_condition]
+        [message]
+            speaker=third_bringer
+            message=_"You will never catch me!"
+        [/message]
+        [move_unit]
+            id=third_bringer
+            to_x=45
+            to_y=5
+            fire_event=no
+        [/move_unit]
+        [store_unit]
+            [filter]
+                id=third_bringer
+            [/filter]
+            variable=bringer
+            kill=yes
+        [/store_unit]
+        [message]
+            speaker=Burke
+            message=_"Catch him, he's on a dead end road!"
+        [/message]
         [endlevel]
             result=victory
             bonus=yes
@@ -977,6 +941,45 @@
         [/endlevel]
     [/event]
 
+    [event]
+        name=last breath
+        [filter]
+            id=second_bringer
+        [/filter]
+        [filter_condition]
+            [not]
+                [have_unit]
+                    id=third_bringer
+                [/have_unit]
+            [/not]
+        [/filter_condition]
+        [message]
+            speaker=second_bringer
+            message=_"Catch me if you can."
+        [/message]
+        [move_unit]
+            id=second_bringer
+            to_x=45
+            to_y=5
+            fire_event=no
+        [/move_unit]
+        [store_unit]
+            [filter]
+                id=second_bringer
+            [/filter]
+            variable=bringer
+            kill=yes
+        [/store_unit]
+        [message]
+            speaker=Burke
+            message=_"Catch that lowlife, he has nowhere to run!"
+        [/message]
+        [endlevel]
+            result=victory
+            bonus=yes
+            {NEW_GOLD_CARRYOVER 100}
+        [/endlevel]
+    [/event]
 
     {TBC_GLOBAL_EVENTS_STRATEGY}
 [/scenario]

--- a/spinoffs/The_Beautiful_Child/scenarios/Burkes_Castle.cfg
+++ b/spinoffs/The_Beautiful_Child/scenarios/Burkes_Castle.cfg
@@ -29,34 +29,34 @@
         side=2
         team_name=twisted_good
         user_team_name=_"Twisted Good"
-    [ai]
-        passive_leader=yes
-        aggression=1
-    [/ai]
+        [ai]
+            passive_leader=yes
+            aggression=1
+        [/ai]
     [/side]
 
     {TBC_PLACE_WAYPOINT 7 5}
 
     [event]
-    name=prestart
-    {CLEAR_RECALLS}
-    {VARIABLE current_scenario burkes_castle}
-    {TBC_ORIGIN goonville 21 17}
-    {TBC_ORIGIN to_tame_a_land 5 4}
-    {TBC_TRANSITION 23-26 18-20 Goonville _"Goonville" 23 18}
-    [if]
-        [variable]
-            name=quests.overall
-            equals=5
-        [/variable]
-        [then]
-            {VARIABLE disallow_waypoint yes}
-        [/then]
-    [/if]
+        name=prestart
+        {CLEAR_RECALLS}
+        {VARIABLE current_scenario burkes_castle}
+        {TBC_ORIGIN goonville 21 17}
+        {TBC_ORIGIN to_tame_a_land 5 4}
+        {TBC_TRANSITION 23-26 18-20 Goonville _"Goonville" 23 18}
+        [if]
+            [variable]
+                name=quests.overall
+                equals=5
+            [/variable]
+            [then]
+                {VARIABLE disallow_waypoint yes}
+            [/then]
+        [/if]
     [/event]
 
     [event]
-    name=start
+        name=start
         {PLACE_IMAGE scenery/bookshelf-1.png 3 19}
         {PLACE_IMAGE items/box.png 2 18}
         {PLACE_IMAGE items/box.png 13 11}
@@ -64,870 +64,870 @@
         {PLACE_IMAGE scenery/bookshelf-2.png 7 2}
         {PLACE_IMAGE scenery/bookshelf-3.png 2 3}
         {PLACE_IMAGE cabinet.png 3 2}
-    [if]
-        [variable]
-            name=quests.overall
-            less_than=3
-        [/variable]
-        [then]
+        [if]
+            [variable]
+                name=quests.overall
+                less_than=3
+            [/variable]
+            [then]
                 {RARE_ITEM 15 13}
                 {RARE_ITEM 9 13}
-            [message]
-                speaker=Rimaru
-                message=_"There is one more problem to worry about. We can overpower Burke, but how will we make him cooperate?"
-                [option]
-                message=_"We may threaten him with death. We can make him an offer he cannot refuse, death or alliance."
-                [command]
-                    [message]
-                        speaker=Rimaru
-                        message=_"He would betray us as soon as he would be able to."
-                    [/message]
-                    [if]
-                        [have_unit]
-                            id=she_brother
-                        [/have_unit]
-                        [then]
+                [message]
+                    speaker=Rimaru
+                    message=_"There is one more problem to worry about. We can overpower Burke, but how will we make him cooperate?"
+                    [option]
+                        message=_"We may threaten him with death. We can make him an offer he cannot refuse, death or alliance."
+                        [command]
+                            [message]
+                                speaker=Rimaru
+                                message=_"He would betray us as soon as he would be able to."
+                            [/message]
+                            [if]
+                                [have_unit]
+                                    id=she_brother
+                                [/have_unit]
+                                [then]
+                                    [message]
+                                        speaker=she_brother
+                                        message=_"I agree. He was loyal to us. Of course, the cooperation brought him profit, my former order helped him to build the town we have seen today. There was a deal, he will be one of the examples of a cooperative, pious nobleman, and his town will be rebuilt to show how glorious he is."
+                                    [/message]
+                                    [message]
+                                        speaker=elf_merc
+                                        message=_"Burke and p... pious? It's hard to pronounce these two words in a single sentence."
+                                    [/message]
+                                [/then]
+                            [/if]
+                            [message]
+                                speaker=Rimaru
+                                message=_"Turning him to our side will not be easy, but I think that we might try something else. Do you think that he obeys the law?"
+                            [/message]
+                            [message]
+                                speaker=bandit_merc
+                                message=_"I don't think so. He's surely cheating somewhere, he has always been like that, regardless how the Brothers described him."
+                            [/message]
+                            [message]
+                                speaker=Rimaru
+                                message=_"Sure he doesn't. Just like the Brothers of Larceny don't. All we need to do is to find some evidence."
+                            [/message]
+                        [/command]
+                    [/option]
+                    [option]
+                        message=_"How about sending a woman to seduce him?"
+                        [show_if]
+                            [have_unit]
+                                id=elf_merc
+                            [/have_unit]
+                            [or]
+                                [have_unit]
+                                    id=she_brother
+                                [/have_unit]
+                            [/or]
+                        [/show_if]
+                        [command]
                             [message]
                                 speaker=she_brother
-                                message=_"I agree. He was loyal to us. Of course, the cooperation brought him profit, my former order helped him to build the town we have seen today. There was a deal, he will be one of the examples of a cooperative, pious nobleman, and his town will be rebuilt to show how glorious he is."
+                                message=_"Never! Love isn't forbidden by my orders' rules, and I am not a member of the order anymore anyway, but I will not do that. Love for profit is not my method of dealing with problems, and furthermore Burke is ugly and he stinks."
                             [/message]
                             [message]
                                 speaker=elf_merc
-                                message=_"Burke and p... pious? It's hard to pronounce these two words in a single sentence."
+                                message=_"I fight for money, I kill for money, but this is one of the things I don't do for money. If there was a love at first sight, maybe I could help you this way, but I doubt that there will be. I don't find humans very attractive."
                             [/message]
-                        [/then]
-                    [/if]
-                    [message]
-                        speaker=Rimaru
-                        message=_"Turning him to our side will not be easy, but I think that we might try something else. Do you think that he obeys the law?"
-                    [/message]
-                    [message]
-                        speaker=bandit_merc
-                        message=_"I don't think so. He's surely cheating somewhere, he has always been like that, regardless how the Brothers described him."
-                    [/message]
-                    [message]
-                        speaker=Rimaru
-                        message=_"Sure he doesn't. Just like the Brothers of Larceny don't. All we need to do is to find some evidence."
-                    [/message]
-                [/command]
-                 [/option]
-                [option]
-                message=_"How about sending a woman to seduce him?"
-                [show_if]
-                    [have_unit]
-                        id=elf_merc
-                    [/have_unit]
-                    [or]
-                        [have_unit]
-                            id=she_brother
-                        [/have_unit]
-                    [/or]
-                [/show_if]
-                [command]
-                    [message]
-                        speaker=she_brother
-                        message=_"Never! Love isn't forbidden by my orders' rules, and I am not a member of the order anymore anyway, but I will not do that. Love for profit is not my method of dealing with problems, and furthermore Burke is ugly and he stinks."
-                    [/message]
-                    [message]
-                        speaker=elf_merc
-                        message=_"I fight for money, I kill for money, but this is one of the things I don't do for money. If there was a love at first sight, maybe I could help you this way, but I doubt that there will be. I don't find humans very attractive."
-                    [/message]
-                    [message]
-                        speaker=Rimaru
-                        message=_"That was an ugly thing to say, my friend."
-                    [/message]
-                    [message]
-                        speaker=player
-                        message=_"Excuse me, whoever I have offended. I had no other ideas what might we do, this was a last resort."
-                    [/message]
-                    [message]
-                        speaker=Rimaru
-                        message=_"I think that Burke might be disobeying the law. Most noblemen do it, they collect more money from peasants than they're allowed to, and take from the taxes belonging to the king. If we find some evidence about it..."
-                    [/message]
-                [/command]
-                 [/option]
-                [option]
-                message=_"Do you think that he could build a town like this from his own resources? He does not govern a large land. We might find some evidence against him and blackmail him."
-                [command]
-                    [message]
-                        speaker=Rimaru
-                        message=_"That is a good idea! Blackmailing! That will surely bend him will, he must obey us or he will be hanged by the king."
-                    [/message]
-                    [message]
-                        speaker=bandit_merc
-                        message=_"I support anything that disobeys the law. I must confess that I have never tried blackmailing before, I can't wait to try it!"
-                    [/message]
-                    [message]
-                        speaker=she_brother
-                        message=_"Great plan!"
-                    [/message]
-                [/command]
-                 [/option]
-            [/message]
-            {VARIABLE quests.overall 3}
-        [/then]
-    [/if]
+                            [message]
+                                speaker=Rimaru
+                                message=_"That was an ugly thing to say, my friend."
+                            [/message]
+                            [message]
+                                speaker=player
+                                message=_"Excuse me, whoever I have offended. I had no other ideas what might we do, this was a last resort."
+                            [/message]
+                            [message]
+                                speaker=Rimaru
+                                message=_"I think that Burke might be disobeying the law. Most noblemen do it, they collect more money from peasants than they're allowed to, and take from the taxes belonging to the king. If we find some evidence about it..."
+                            [/message]
+                        [/command]
+                    [/option]
+                    [option]
+                        message=_"Do you think that he could build a town like this from his own resources? He does not govern a large land. We might find some evidence against him and blackmail him."
+                        [command]
+                            [message]
+                                speaker=Rimaru
+                                message=_"That is a good idea! Blackmailing! That will surely bend him will, he must obey us or he will be hanged by the king."
+                            [/message]
+                            [message]
+                                speaker=bandit_merc
+                                message=_"I support anything that disobeys the law. I must confess that I have never tried blackmailing before, I can't wait to try it!"
+                            [/message]
+                            [message]
+                                speaker=she_brother
+                                message=_"Great plan!"
+                            [/message]
+                        [/command]
+                    [/option]
+                [/message]
+                {VARIABLE quests.overall 3}
+            [/then]
+        [/if]
 
-    [if]
-        [variable]
-            name=quests.overall
-            less_than=4
-        [/variable]
-        [then]
-            [unit]
-                side=2
-                type=Duelist
-                id=Burke
-                name=_"Burke"
-                x,y=4,2
-                random_traits=yes
-                canrecruit=yes
-                [modifications]
-                    [advance]
-                        id=portrait
-                        [effect]
-                            apply_to=profile
-                            portrait="portraits/humans/transparent/duelist.png"
-                        [/effect]
-                    [/advance]
-                [/modifications]
-            [/unit]
+        [if]
+            [variable]
+                name=quests.overall
+                less_than=4
+            [/variable]
+            [then]
+                [unit]
+                    side=2
+                    type=Duelist
+                    id=Burke
+                    name=_"Burke"
+                    x,y=4,2
+                    random_traits=yes
+                    canrecruit=yes
+                    [modifications]
+                        [advance]
+                            id=portrait
+                            [effect]
+                                apply_to=profile
+                                portrait="portraits/humans/transparent/duelist.png"
+                            [/effect]
+                        [/advance]
+                    [/modifications]
+                [/unit]
 
-            [if]
-                [variable]
-                    name=quests.overall
-                    equals=3
-                [/variable]
-                [then]
-                    [event]
-                        name=moveto
-                        id=burke_disagrees
-                        [filter]
-                            x,y=1-10,1-5
-                            side=1
-                        [/filter]
-                        [message]
-                            speaker=Burke
-                            message=_"I will not fight you because I know that it's a folly. If you attack me directly, I will fight back, but I am not like the turncoats in your party. I will not join you to save my life. This town is mine and you will not separate me from it."
-                        [/message]
-                        [message]
-                            speaker=Rimaru
-                            message=_"I told you that we need to find evidence about some crimes he has done."
-                        [/message]
-                    [/event]
-                    [event]
-                        name=moveto
-                        [filter]
-                            x,y=3,19
-                            side=1
-                        [/filter]
-                        [message]
-                            speaker=unit
-                            message=_"I have found some information here... it looks like some financial records."
-                        [/message]
-                        [move_unit]
-                            id=$unit.id
-                            to_x=4
-                            to_y=18
-                            fire_event=no
-                        [/move_unit]
-                        [move_unit]
-                            id=Rimaru
-                            to_x=3
-                            to_y=19
-                            fire_event=no
-                        [/move_unit]
-                        [message]
-                            speaker=Rimaru
-                            message=_"Interesting. He has kept the peasants in the uninformed that the king has ordered lower taxes to make people like him more when he needed more popularity. He collected the same amount of taxes than before, but he kept the difference. He also stole from the Brothers of Light... pardon, Larceny, he reported to them that he has far less tax-payers. And collected the taxes from the unreported tax-payers himself."
-                        [/message]
-                        [message]
-                            speaker=Rimaru
-                            message=_"What is worse for him and better for us, he reported a lower number of tax-payers also to the royal tax collectors, and stole some of king's taxes. Through these frauds, he was earning on taxes twice as much as he should have."
-                        [/message]
-                        [message]
-                            speaker=she_brother
-                            message=_"Where did he spend the money? Or does it keep it somewhere?"
-                        [/message]
-                        [message]
-                            speaker=Rimaru
-                            message=_"He spent most of it. He bought expensive food in large numbers, rebuilt a lot of buildings in the town, spent a lot of money in unknown transactions, probably some gambling... He did not invest much into his army, fortunately for us, he does not seem to care much about defense, obviously he did not fear war. Okay, I think that this will prove him guilty. Now, it's time to go threatening him with these papers."
-                        [/message]
-                        [remove_event]
-                            id=burke_disagrees
-                        [/remove_event]
-                        {VARIABLE quests.overall 4}
-                    [/event]
-                [/then]
-            [/if]
-
-            [event]
-                name=moveto
-                [filter]
-                    x,y=1-10,1-5
-                    side=1
-                [/filter]
-                [filter_condition]
+                [if]
                     [variable]
                         name=quests.overall
-                        equals=4
+                        equals=3
                     [/variable]
-                [/filter_condition]
-                [message]
-                    speaker=Burke
-                    message=_"Are you going to kill me? What will you achieve with an act like that? If I am dead, you will gain nothing. If you let me live, I might save you from beheading..."
-                [/message]
-                [message]
-                    speaker=Rimaru
-                    message=_"We don't need to get our hands dirty by killing you. We kill only in self-defence, and this is not the case. You will be killed by the king."
-                [/message]
-                [message]
-                    speaker=Burke
-                    message=_"What, you used your evil magic to control our king?"
-                [/message]
-                [message]
-                    speaker=Rimaru
-                    message=_"No, not that. We have found some evidence against your crimes."
-                [/message]
-                [message]
-                    speaker=Burke
-                    message=_"Evidence? Who needs that. And how hard was it to find it? There is a plenty of dead bodies near the Crooked Ravine, but who cares about that? The slaughter was ordered by the Brothers of Light. It was necessary to put down the peasant rebellion, although... it failed. Nobody can legally punish me for that!"
-                [/message]
-                [message]
-                    speaker=Rimaru
-                    message=_"Indeed. Your crimes against the folk will be ignored as usually. But when it comes to your crimes against the king, it won't be ignored."
-                [/message]
-                [message]
-                    speaker=Burke
-                    message=_"What crimes against my king? I am not preparing any rebellion against him, I am putting down one. I am not allied with the Sand Empire neither. What crimes are you talking about?"
-                [/message]
-                [message]
-                    speaker=Rimaru
-                    message=_"Don't pretend that you're innocent, Burke. We have found your financial records. You have stolen the royal taxes. You have stolen the taxes belonging to the Brothers of Larceny. You have reported to have about a half of the number of peasants than you really have."
-                [/message]
-                [message]
-                    speaker=Burke
-                    message=_"So it's this... But... well, you know that... huh... ehm... Why are you sure that you understood it right, brother Rimaru?"
-                    [option]
-                    message=_"It's absolutely obvious, you wretch! Don't play any tricks, they are all bound to fail."
-                    [command]
-                        [message]
-                            speaker=bandit_merc
-                            message=_"This is how I like to hear you speaking."
-                        [/message]
-                    [/command]
-                     [/option]
-                    [option]
-                    message=_"We understood it right. You have collected taxes from over a thousand tax-payers, about a hundred did not pay for whatever reasons. However, you reported that you have only six hundreds of tax payers. That is a tax fraud, obviously."
-                    [command]
-                        [message]
-                            speaker=fiathful_lieutenant
-                            message=_"What a lawyer you are..."
-                        [/message]
-                    [/command]
-                     [/option]
-                    [option]
-                    message=_"Where could we misunderstand something?"
-                    [command]
-                        [message]
-                            speaker=Burke
-                            message=_"Ehm.. maybe in the... numbers... the amount of tax payers..."
-                        [/message]
-                        [if]
-                            [have_unit]
-                                id=she_brother
-                            [/have_unit]
-                            [then]
-                                [message]
-                                    speaker=she_brother
-                                    message=_"Stop making up excuses, it's too late. If there was some truth, you would know it."
-                                [/message]
-                            [/then]
-                            [else]
-                                [message]
-                                    speaker=Burke
-                                    message=_"It's soooo damn obvious that you're lying. You are totally guilty."
-                                [/message]
-                            [/else]
-                        [/if]
-                    [/command]
-                     [/option]
-                [/message]
-                [message]
-                    speaker=Burke
-                    message=_"Okay, so you found a way how to get rid of me. But why do you need that? The king will name another baron to govern this place. He will not know the area and there will be far less prosperity. And you can't know if it won't be somebody far worse than me. I am not plundering my lands to collect more money, I am not leading a war. I am a very good man if you take it so."
-                [/message]
-                [message]
-                    speaker=Rimaru
-                    message=_"That is not the point. I can get rid of you. I will gain nothing, you will lose all. Is that what you want? I think that you want it far less than I do. And you will do anything to prevent it."
-                [/message]
-                [message]
-                    speaker=Burke
-                    message=_"I don't want that indeed. But there are things I would not do to prevent it. Though... there aren't many of them."
-                [/message]
-                [message]
-                    speaker=Rimaru
-                    message=_"So, let's make a deal. I have a few trusted people in the town who will guard the evidence to make sure that you will not try to cheat us. Now, the deal. You will support us in our campaign against the Brothers of Larceny. Or Brothers of Light, as they call themselves. We will change their leaders to prevent them from spending too much money on gambling, expensive food and their own personal welfare. You will help us as much as you can. And in reward, we will not report your crimes. When we finish, I'll burn the papers. Deal?"
-                [/message]
-                [message]
-                    speaker=Burke
-                    message=_"You treacherous pricks! You have won this time. Deal."
-                [/message]
-                [message]
-                    speaker=Rimaru
-                    message=_"Okay, we need to gain support from lord Konrad. I know that man and I believe that we can persuade him to support us. He dislikes the Brothers of Larceny and he wants to weaken their grip. And we already have support from a nobleman, he'll not be alone."
-                [/message]
-                [message]
-                    speaker=Burke
-                    message=_"To be honest, I never liked the Brothers of <i>Light</i>. They are complacent and self-loving, caring far more about politics and power than about the things they're supposed to care about. But I believed that it was all done for a good cause."
-                [/message]
-                [message]
-                    speaker=she_brother
-                    message=_"I think that we should talk more about getting lord Konrad to support us."
-                [/message]
-                [message]
-                    speaker=Burke
-                    message=_"Sorry for changing the topic. To get to lord Konrad, we need to pass through untamed Grey Hills, hills and forests filled with lawless scum, bandits, cut-throats, marauders and all kinds of other vermin. We cannot just travel through that place."
-                    [option]
-                    message=_"Why didn't you just kill the bandits? It's your duty to fight them, no?"
-                    [command]
-                        [message]
-                            speaker=Burke
-                            message=_"That isn't so easy. I know that I should have done that, but I did not have the resources necessary for a military operation of that size. They knew that attacking my town would force me to attack them, and would also persuade many peasants to pay some extra taxes for warfare. Bandits don't annoy me, so I can ignore them. But they attack most travellers passing through there."
-                        [/message]
-                        [message]
-                            speaker=Rimaru
-                            message=_"So we will bring the law there now."
-                        [/message]
-                        [message]
-                            speaker=she_brother
-                            message=_"Great plan! So specific..."
-                        [/message]
-                    [/command]
-                     [/option]
-                    [option]
-                    message=_"But we must go there."
-                    [command]
-                        [message]
-                            speaker=Burke
-                            message=_"Well, we'll have to destroy them. But how?"
-                        [/message]
-                    [/command]
-                     [/option]
-                [/message]
-                [message]
-                    speaker=Rimaru
-                    message=_"So, here is a plan. We will hire the first bandit group we find. They will follow us and support your own soldiers. Maybe we'll also hire another group, depends what will be cheaper, soldiers or hired bandits. Together, we'll attack bandit nests one by one, until we clear the place. The bandit groups aren't loyal to other bandit groups and occasionally even fight others, so they will not be reluctant to fight against other bandits."
-                [/message]
-                [message]
-                    speaker=Burke
-                    message=_"That sounds doable. Let me start the preparations."
-                [/message]
-                [store_unit]
+                    [then]
+                        [event]
+                            name=moveto
+                            id=burke_disagrees
+                            [filter]
+                                x,y=1-10,1-5
+                                side=1
+                            [/filter]
+                            [message]
+                                speaker=Burke
+                                message=_"I will not fight you because I know that it's a folly. If you attack me directly, I will fight back, but I am not like the turncoats in your party. I will not join you to save my life. This town is mine and you will not separate me from it."
+                            [/message]
+                            [message]
+                                speaker=Rimaru
+                                message=_"I told you that we need to find evidence about some crimes he has done."
+                            [/message]
+                        [/event]
+                        [event]
+                            name=moveto
+                            [filter]
+                                x,y=3,19
+                                side=1
+                            [/filter]
+                            [message]
+                                speaker=unit
+                                message=_"I have found some information here... it looks like some financial records."
+                            [/message]
+                            [move_unit]
+                                id=$unit.id
+                                to_x=4
+                                to_y=18
+                                fire_event=no
+                            [/move_unit]
+                            [move_unit]
+                                id=Rimaru
+                                to_x=3
+                                to_y=19
+                                fire_event=no
+                            [/move_unit]
+                            [message]
+                                speaker=Rimaru
+                                message=_"Interesting. He has kept the peasants in the uninformed that the king has ordered lower taxes to make people like him more when he needed more popularity. He collected the same amount of taxes than before, but he kept the difference. He also stole from the Brothers of Light... pardon, Larceny, he reported to them that he has far less tax-payers. And collected the taxes from the unreported tax-payers himself."
+                            [/message]
+                            [message]
+                                speaker=Rimaru
+                                message=_"What is worse for him and better for us, he reported a lower number of tax-payers also to the royal tax collectors, and stole some of king's taxes. Through these frauds, he was earning on taxes twice as much as he should have."
+                            [/message]
+                            [message]
+                                speaker=she_brother
+                                message=_"Where did he spend the money? Or does it keep it somewhere?"
+                            [/message]
+                            [message]
+                                speaker=Rimaru
+                                message=_"He spent most of it. He bought expensive food in large numbers, rebuilt a lot of buildings in the town, spent a lot of money in unknown transactions, probably some gambling... He did not invest much into his army, fortunately for us, he does not seem to care much about defense, obviously he did not fear war. Okay, I think that this will prove him guilty. Now, it's time to go threatening him with these papers."
+                            [/message]
+                            [remove_event]
+                                id=burke_disagrees
+                            [/remove_event]
+                            {VARIABLE quests.overall 4}
+                        [/event]
+                    [/then]
+                [/if]
+
+                [event]
+                    name=moveto
                     [filter]
-                        id=Burke
+                        x,y=1-10,1-5
+                        side=1
                     [/filter]
-                    variable=burke_store
-                [/store_unit]
-                {VARIABLE burke_store.side 1}
-                {VARIABLE burke_store.variables.hero yes}
-                [unstore_unit]
-                    variable=burke_store
-                    find_vacant=no
-                [/unstore_unit]
-                {CLEAR_VARIABLE burke_store}
-                {VARIABLE party_members[$party_members.length].id Burke}
-                {VARIABLE quests.overall 5}
-                [endlevel]
-                    result=victory
-                    bonus=no
-                    next_scenario=03_To_Tame_a_Land
-                    {NEW_GOLD_CARRYOVER 100}
-                [/endlevel]
-            [/event]
-
-            [if]
-                [variable]
-                    name=quests.burkes_castle_southwest_guards
-                    equals=yes
-                [/variable]
-                [else]
-                    [event]
-                        name=moveto
-                        [filter]
-                            x,y=1-11,11-20
-                            side=1
-                        [/filter]
-                        {TBC_SPAWN_UNITS_NO_LEADER 2 1.3 "Spearman,Heavy Infantryman,Bowman,Swordsman,Javelineer,Longbowman" 5 16}
-                        [message]
-                            speaker=unit
-                            message=_"There are some guards ahead!"
-                        [/message]
-                        {VARIABLE quests.burkes_castle_southwest_guards yes}
-                    [/event]
-                [/else]
-            [/if]	
-
-            [if]
-                [variable]
-                    name=quests.burkes_castle_northeast_guards
-                    equals=yes
-                [/variable]
-                [else]
-                    [event]
-                        name=moveto
-                        [filter]
-                            x,y=14-23,5-13
-                            side=1
-                        [/filter]
-                        {TBC_SPAWN_UNITS_NO_LEADER 2 1.3 "Spearman,Heavy Infantryman,Pikeman,Bowman,Javelineer,Longbowman" 19 7}
-                        [message]
-                            speaker=unit
-                            message=_"It seems that Burke isn't a good strategist. He has some guards here. If he sent them together with the town's guardsmen against us, we would be in a much greater trouble."
-                        [/message]
-                        {VARIABLE quests.burkes_castle_northeast_guards yes}
-                    [/event]
-                [/else]
-            [/if]
-
-            [if]
-                [variable]
-                    name=quests.burkes_castle_burkes_guards
-                    equals=yes
-                [/variable]
-                [else]
-                    [event]
-                        name=moveto
-                        [filter]
-                            x,y=1-14,1-10
-                            side=1
-                        [/filter]
-                        {TBC_SPAWN_UNITS_NO_LEADER 2 1 "Swordsman,Pikeman,Shock Trooper,Fencer,Javelineer,Longbowman" 7 5}
-                        [message]
-                            speaker=unit
-                            message=_"Burke's bodyguards are attacking us, I think"
-                        [/message]
-                        {VARIABLE quests.burkes_castle_burkes_guards yes}
-                    [/event]
-                [/else]
-            [/if]
-
-        [/then]
-    [/if]
-    {TBC_GOLD_CHEST 4 12 burkes_castle_southwest_chest}
-    {TBC_GOLD_CHEST 12 11 burkes_castle_central_chest}
-    {TBC_GOLD_CHEST 19 6 burkes_castle_northeast_chest}
-
-
-    [if]
-        [variable]
-            name=quests.overall
-            equals=5
-        [/variable]
-        [then]
-            [message]
-                speaker=Rimaru
-                message=_"It's good that the bandits are gone."
-            [/message]
-            [message]
-                speaker=Burke
-                message=_"Not really gone, but they are much weaker now. Certainly the remains will still pose a threat to weaker groups of travellers, but lord Konrad's troops will take care of them."
-            [/message]
-            [message]
-                speaker=Rimaru
-                message=_"Now, we would like you to accompany us into lord Konrad's court. We need you to help us persuade him to stand against the evil. Or better to say, good twisted into doing evil."
-            [/message]
-            [unit]
-                side=1
-                type=Shuja tbc
-                canrecruit=yes
-                x,y=23,19
-                name=_"Al Ghareeb"
-                id=Al Ghareeb
-                [variables]
-                    hero=yes
-                [/variables]
-            [/unit]
-            {VARIABLE party_members[$party_members.length].id "Al Ghareeb"}
-            [move_unit]
-                id=Al Ghareeb
-                to_x=7
-                to_y=4
-                fire_event=no
-            [/move_unit]
-            [message]
-                speaker=Burke
-                message=_"Who are you, stranger? What do you want here? How did you even get here?"
-            [/message]
-            [message]
-                speaker=Al Ghareeb
-                message=_"My name is Al Ghareeb. I am an emissary of the Sand Empire. And I paid some of your soldiers to let me here. They were not afraid about your safety, because you have strong friends with you."
-            [/message]
-            [message]
-                speaker=Burke
-                message=_"Interesting. What leads an Emissary of the Sand Empire here? I am not the king."
-            [/message]
-            [message]
-                speaker=Al Ghareeb
-                message=_"I know that you are not the king, but that is the point. Our countries are at war. A meaningless war, I'd like to say."
-            [/message]
-            [message]
-                speaker=Burke
-                message=_"The news of that war haven't reached me yet. I am probably too far away from the borders and they didn't need my soldiers. Why are we at war? Your empire produces a lot of interesting goods I like buying."
-            [/message]
-            [message]
-                speaker=Al Ghareeb
-                message=_"A group of healers from your country entered my country. We let them in, because who wouldn't like to have more healers. But they did not heal almost at all. Instead, they started preaching about their faith. That would not be a problem itself, we have the same gods. But they started speaking about the gods having a child sent into their home town, called it a proof of their supremacy and tried to command us and demanded additional tithes for themselves."
-            [/message]
-            [message]
-                speaker=Rimaru
-                message=_"These damned Brothers of Larceny... They're trying to advance their schemes even behind the borders of our kingdom. I hope they are leaving the orcs and elves be, that would be a war we cannot win."
-            [/message]
-            [message]
-                speaker=Burke
-                message=_"I assume that these men and women were expelled from the country."
-            [/message]
-            [message]
-                speaker=Al Ghareeb
-                message=_"Well, we should have done that, but it was too late when we realised what's going on. They realised that public speeches will not allow them to control the people, so they changed their strategy. They hired an insane quantity of mercenaries and started conquering the country, from one oasis to another. No idea where they have the money from. Your king demanded our ruler to stop fighting and suggest a peace treaty with them, but the peace treaty he suggested demanded leaving the conquered land to them."
-            [/message]
-            [message]
-                speaker=Al Ghareeb
-                message=_"We could not accept that. We had our duty to our people and we didn't want to lose a quarter of our country. We destroyed them, made the mercenaries flee and killed the preachy healers. But your king started a war with us, invaded our north while we were securing lands elsewhere. We stopped their rapid progress when our armies united, but still, a fifth of our land is occupied and battles are being fought on the new borders."
-            [/message]
-            [message]
-                speaker=Rimaru
-                message=_"That was ugly from them. I assume that you're visiting us because you learned somewhere that we're leading a rebellion against Brothers of Larceny as well."
-            [/message]
-            [message]
-                speaker=Al Ghareeb
-                message=_"Yes. We have learned that the problem is not your country, but that particular order of white mages. Their control of your country is strong. Conquering your country to get rid of them is a very hard and bloody task and we'd prefer a better solution. A rebellion in your country that would either destroy or reform the Brothers of... Larceny...?"
-            [/message]
-            [message]
-                speaker=Rimaru
-                message=_"They call themselves Brothers of Light, but I called them Brothers of Larceny because I started this rebellion due to the extreme tithes they're demanding. Probably to pay those mercenaries to trouble you."
-            [/message]
-            [message]
-                speaker=Al Ghareeb
-                message=_"Ah, well. So, we need your rebellion to avoid a large scale war with huge casualties. We will try to force your king to send as many soldiers to the south and avoid confrontations, so that you could attack them without heavy resistance."
-            [/message]
-            [message]
-                speaker=Burke
-                message=_"Great. That will be a good alliance."
-            [/message]
-            [while]
-                [not]
-                    [variable]
-                        name=done
-                        equals=yes
-                    [/variable]
-                [/not]
-                [do]
+                    [filter_condition]
+                        [variable]
+                            name=quests.overall
+                            equals=4
+                        [/variable]
+                    [/filter_condition]
                     [message]
                         speaker=Burke
-                        message=_"Good. Any other questions?"
+                        message=_"Are you going to kill me? What will you achieve with an act like that? If I am dead, you will gain nothing. If you let me live, I might save you from beheading..."
+                    [/message]
+                    [message]
+                        speaker=Rimaru
+                        message=_"We don't need to get our hands dirty by killing you. We kill only in self-defence, and this is not the case. You will be killed by the king."
+                    [/message]
+                    [message]
+                        speaker=Burke
+                        message=_"What, you used your evil magic to control our king?"
+                    [/message]
+                    [message]
+                        speaker=Rimaru
+                        message=_"No, not that. We have found some evidence against your crimes."
+                    [/message]
+                    [message]
+                        speaker=Burke
+                        message=_"Evidence? Who needs that. And how hard was it to find it? There is a plenty of dead bodies near the Crooked Ravine, but who cares about that? The slaughter was ordered by the Brothers of Light. It was necessary to put down the peasant rebellion, although... it failed. Nobody can legally punish me for that!"
+                    [/message]
+                    [message]
+                        speaker=Rimaru
+                        message=_"Indeed. Your crimes against the folk will be ignored as usually. But when it comes to your crimes against the king, it won't be ignored."
+                    [/message]
+                    [message]
+                        speaker=Burke
+                        message=_"What crimes against my king? I am not preparing any rebellion against him, I am putting down one. I am not allied with the Sand Empire neither. What crimes are you talking about?"
+                    [/message]
+                    [message]
+                        speaker=Rimaru
+                        message=_"Don't pretend that you're innocent, Burke. We have found your financial records. You have stolen the royal taxes. You have stolen the taxes belonging to the Brothers of Larceny. You have reported to have about a half of the number of peasants than you really have."
+                    [/message]
+                    [message]
+                        speaker=Burke
+                        message=_"So it's this... But... well, you know that... huh... ehm... Why are you sure that you understood it right, brother Rimaru?"
                         [option]
-                        message=_"How do we know that you can be trusted?"
-                        [command]
-                            [message]
-                                speaker=Al Ghareeb
-                                message=_"That is a good question. I think that you'll learn about the war quite soon. And you should be able to verify what I told about the rebellion your white mages started, though the story will be told from a different angle. And regarding our plan, it's something that can't be verified right now."
-                            [/message]
-                            [message]
-                                speaker=Rimaru
-                                message=_"They would gain nothing by sending a man to impersonate an emissary bringing a message like this."
-                            [/message]
-                        [/command]
+                            message=_"It's absolutely obvious, you wretch! Don't play any tricks, they are all bound to fail."
+                            [command]
+                                [message]
+                                    speaker=bandit_merc
+                                    message=_"This is how I like to hear you speaking."
+                                [/message]
+                            [/command]
                         [/option]
                         [option]
-                        message=_"What will you do now?"
-                        [command]
-                            [message]
-                                speaker=Al Ghareeb
-                                message=_"The primary goal of my mission is complete. Only the second part remains now, less important and less specific. I was asked to help you in your war. A man of completely different background from a land where different strategies are used must be a handy help."
-                            [/message]
-                            [message]
-                                speaker=hired_swordsman
-                                message=_"Indeed. Different thinking, better variety of our strategies."
-                            [/message]
-                            [message]
-                                speaker=she_brother
-                                message=_"I don't mind having him around."
-                            [/message]
-                            [message]
-                                speaker=Rimaru
-                                message=_"Well, Al Ghareeb, you're in."
-                            [/message]
-                        [/command]
+                            message=_"We understood it right. You have collected taxes from over a thousand tax-payers, about a hundred did not pay for whatever reasons. However, you reported that you have only six hundreds of tax payers. That is a tax fraud, obviously."
+                            [command]
+                                [message]
+                                    speaker=fiathful_lieutenant
+                                    message=_"What a lawyer you are..."
+                                [/message]
+                            [/command]
                         [/option]
                         [option]
-                        message=_"Can you tell us something about the Sand Empire?"
-                        [command]
-                            [message]
-                                speaker=Al Ghareeb
-                                message=_"It's south from your kingdom. Its north, that borders with your land and has been conquered, is similar to your lands, it's just more dry, with little rivers and unusual trees. The rest of its lands is a large desert, where the sun shines so hot that there are almost no rivers, only rocks and sand. In some areas, there is more sand, in some areas, there are more rocks, but in general it isn't very habitable."
-                            [/message]
-                            [message]
-                                speaker=Al Ghareeb
-                                message=_"However, there are oases in the dry lands. A lake usually surrounded by lush vegetation and fertile soil. We live mostly in those oases, but many also herd goats on scarce vegetation that grows on the barren rocks. Further south, there is just totally dry desert where nobody can live. Legends tell that there are dense forests with abundance of rain beyond that desert, but very few travellers who go there return. And those who return report that they found nothing."
-                            [/message]
-                        [/command]
-                        [/option]
-                        [option]
-                        message=_"You've told us that Sand Empire has the same gods as we... what are the differences the Brothers of Light have trouble with?"
-                        [command]
-                            [message]
-                                speaker=faithful_lieutenant
-                                message=_"I was told that they have strange traditions. The old stories are the same, but they have a strange ritual that they chase a man across the desert, then they catch him and eat him."
-                            [/message]
-                            [message]
-                                speaker=Al Ghareeb
-                                message=_"The traditions between our countries differ greatly. Vritra the Daughter of Gods was living among us until her departure into unknown, she was our legendary ruler and we're still ruled by her descendants. Her bloodline is still among us, but it's weakening from generation to generation. She was very fond of hunting, so in her name, every year, in every bigger city, we release a prisoner and offer him freedom if we don't find him."
-                            [/message]
-                            [message]
-                                speaker=Rimaru
-                                message=_"That's quite cruel. But if the stories are true, Vritra was a killer at heart and could not live without battle for too long. She was on the side of good, but her strange need to kill was known to be disturbing. It was a problem sometimes when there were no evil men available."
-                            [/message]
-                            [message]
-                                speaker=she_brother
-                                message=_"She was capable of so many heroic deeds, but she was not capable of controlling the beast within her. Stories say that she tried to live with humans, but then she left somewhere, maybe to live with communities that did not consider killing evil, like orcs."
-                            [/message]
-                            [message]
-                                speaker=Al Ghareeb
-                                message=_"The prisoner would sit in prison until his death or would be executed otherwise. We are picking from a group of volunteers usually. He has one night of time to flee, then people start the pursuit. In average, three out of five are caught... and usually killed."
-                            [/message]
-                            [message]
-                                speaker=Rimaru
-                                message=_"I wonder... wasn't one of your emperor's children... snatched? Or replaced?"
-                            [/message]
-                            [message]
-                                speaker=Al Ghareeb
-                                message=_"No. They would have noticed it. The emperor's family still looks somewhat different from ordinary humans... exquisite skin, uncanny intelligence, gracious movements, always slim and tall, strength that you would not expect from their body size... They used to be even more glorious, they're trying to marry their cousins to maintain their bloodline's purity, but still it's weakening, children are never grown stronger than parents. Why are you asking?"
-                            [/message]
-                            [message]
-                                speaker=Rimaru
-                                message=_"The Brothers of Larceny claim that they have a child of gods in their caring hands. I wonder if they didn't steal your emperor's child, that one is literally the descendant of gods."
-                            [/message]
-                            [message]
-                                speaker=Al Ghareeb
-                                message=_"That's very unlikely. There is a visible difference between Emperor's children and normal children, but the difference isn't striking."
-                            [/message]
-                        [/command]
-                        [/option]
-                        [option]
-                        message=_"Enough planning, let's visit lord Konrad!"
-                        [command]
-                            {VARIABLE done yes}
-                        [/command]
+                            message=_"Where could we misunderstand something?"
+                            [command]
+                                [message]
+                                    speaker=Burke
+                                    message=_"Ehm.. maybe in the... numbers... the amount of tax payers..."
+                                [/message]
+                                [if]
+                                    [have_unit]
+                                        id=she_brother
+                                    [/have_unit]
+                                    [then]
+                                        [message]
+                                            speaker=she_brother
+                                            message=_"Stop making up excuses, it's too late. If there was some truth, you would know it."
+                                        [/message]
+                                    [/then]
+                                    [else]
+                                        [message]
+                                            speaker=Burke
+                                            message=_"It's soooo damn obvious that you're lying. You are totally guilty."
+                                        [/message]
+                                    [/else]
+                                [/if]
+                            [/command]
                         [/option]
                     [/message]
-                [/do]
-            [/while]
-            {CLEAR_VARIABLE done}
-            [unit]
-                side=2
-                type=Manhunter
-                name=_"???"
-                x,y=22,18
-                id=Manhunter
-            [/unit]
-            [if]
-                [variable]
-                    name=party_members.length
-                    less_than=4
-                [/variable]
-                [then]
-                    [object]
+                    [message]
+                        speaker=Burke
+                        message=_"Okay, so you found a way how to get rid of me. But why do you need that? The king will name another baron to govern this place. He will not know the area and there will be far less prosperity. And you can't know if it won't be somebody far worse than me. I am not plundering my lands to collect more money, I am not leading a war. I am a very good man if you take it so."
+                    [/message]
+                    [message]
+                        speaker=Rimaru
+                        message=_"That is not the point. I can get rid of you. I will gain nothing, you will lose all. Is that what you want? I think that you want it far less than I do. And you will do anything to prevent it."
+                    [/message]
+                    [message]
+                        speaker=Burke
+                        message=_"I don't want that indeed. But there are things I would not do to prevent it. Though... there aren't many of them."
+                    [/message]
+                    [message]
+                        speaker=Rimaru
+                        message=_"So, let's make a deal. I have a few trusted people in the town who will guard the evidence to make sure that you will not try to cheat us. Now, the deal. You will support us in our campaign against the Brothers of Larceny. Or Brothers of Light, as they call themselves. We will change their leaders to prevent them from spending too much money on gambling, expensive food and their own personal welfare. You will help us as much as you can. And in reward, we will not report your crimes. When we finish, I'll burn the papers. Deal?"
+                    [/message]
+                    [message]
+                        speaker=Burke
+                        message=_"You treacherous pricks! You have won this time. Deal."
+                    [/message]
+                    [message]
+                        speaker=Rimaru
+                        message=_"Okay, we need to gain support from lord Konrad. I know that man and I believe that we can persuade him to support us. He dislikes the Brothers of Larceny and he wants to weaken their grip. And we already have support from a nobleman, he'll not be alone."
+                    [/message]
+                    [message]
+                        speaker=Burke
+                        message=_"To be honest, I never liked the Brothers of <i>Light</i>. They are complacent and self-loving, caring far more about politics and power than about the things they're supposed to care about. But I believed that it was all done for a good cause."
+                    [/message]
+                    [message]
+                        speaker=she_brother
+                        message=_"I think that we should talk more about getting lord Konrad to support us."
+                    [/message]
+                    [message]
+                        speaker=Burke
+                        message=_"Sorry for changing the topic. To get to lord Konrad, we need to pass through untamed Grey Hills, hills and forests filled with lawless scum, bandits, cut-throats, marauders and all kinds of other vermin. We cannot just travel through that place."
+                        [option]
+                            message=_"Why didn't you just kill the bandits? It's your duty to fight them, no?"
+                            [command]
+                                [message]
+                                    speaker=Burke
+                                    message=_"That isn't so easy. I know that I should have done that, but I did not have the resources necessary for a military operation of that size. They knew that attacking my town would force me to attack them, and would also persuade many peasants to pay some extra taxes for warfare. Bandits don't annoy me, so I can ignore them. But they attack most travellers passing through there."
+                                [/message]
+                                [message]
+                                    speaker=Rimaru
+                                    message=_"So we will bring the law there now."
+                                [/message]
+                                [message]
+                                    speaker=she_brother
+                                    message=_"Great plan! So specific..."
+                                [/message]
+                            [/command]
+                        [/option]
+                        [option]
+                            message=_"But we must go there."
+                            [command]
+                                [message]
+                                    speaker=Burke
+                                    message=_"Well, we'll have to destroy them. But how?"
+                                [/message]
+                            [/command]
+                        [/option]
+                    [/message]
+                    [message]
+                        speaker=Rimaru
+                        message=_"So, here is a plan. We will hire the first bandit group we find. They will follow us and support your own soldiers. Maybe we'll also hire another group, depends what will be cheaper, soldiers or hired bandits. Together, we'll attack bandit nests one by one, until we clear the place. The bandit groups aren't loyal to other bandit groups and occasionally even fight others, so they will not be reluctant to fight against other bandits."
+                    [/message]
+                    [message]
+                        speaker=Burke
+                        message=_"That sounds doable. Let me start the preparations."
+                    [/message]
+                    [store_unit]
                         [filter]
-                            id=Manhunter
+                            id=Burke
                         [/filter]
-                        silent=yes
-                        [effect]
-                            apply_to=hitpoints
-                            increase_total=-40%
-                            heal_full=yes
-                        [/effect]
-                    [/object]
-                [/then]
-            [/if]
-            [if]
-                [variable]
-                    name=party_members.length
-                    less_than=7
-                [/variable]
-                [then]
-                    [object]
-                        [filter]
-                            id=Manhunter
-                        [/filter]
-                        silent=yes
-                        [effect]
-                            apply_to=hitpoints
-                            increase_total=-20%
-                            heal_full=yes
-                        [/effect]
-                    [/object]
-                [/then]
-            [/if]
-            [move_unit]
-                id=Manhunter
-                to_x=8
-                to_y=6
-                fire_event=no
-            [/move_unit]
-            {EARTHQUAKE (
+                        variable=burke_store
+                    [/store_unit]
+                    {VARIABLE burke_store.side 1}
+                    {VARIABLE burke_store.variables.hero yes}
+                    [unstore_unit]
+                        variable=burke_store
+                        find_vacant=no
+                    [/unstore_unit]
+                    {CLEAR_VARIABLE burke_store}
+                    {VARIABLE party_members[$party_members.length].id Burke}
+                    {VARIABLE quests.overall 5}
+                    [endlevel]
+                        result=victory
+                        bonus=no
+                        next_scenario=03_To_Tame_a_Land
+                        {NEW_GOLD_CARRYOVER 100}
+                    [/endlevel]
+                [/event]
+
+                [if]
+                    [variable]
+                        name=quests.burkes_castle_southwest_guards
+                        equals=yes
+                    [/variable]
+                    [else]
+                        [event]
+                            name=moveto
+                            [filter]
+                                x,y=1-11,11-20
+                                side=1
+                            [/filter]
+                            {TBC_SPAWN_UNITS_NO_LEADER 2 1.3 "Spearman,Heavy Infantryman,Bowman,Swordsman,Javelineer,Longbowman" 5 16}
+                            [message]
+                                speaker=unit
+                                message=_"There are some guards ahead!"
+                            [/message]
+                            {VARIABLE quests.burkes_castle_southwest_guards yes}
+                        [/event]
+                    [/else]
+                [/if]
+
+                [if]
+                    [variable]
+                        name=quests.burkes_castle_northeast_guards
+                        equals=yes
+                    [/variable]
+                    [else]
+                        [event]
+                            name=moveto
+                            [filter]
+                                x,y=14-23,5-13
+                                side=1
+                            [/filter]
+                            {TBC_SPAWN_UNITS_NO_LEADER 2 1.3 "Spearman,Heavy Infantryman,Pikeman,Bowman,Javelineer,Longbowman" 19 7}
+                            [message]
+                                speaker=unit
+                                message=_"It seems that Burke isn't a good strategist. He has some guards here. If he sent them together with the town's guardsmen against us, we would be in a much greater trouble."
+                            [/message]
+                            {VARIABLE quests.burkes_castle_northeast_guards yes}
+                        [/event]
+                    [/else]
+                [/if]
+
+                [if]
+                    [variable]
+                        name=quests.burkes_castle_burkes_guards
+                        equals=yes
+                    [/variable]
+                    [else]
+                        [event]
+                            name=moveto
+                            [filter]
+                                x,y=1-14,1-10
+                                side=1
+                            [/filter]
+                            {TBC_SPAWN_UNITS_NO_LEADER 2 1 "Swordsman,Pikeman,Shock Trooper,Fencer,Javelineer,Longbowman" 7 5}
+                            [message]
+                                speaker=unit
+                                message=_"Burke's bodyguards are attacking us, I think"
+                            [/message]
+                            {VARIABLE quests.burkes_castle_burkes_guards yes}
+                        [/event]
+                    [/else]
+                [/if]
+            [/then]
+        [/if]
+        {TBC_GOLD_CHEST 4 12 burkes_castle_southwest_chest}
+        {TBC_GOLD_CHEST 12 11 burkes_castle_central_chest}
+        {TBC_GOLD_CHEST 19 6 burkes_castle_northeast_chest}
+
+        [if]
+            [variable]
+                name=quests.overall
+                equals=5
+            [/variable]
+            [then]
+                [message]
+                    speaker=Rimaru
+                    message=_"It's good that the bandits are gone."
+                [/message]
+                [message]
+                    speaker=Burke
+                    message=_"Not really gone, but they are much weaker now. Certainly the remains will still pose a threat to weaker groups of travellers, but lord Konrad's troops will take care of them."
+                [/message]
+                [message]
+                    speaker=Rimaru
+                    message=_"Now, we would like you to accompany us into lord Konrad's court. We need you to help us persuade him to stand against the evil. Or better to say, good twisted into doing evil."
+                [/message]
+                [unit]
+                    side=1
+                    type=Shuja tbc
+                    canrecruit=yes
+                    x,y=23,19
+                    name=_"Al Ghareeb"
+                    id=Al Ghareeb
+                    [variables]
+                        hero=yes
+                    [/variables]
+                [/unit]
+                {VARIABLE party_members[$party_members.length].id "Al Ghareeb"}
+                [move_unit]
+                    id=Al Ghareeb
+                    to_x=7
+                    to_y=4
+                    fire_event=no
+                [/move_unit]
+                [message]
+                    speaker=Burke
+                    message=_"Who are you, stranger? What do you want here? How did you even get here?"
+                [/message]
+                [message]
+                    speaker=Al Ghareeb
+                    message=_"My name is Al Ghareeb. I am an emissary of the Sand Empire. And I paid some of your soldiers to let me here. They were not afraid about your safety, because you have strong friends with you."
+                [/message]
+                [message]
+                    speaker=Burke
+                    message=_"Interesting. What leads an Emissary of the Sand Empire here? I am not the king."
+                [/message]
+                [message]
+                    speaker=Al Ghareeb
+                    message=_"I know that you are not the king, but that is the point. Our countries are at war. A meaningless war, I'd like to say."
+                [/message]
+                [message]
+                    speaker=Burke
+                    message=_"The news of that war haven't reached me yet. I am probably too far away from the borders and they didn't need my soldiers. Why are we at war? Your empire produces a lot of interesting goods I like buying."
+                [/message]
+                [message]
+                    speaker=Al Ghareeb
+                    message=_"A group of healers from your country entered my country. We let them in, because who wouldn't like to have more healers. But they did not heal almost at all. Instead, they started preaching about their faith. That would not be a problem itself, we have the same gods. But they started speaking about the gods having a child sent into their home town, called it a proof of their supremacy and tried to command us and demanded additional tithes for themselves."
+                [/message]
+                [message]
+                    speaker=Rimaru
+                    message=_"These damned Brothers of Larceny... They're trying to advance their schemes even behind the borders of our kingdom. I hope they are leaving the orcs and elves be, that would be a war we cannot win."
+                [/message]
+                [message]
+                    speaker=Burke
+                    message=_"I assume that these men and women were expelled from the country."
+                [/message]
+                [message]
+                    speaker=Al Ghareeb
+                    message=_"Well, we should have done that, but it was too late when we realised what's going on. They realised that public speeches will not allow them to control the people, so they changed their strategy. They hired an insane quantity of mercenaries and started conquering the country, from one oasis to another. No idea where they have the money from. Your king demanded our ruler to stop fighting and suggest a peace treaty with them, but the peace treaty he suggested demanded leaving the conquered land to them."
+                [/message]
+                [message]
+                    speaker=Al Ghareeb
+                    message=_"We could not accept that. We had our duty to our people and we didn't want to lose a quarter of our country. We destroyed them, made the mercenaries flee and killed the preachy healers. But your king started a war with us, invaded our north while we were securing lands elsewhere. We stopped their rapid progress when our armies united, but still, a fifth of our land is occupied and battles are being fought on the new borders."
+                [/message]
+                [message]
+                    speaker=Rimaru
+                    message=_"That was ugly from them. I assume that you're visiting us because you learned somewhere that we're leading a rebellion against Brothers of Larceny as well."
+                [/message]
+                [message]
+                    speaker=Al Ghareeb
+                    message=_"Yes. We have learned that the problem is not your country, but that particular order of white mages. Their control of your country is strong. Conquering your country to get rid of them is a very hard and bloody task and we'd prefer a better solution. A rebellion in your country that would either destroy or reform the Brothers of... Larceny...?"
+                [/message]
+                [message]
+                    speaker=Rimaru
+                    message=_"They call themselves Brothers of Light, but I called them Brothers of Larceny because I started this rebellion due to the extreme tithes they're demanding. Probably to pay those mercenaries to trouble you."
+                [/message]
+                [message]
+                    speaker=Al Ghareeb
+                    message=_"Ah, well. So, we need your rebellion to avoid a large scale war with huge casualties. We will try to force your king to send as many soldiers to the south and avoid confrontations, so that you could attack them without heavy resistance."
+                [/message]
+                [message]
+                    speaker=Burke
+                    message=_"Great. That will be a good alliance."
+                [/message]
+                [while]
+                    [not]
+                        [variable]
+                            name=done
+                            equals=yes
+                        [/variable]
+                    [/not]
+                    [do]
+                        [message]
+                            speaker=Burke
+                            message=_"Good. Any other questions?"
+                            [option]
+                                message=_"How do we know that you can be trusted?"
+                                [command]
+                                    [message]
+                                        speaker=Al Ghareeb
+                                        message=_"That is a good question. I think that you'll learn about the war quite soon. And you should be able to verify what I told about the rebellion your white mages started, though the story will be told from a different angle. And regarding our plan, it's something that can't be verified right now."
+                                    [/message]
+                                    [message]
+                                        speaker=Rimaru
+                                        message=_"They would gain nothing by sending a man to impersonate an emissary bringing a message like this."
+                                    [/message]
+                                [/command]
+                            [/option]
+                            [option]
+                                message=_"What will you do now?"
+                                [command]
+                                    [message]
+                                        speaker=Al Ghareeb
+                                        message=_"The primary goal of my mission is complete. Only the second part remains now, less important and less specific. I was asked to help you in your war. A man of completely different background from a land where different strategies are used must be a handy help."
+                                    [/message]
+                                    [message]
+                                        speaker=hired_swordsman
+                                        message=_"Indeed. Different thinking, better variety of our strategies."
+                                    [/message]
+                                    [message]
+                                        speaker=she_brother
+                                        message=_"I don't mind having him around."
+                                    [/message]
+                                    [message]
+                                        speaker=Rimaru
+                                        message=_"Well, Al Ghareeb, you're in."
+                                    [/message]
+                                [/command]
+                            [/option]
+                            [option]
+                                message=_"Can you tell us something about the Sand Empire?"
+                                [command]
+                                    [message]
+                                        speaker=Al Ghareeb
+                                        message=_"It's south from your kingdom. Its north, that borders with your land and has been conquered, is similar to your lands, it's just more dry, with little rivers and unusual trees. The rest of its lands is a large desert, where the sun shines so hot that there are almost no rivers, only rocks and sand. In some areas, there is more sand, in some areas, there are more rocks, but in general it isn't very habitable."
+                                    [/message]
+                                    [message]
+                                        speaker=Al Ghareeb
+                                        message=_"However, there are oases in the dry lands. A lake usually surrounded by lush vegetation and fertile soil. We live mostly in those oases, but many also herd goats on scarce vegetation that grows on the barren rocks. Further south, there is just totally dry desert where nobody can live. Legends tell that there are dense forests with abundance of rain beyond that desert, but very few travellers who go there return. And those who return report that they found nothing."
+                                    [/message]
+                                [/command]
+                            [/option]
+                            [option]
+                                message=_"You've told us that Sand Empire has the same gods as we... what are the differences the Brothers of Light have trouble with?"
+                                [command]
+                                    [message]
+                                        speaker=faithful_lieutenant
+                                        message=_"I was told that they have strange traditions. The old stories are the same, but they have a strange ritual that they chase a man across the desert, then they catch him and eat him."
+                                    [/message]
+                                    [message]
+                                        speaker=Al Ghareeb
+                                        message=_"The traditions between our countries differ greatly. Vritra the Daughter of Gods was living among us until her departure into unknown, she was our legendary ruler and we're still ruled by her descendants. Her bloodline is still among us, but it's weakening from generation to generation. She was very fond of hunting, so in her name, every year, in every bigger city, we release a prisoner and offer him freedom if we don't find him."
+                                    [/message]
+                                    [message]
+                                        speaker=Rimaru
+                                        message=_"That's quite cruel. But if the stories are true, Vritra was a killer at heart and could not live without battle for too long. She was on the side of good, but her strange need to kill was known to be disturbing. It was a problem sometimes when there were no evil men available."
+                                    [/message]
+                                    [message]
+                                        speaker=she_brother
+                                        message=_"She was capable of so many heroic deeds, but she was not capable of controlling the beast within her. Stories say that she tried to live with humans, but then she left somewhere, maybe to live with communities that did not consider killing evil, like orcs."
+                                    [/message]
+                                    [message]
+                                        speaker=Al Ghareeb
+                                        message=_"The prisoner would sit in prison until his death or would be executed otherwise. We are picking from a group of volunteers usually. He has one night of time to flee, then people start the pursuit. In average, three out of five are caught... and usually killed."
+                                    [/message]
+                                    [message]
+                                        speaker=Rimaru
+                                        message=_"I wonder... wasn't one of your emperor's children... snatched? Or replaced?"
+                                    [/message]
+                                    [message]
+                                        speaker=Al Ghareeb
+                                        message=_"No. They would have noticed it. The emperor's family still looks somewhat different from ordinary humans... exquisite skin, uncanny intelligence, gracious movements, always slim and tall, strength that you would not expect from their body size... They used to be even more glorious, they're trying to marry their cousins to maintain their bloodline's purity, but still it's weakening, children are never grown stronger than parents. Why are you asking?"
+                                    [/message]
+                                    [message]
+                                        speaker=Rimaru
+                                        message=_"The Brothers of Larceny claim that they have a child of gods in their caring hands. I wonder if they didn't steal your emperor's child, that one is literally the descendant of gods."
+                                    [/message]
+                                    [message]
+                                        speaker=Al Ghareeb
+                                        message=_"That's very unlikely. There is a visible difference between Emperor's children and normal children, but the difference isn't striking."
+                                    [/message]
+                                [/command]
+                            [/option]
+                            [option]
+                                message=_"Enough planning, let's visit lord Konrad!"
+                                [command]
+                                    {VARIABLE done yes}
+                                [/command]
+                            [/option]
+                        [/message]
+                    [/do]
+                [/while]
+                {CLEAR_VARIABLE done}
+                [unit]
+                    side=2
+                    type=Manhunter
+                    name=_"???"
+                    x,y=22,18
+                    id=Manhunter
+                [/unit]
+                [if]
+                    [variable]
+                        name=party_members.length
+                        less_than=4
+                    [/variable]
+                    [then]
+                        [object]
+                            [filter]
+                                id=Manhunter
+                            [/filter]
+                            silent=yes
+                            [effect]
+                                apply_to=hitpoints
+                                increase_total=-40%
+                                heal_full=yes
+                            [/effect]
+                        [/object]
+                    [/then]
+                [/if]
+                [if]
+                    [variable]
+                        name=party_members.length
+                        less_than=7
+                    [/variable]
+                    [then]
+                        [object]
+                            [filter]
+                                id=Manhunter
+                            [/filter]
+                            silent=yes
+                            [effect]
+                                apply_to=hitpoints
+                                increase_total=-20%
+                                heal_full=yes
+                            [/effect]
+                        [/object]
+                    [/then]
+                [/if]
+                [move_unit]
+                    id=Manhunter
+                    to_x=8
+                    to_y=6
+                    fire_event=no
+                [/move_unit]
+                {EARTHQUAKE (
+                    [terrain]
+                        x,y=20-21,12
+                        terrain=Xu
+                    [/terrain]
+                    [terrain]
+                        x,y=7,17
+                        terrain=Xu
+                    [/terrain]
+                    [redraw]
+                    [/redraw]
+                )}
+                [message]
+                    speaker=Rimaru
+                    message=_"Who are you? You don't look like another messenger."
+                [/message]
+                [message]
+                    speaker=Manhunter
+                    message=_"I am the bringer of your fate..."
+                [/message]
+                [event]
+                    name=last breath
+                    [filter]
+                        id=Manhunter
+                    [/filter]
+                    [message]
+                        speaker=Manhunter
+                        message=_"You are trying to deny your destiny... It will come for you again..."
+                    [/message]
+                    [move_unit]
+                        id=Manhunter
+                        to_x=22
+                        to_y=18
+                        fire_event=no
+                    [/move_unit]
+                    [kill]
+                        id=Manhunter
+                        fire_event=no
+                        animate=no
+                    [/kill]
+                    [message]
+                        speaker=Burke
+                        message=_"Who the hell was that assassin?"
+                    [/message]
+                    [message]
+                        speaker=Rimaru
+                        message=_"I have no idea. We should be more careful next time when he strikes."
+                    [/message]
+                    {CLEAR_VARIABLE disallow_waypoint}
+                    {VARIABLE quests.overall 6}
+                [/event]
+                [if]
+                    [variable]
+                        name=party_members.length
+                        less_than=8
+                    [/variable]
+                    [then]
+                        [event]
+                            name=spellcast
+                            first_time_only=no
+                            [store_unit]
+                                [filter]
+                                    type=Magic Missile
+                                    [or]
+                                        type=Soulless
+                                    [/or]
+                                    [not]
+                                        [filter_wml]
+                                            [variables]
+                                                weakened=yes
+                                            [/variables]
+                                        [/filter_wml]
+                                    [/not]
+                                [/filter]
+                                variable=summons
+                                kill=no
+                            [/store_unit]
+                            [for]
+                                array=summons
+                                [do]
+                                    {VARIABLE summons[$i].variables.weakened yes}
+                                    [if]
+                                        [variable]
+                                            name=party_members.length
+                                            less_than=6
+                                        [/variable]
+                                        [then]
+                                            [object]
+                                                [filter]
+                                                    id=$summons[$i].id
+                                                [/filter]
+                                                silent=yes
+                                                [effect]
+                                                    apply_to=attack
+                                                    increase_damage=-1
+                                                [/effect]
+                                            [/object]
+                                        [/then]
+                                    [/if]
+                                    [if]
+                                        [variable]
+                                            name=party_members.length
+                                            less_than=5
+                                        [/variable]
+                                        [then]
+                                            [object]
+                                                [filter]
+                                                    id=$summons[$i].id
+                                                [/filter]
+                                                silent=yes
+                                                [effect]
+                                                    apply_to=attack
+                                                    increase_damage=-30%
+                                                [/effect]
+                                            [/object]
+                                        [/then]
+                                    [/if]
+                                    [if]
+                                        [variable]
+                                            name=party_members.length
+                                            less_than=4
+                                        [/variable]
+                                        [then]
+                                            [object]
+                                                [filter]
+                                                    id=$summons[$i].id
+                                                [/filter]
+                                                silent=yes
+                                                [effect]
+                                                    apply_to=attack
+                                                    increase_damage=-1
+                                                [/effect]
+                                            [/object]
+                                        [/then]
+                                    [/if]
+                                [/do]
+                            [/for]
+                            {CLEAR_VARIABLE summons}
+                        [/event]
+                    [/then]
+                [/if]
                 [terrain]
                     x,y=20-21,12
-                    terrain=Xu
+                    terrain=Urb
                 [/terrain]
                 [terrain]
                     x,y=7,17
-                    terrain=Xu
+                    terrain=Urb
                 [/terrain]
                 [redraw]
                 [/redraw]
-            )}
-            [message]
-                speaker=Rimaru
-                message=_"Who are you? You don't look like another messenger."
-            [/message]
-            [message]
-                speaker=Manhunter
-                message=_"I am the bringer of your fate..."
-            [/message]
-            [event]
-                name=last breath
-                [filter]
-                    id=Manhunter
-                [/filter]
-                [message]
-                    speaker=Manhunter
-                    message=_"You are trying to deny your destiny... It will come for you again..."
-                [/message]
-                [move_unit]
-                    id=Manhunter
-                    to_x=22
-                    to_y=18
-                    fire_event=no
-                [/move_unit]
-                [kill]
-                    id=Manhunter
-                    fire_event=no
-                    animate=no
-                [/kill]
-                [message]
-                    speaker=Burke
-                    message=_"Who the hell was that assassin?"
-                [/message]
-                [message]
-                    speaker=Rimaru
-                    message=_"I have no idea. We should be more careful next time when he strikes."
-                [/message]
-                {CLEAR_VARIABLE disallow_waypoint}
-                {VARIABLE quests.overall 6}
-            [/event]
-            [if]
-                [variable]
-                    name=party_members.length
-                    less_than=8
-                [/variable]
-                [then]
-                    [event]
-                        name=spellcast
-                        first_time_only=no
-                        [store_unit]
-                            [filter]
-                                type=Magic Missile
-                                [or]
-                                    type=Soulless
-                                [/or]
-                                [not]
-                                    [filter_wml]
-                                        [variables]
-                                            weakened=yes
-                                        [/variables]
-                                    [/filter_wml]
-                                [/not]
-                            [/filter]
-                            variable=summons
-                            kill=no
-                        [/store_unit]
-                        {FOREACH summons i}
-                            {VARIABLE summons[$i].variables.weakened yes}
-                            [if]
-                                [variable]
-                                    name=party_members.length
-                                    less_than=6
-                                [/variable]
-                                [then]
-                                    [object]
-                                        [filter]
-                                            id=$summons[$i].id
-                                        [/filter]
-                                        silent=yes
-                                        [effect]
-                                            apply_to=attack
-                                            increase_damage=-1
-                                        [/effect]
-                                    [/object]
-                                [/then]
-                            [/if]
-                            [if]
-                                [variable]
-                                    name=party_members.length
-                                    less_than=5
-                                [/variable]
-                                [then]
-                                    [object]
-                                        [filter]
-                                            id=$summons[$i].id
-                                        [/filter]
-                                        silent=yes
-                                        [effect]
-                                            apply_to=attack
-                                            increase_damage=-30%
-                                        [/effect]
-                                    [/object]
-                                [/then]
-                            [/if]
-                            [if]
-                                [variable]
-                                    name=party_members.length
-                                    less_than=4
-                                [/variable]
-                                [then]
-                                    [object]
-                                        [filter]
-                                            id=$summons[$i].id
-                                        [/filter]
-                                        silent=yes
-                                        [effect]
-                                            apply_to=attack
-                                            increase_damage=-1
-                                        [/effect]
-                                    [/object]
-                                [/then]
-                            [/if]
-                        {NEXT i}
-                        {CLEAR_VARIABLE summons}
-                    [/event]
-                [/then]
-            [/if]
-            [terrain]
-                x,y=20-21,12
-                terrain=Urb
-            [/terrain]
-            [terrain]
-                x,y=7,17
-                terrain=Urb
-            [/terrain]
-            [redraw]
-            [/redraw]
-            [end_turn]
-            [/end_turn]				
-        [/then]
-    [/if]
-
+                [end_turn]
+                [/end_turn]
+            [/then]
+        [/if]
     [/event]
 
     {TBC_GLOBAL_EVENTS_RPG}

--- a/spinoffs/The_Beautiful_Child/scenarios/Crooked_Ravine.cfg
+++ b/spinoffs/The_Beautiful_Child/scenarios/Crooked_Ravine.cfg
@@ -46,923 +46,924 @@
     {TBC_PLACE_WAYPOINT 22 19}
 
     [event]
-    name=prestart
-    {CLEAR_RECALLS}
+        name=prestart
+        {CLEAR_RECALLS}
         [time_area]
-        terrain=Mm^Xm,U*,X*
-        {UNDERGROUND}
+            terrain=Mm^Xm,U*,X*
+            {UNDERGROUND}
         [/time_area]
-    {VARIABLE current_scenario crooked_ravine}
-    {TBC_ORIGIN farborough 20 35}
-    {TBC_ORIGIN goonville 20 2}
-    {TBC_ORIGIN burkes_retribution 22 20}
-    {TBC_TRANSITION 0-45 36-37 Farborough _"Farborough" 20 36}
-    [if]
-        [variable]
-            name=quests.overall
-            less_than=2
-        [/variable]
-        [else]
-            {TBC_TRANSITION 13-21 1-2 Goonville _"Goonville" 19 1}
-        [/else]
-        [then]
-            [event]
-                name=moveto
-                [filter]
-                    side=1
-                    x,y=14-35,1-12
-                [/filter]
-                        [remove_shroud]
-                            x,y=21-29,4-11
-                            side=1
-                        [/remove_shroud]
-                {FOREACH brothers_store i}
-                    [unstore_unit]
-                        variable=brothers_store[$i]
-                        find_vacant=yes
-                        x,y=24,7
-                    [/unstore_unit]
-                {NEXT i}
-                {TBC_SPAWN_UNITS_NO_LEADER 2 0.7 "Spearman,Heavy Infantryman,Sergeant,Bowman" 25 8}
-                [message]
-                    speaker=brother_1
-                    message=_"So here you are. The rebels. The ridiculous little rebellion."
-                [/message]
-                [message]
-                    speaker=Rimaru
-                    message=_"So here you are. Brothers of Light. You started all of this trouble. Now, prepare to pay."
-                    [option]
-                    message=_"Calm yourself, Rimaru, you were the peaceful man here."
-                    [command]
-                        [message]
-                            speaker=Rimaru
-                            message=_"These men are warmongers! But well, I am only angry, I am not bloodthirsty. Don't worry, I'll be merciful when it comes to combat. That is quite inevitable."
-                        [/message]
-                        [message]
-                            speaker=bandit_merc
-                            message=_"Skin them alive!"
-                        [/message]
-                        {TBC_DIPLOMACY_TRIED}
-                    [/command]
-                    [/option]
-                    [option]
-                    message=_"You caused all this war, you <i>pyjama wearers</i>, and you deserve punishment for it."
-                    [command]
-                        [message]
-                            speaker=elf_merc
-                            message=_"Or payment, I will get money thanks to their scheme..."
-                        [/message]
-                    [/command]
-                    [/option]
-                    [option]
-                    message=_"We will beat impale you on sticks, skin you alive and boil you to death afterwards!"
-                    [command]
-                        [message]
-                            speaker=Rimaru
-                            message=_"I did not mean to do such horrible things to them. I do not need to kill the people I hate, I kill only if it becomes necessary."
-                        [/message]
-                    [/command]
-                    [/option]
-                [/message]
-                [message]
-                    speaker=she_brother
-                    message=_"That won't help you much. We have already contacted baron Burke and he's ready to send an army to kill you all. And wipe your pathetic Farborough from existence."
-                [/message]
-                [message]
-                    speaker=faithful_lieutenant
-                    message=_"Burke's army is not so huge, we might deal with them with enough support of the villagers. But it won't be possible without casualties."
-                [/message]
-                [message]
-                    speaker=Rimaru
-                    message=_"I think that I will take you captive to make sure that you won't do more harm. And maybe it will help fix you overly callous ways of thinking and undo the harms that brainwashing has done on you."
-                [/message]
-                [message]
-                    speaker=brother_2
-                    message=_"Rimaru, I think that your problem with us is personal. It is not about this increase in tithes, but it is your old pain."
-                [/message]
-                [message]
-                    speaker=she_brother
-                    message=_"What old pain?"
-                [/message]
-                [message]
-                    speaker=Rimaru
-                    message=_"It is an old affair. I may be a grumpy man in my thirties, but I was not like that before. I was a young, aspirant Brother of Light, excelling at healing. I had a little sister named Sicaria to care about after my parents died. I loved her, I cared about her as much as I could, she was also close to becoming a member. We loved each other, because we had no one else."
-                [/message]
-                [message]
-                    speaker=Rimaru
-                    message=_"But then, she got sick. I was trying to heal her, but the disease was too strong. I don't know what disease it was, or if it really was a disease. My cures did not help her to recover, only to slow down its progress. I asked my superiors to help her, to call somebody better at healing, but they told me that I am a very good healer and assigned the task to heal her to me. The best healer himself made that decision. He made much greater miracles in the past, yet..."
-                [/message]
-                [message]
-                    speaker=Rimaru
-                    message=_"He was too lazy to heal her, or it did not fit into his scheme. I could not ask regular Brothers to help me, because their skills were inferior to mine. I struggled for a week, but then she was gone. They probably feared that my brotherly love for her would have brought me to a necromancer who can save even the dead in his own dark way, so they took her to a morgue where I could not go. I haven't even seen her burial, not even her grave."
-                [/message]
-                [message]
-                    speaker=Rimaru
-                    message=_"I have a feeling that there was something darker behind her illness. I had a feeling that my superiors thought that I loved my sister a bit too much and I put her needs above my duties. They were right, I missed many pathetic events of the community because my little sister needed somebody to hold her hand while she falls asleep. I was teaching her some white magic too. It was just an excuse so that I could miss these boring meetings."
-                [/message]
-                [message]
-                    speaker=she_brother
-                    message=_"Stop accusing us of such things. Our order would never have done something so heinous!"
-                [/message]
-                [message]
-                    speaker=Rimaru
-                    message=_"The low-ranking members hardly know what schemes their superiors are working on."
-                [/message]
-                [message]
-                    speaker=brother_1
-                    message=_"I wasn't aware of that story. I never knew why you had left our order. I thought you were forced to leave because of your poisonous talks. But it seems that you became as grumpy as you are now after being removed. We are sorry for the thing that happened to your sister, but that does not excuse your recent actions."
-                [/message]
-                [message]
-                    speaker=Rimaru
-                    message=_"It merely opened my eyes so that I could see through your shallow plots and understand your real intentions. It was money. A lot of money. Hoarding them. Embracing them. Swimming in golden coins."
-                [/message]
-                [message]
-                    speaker=brother_1
-                    message=_"You have gone way too far, Rimaru. For dregs like you, there is only one possible solution. Death. Kill them!"
-                [/message]
-                [message]
-                    speaker=bandit_merc
-                    message=_"Leave no one alive!"
-                [/message]
+        {VARIABLE current_scenario crooked_ravine}
+        {TBC_ORIGIN farborough 20 35}
+        {TBC_ORIGIN goonville 20 2}
+        {TBC_ORIGIN burkes_retribution 22 20}
+        {TBC_TRANSITION 0-45 36-37 Farborough _"Farborough" 20 36}
+        [if]
+            [variable]
+                name=quests.overall
+                less_than=2
+            [/variable]
+            [else]
+                {TBC_TRANSITION 13-21 1-2 Goonville _"Goonville" 19 1}
+            [/else]
+            [then]
                 [event]
-                    name=last breath
-                    first_time_only=no
+                    name=moveto
                     [filter]
-                        type=White Mage
-                        side=2
-                        [or]
-                            type=Mage of Light
-                            side=2
-                        [/or]
+                        side=1
+                        x,y=14-35,1-12
                     [/filter]
-                    [fire_event]
-                        name=brothers_dead_check
-                    [/fire_event]
-                [/event]
-
-                [event]
-                    name=turn refresh
-                    first_time_only=no
-                    [fire_event]
-                        name=brothers_dead_check
-                    [/fire_event]
-                [/event]
-
-                [event]
-                    name=brothers_dead_check
-                    first_time_only=no
-                    [if]
-                        [have_unit]
+                    [remove_shroud]
+                        x,y=21-29,4-11
+                        side=1
+                    [/remove_shroud]
+                    [foreach]
+                        array=brothers_store
+                        [do]
+                            [unstore_unit]
+                                variable=this_item
+                                find_vacant=yes
+                                x,y=24,7
+                            [/unstore_unit]
+                        [/do]
+                    [/foreach]
+                    {TBC_SPAWN_UNITS_NO_LEADER 2 0.7 "Spearman,Heavy Infantryman,Sergeant,Bowman" 25 8}
+                    [message]
+                        speaker=brother_1
+                        message=_"So here you are. The rebels. The ridiculous little rebellion."
+                    [/message]
+                    [message]
+                        speaker=Rimaru
+                        message=_"So here you are. Brothers of Light. You started all of this trouble. Now, prepare to pay."
+                        [option]
+                            message=_"Calm yourself, Rimaru, you were the peaceful man here."
+                            [command]
+                                [message]
+                                    speaker=Rimaru
+                                    message=_"These men are warmongers! But well, I am only angry, I am not bloodthirsty. Don't worry, I'll be merciful when it comes to combat. That is quite inevitable."
+                                [/message]
+                                [message]
+                                    speaker=bandit_merc
+                                    message=_"Skin them alive!"
+                                [/message]
+                                {TBC_DIPLOMACY_TRIED}
+                            [/command]
+                        [/option]
+                        [option]
+                            message=_"You caused all this war, you <i>pyjama wearers</i>, and you deserve punishment for it."
+                            [command]
+                                [message]
+                                    speaker=elf_merc
+                                    message=_"Or payment, I will get money thanks to their scheme..."
+                                [/message]
+                            [/command]
+                        [/option]
+                        [option]
+                            message=_"We will beat impale you on sticks, skin you alive and boil you to death afterwards!"
+                            [command]
+                                [message]
+                                    speaker=Rimaru
+                                    message=_"I did not mean to do such horrible things to them. I do not need to kill the people I hate, I kill only if it becomes necessary."
+                                [/message]
+                            [/command]
+                        [/option]
+                    [/message]
+                    [message]
+                        speaker=she_brother
+                        message=_"That won't help you much. We have already contacted baron Burke and he's ready to send an army to kill you all. And wipe your pathetic Farborough from existence."
+                    [/message]
+                    [message]
+                        speaker=faithful_lieutenant
+                        message=_"Burke's army is not so huge, we might deal with them with enough support of the villagers. But it won't be possible without casualties."
+                    [/message]
+                    [message]
+                        speaker=Rimaru
+                        message=_"I think that I will take you captive to make sure that you won't do more harm. And maybe it will help fix you overly callous ways of thinking and undo the harms that brainwashing has done on you."
+                    [/message]
+                    [message]
+                        speaker=brother_2
+                        message=_"Rimaru, I think that your problem with us is personal. It is not about this increase in tithes, but it is your old pain."
+                    [/message]
+                    [message]
+                        speaker=she_brother
+                        message=_"What old pain?"
+                    [/message]
+                    [message]
+                        speaker=Rimaru
+                        message=_"It is an old affair. I may be a grumpy man in my thirties, but I was not like that before. I was a young, aspirant Brother of Light, excelling at healing. I had a little sister named Sicaria to care about after my parents died. I loved her, I cared about her as much as I could, she was also close to becoming a member. We loved each other, because we had no one else."
+                    [/message]
+                    [message]
+                        speaker=Rimaru
+                        message=_"But then, she got sick. I was trying to heal her, but the disease was too strong. I don't know what disease it was, or if it really was a disease. My cures did not help her to recover, only to slow down its progress. I asked my superiors to help her, to call somebody better at healing, but they told me that I am a very good healer and assigned the task to heal her to me. The best healer himself made that decision. He made much greater miracles in the past, yet..."
+                    [/message]
+                    [message]
+                        speaker=Rimaru
+                        message=_"He was too lazy to heal her, or it did not fit into his scheme. I could not ask regular Brothers to help me, because their skills were inferior to mine. I struggled for a week, but then she was gone. They probably feared that my brotherly love for her would have brought me to a necromancer who can save even the dead in his own dark way, so they took her to a morgue where I could not go. I haven't even seen her burial, not even her grave."
+                    [/message]
+                    [message]
+                        speaker=Rimaru
+                        message=_"I have a feeling that there was something darker behind her illness. I had a feeling that my superiors thought that I loved my sister a bit too much and I put her needs above my duties. They were right, I missed many pathetic events of the community because my little sister needed somebody to hold her hand while she falls asleep. I was teaching her some white magic too. It was just an excuse so that I could miss these boring meetings."
+                    [/message]
+                    [message]
+                        speaker=she_brother
+                        message=_"Stop accusing us of such things. Our order would never have done something so heinous!"
+                    [/message]
+                    [message]
+                        speaker=Rimaru
+                        message=_"The low-ranking members hardly know what schemes their superiors are working on."
+                    [/message]
+                    [message]
+                        speaker=brother_1
+                        message=_"I wasn't aware of that story. I never knew why you had left our order. I thought you were forced to leave because of your poisonous talks. But it seems that you became as grumpy as you are now after being removed. We are sorry for the thing that happened to your sister, but that does not excuse your recent actions."
+                    [/message]
+                    [message]
+                        speaker=Rimaru
+                        message=_"It merely opened my eyes so that I could see through your shallow plots and understand your real intentions. It was money. A lot of money. Hoarding them. Embracing them. Swimming in golden coins."
+                    [/message]
+                    [message]
+                        speaker=brother_1
+                        message=_"You have gone way too far, Rimaru. For dregs like you, there is only one possible solution. Death. Kill them!"
+                    [/message]
+                    [message]
+                        speaker=bandit_merc
+                        message=_"Leave no one alive!"
+                    [/message]
+                    [event]
+                        name=last breath
+                        first_time_only=no
+                        [filter]
                             type=White Mage
                             side=2
                             [or]
                                 type=Mage of Light
                                 side=2
                             [/or]
-                        [/have_unit]
-                        [else]
-                            [if]
-                                [have_unit]
+                        [/filter]
+                        [fire_event]
+                            name=brothers_dead_check
+                        [/fire_event]
+                    [/event]
+
+                    [event]
+                        name=turn refresh
+                        first_time_only=no
+                        [fire_event]
+                            name=brothers_dead_check
+                        [/fire_event]
+                    [/event]
+
+                    [event]
+                        name=brothers_dead_check
+                        first_time_only=no
+                        [if]
+                            [have_unit]
+                                type=White Mage
+                                side=2
+                                [or]
+                                    type=Mage of Light
                                     side=2
-                                [/have_unit]
-                                [then]
-                                    [message]
+                                [/or]
+                            [/have_unit]
+                            [else]
+                                [if]
+                                    [have_unit]
                                         side=2
-                                        message=_"(throws away his weapon) Time to give up. There is no point to risk our lives for the cause of dead men."
-                                    [/message]
-                                    [message]
-                                        speaker=Rimaru
-                                        message=_"What will you do when we let you go?"
-                                    [/message]
-                                    [message]
-                                        side=2
-                                        message=_"We'll return home or become fugitives. Better than almost sure death by your hands."
-                                    [/message]
-                                    [message]
-                                        speaker=Rimaru
-                                        message=_"Fine, you can go."
-                                    [/message]
-                                [/then]
-                            [/if]
-                            [message]
-                                speaker=Rimaru
-                                message=_"Finally, they are defeated. But it seems like if they already had visited Burke."
-                            [/message]
-                            [message]
-                                speaker=player
-                                message=_"That's bad. What shall we do?"
-                            [/message]
-                            [message]
-                                speaker=Rimaru
-                                message=_"We can expect a load of raiders to punish the village and look for us. We need to rally the villagers and try to defeat them in these woods, before they reach the fields and do damage."
-                            [/message]
-                            [message]
-                                speaker=player
-                                message=_"A lot of people will die, the villagers aren't much prepared for battle."
-                            [/message]
-                            [message]
-                                speaker=Rimaru
-                                message=_"We can't defeat them otherwise, we were capable to defeat a few small groups of soldiers, but not a larger battalion."
-                            [/message]
-                            [endlevel]
-                                result=victory
-                                bonus=no
-                                next_scenario=01_Punishers
-                                {NEW_GOLD_CARRYOVER 100}
-                            [/endlevel]
-                        [/else]
-                    [/if]
+                                    [/have_unit]
+                                    [then]
+                                        [message]
+                                            side=2
+                                            message=_"(throws away his weapon) Time to give up. There is no point to risk our lives for the cause of dead men."
+                                        [/message]
+                                        [message]
+                                            speaker=Rimaru
+                                            message=_"What will you do when we let you go?"
+                                        [/message]
+                                        [message]
+                                            side=2
+                                            message=_"We'll return home or become fugitives. Better than almost sure death by your hands."
+                                        [/message]
+                                        [message]
+                                            speaker=Rimaru
+                                            message=_"Fine, you can go."
+                                        [/message]
+                                    [/then]
+                                [/if]
+                                [message]
+                                    speaker=Rimaru
+                                    message=_"Finally, they are defeated. But it seems like if they already had visited Burke."
+                                [/message]
+                                [message]
+                                    speaker=player
+                                    message=_"That's bad. What shall we do?"
+                                [/message]
+                                [message]
+                                    speaker=Rimaru
+                                    message=_"We can expect a load of raiders to punish the village and look for us. We need to rally the villagers and try to defeat them in these woods, before they reach the fields and do damage."
+                                [/message]
+                                [message]
+                                    speaker=player
+                                    message=_"A lot of people will die, the villagers aren't much prepared for battle."
+                                [/message]
+                                [message]
+                                    speaker=Rimaru
+                                    message=_"We can't defeat them otherwise, we were capable to defeat a few small groups of soldiers, but not a larger battalion."
+                                [/message]
+                                [endlevel]
+                                    result=victory
+                                    bonus=no
+                                    next_scenario=01_Punishers
+                                    {NEW_GOLD_CARRYOVER 100}
+                                [/endlevel]
+                            [/else]
+                        [/if]
+                    [/event]
                 [/event]
-            [/event]
-        [/then]
-    [/if]
+            [/then]
+        [/if]
     [/event]
 
     [event]
-    name=start
-    [if]
-        [variable]
-            name=quests.entered_ravine
-            equals=yes
-        [/variable]
-        [else]
-            [message]
-                speaker=elf_merc
-                message=_"Finally out of the town. The nature is much more beautiful without all those unnatural fields."
-            [/message]
-            [message]
-                speaker=Rimaru
-                message=_"We will soon find the Crooked Ravine. If they get through it before we reach them, it's too late and baron Burke will send his soldiers here."
-            [/message]
-            [while]
-                [not]
-                    [variable]
-                        name=done
-                        equals=yes
-                    [/variable]
-                [/not]
-                [do]
-                    [message]
-                        speaker=Rimaru
-                        message=_"What shall we do?"
-                        [option]
-                        message=_"We might just rush ahead and fight our way through anything that blocks us."
-                        [command]
-                            [if]
-                                [have_unit]
-                                    id=faithful_lieutenant
-                                [/have_unit]
-                                [then]
+        name=start
+        [if]
+            [variable]
+                name=quests.entered_ravine
+                equals=yes
+            [/variable]
+            [else]
+                [message]
+                    speaker=elf_merc
+                    message=_"Finally out of the town. The nature is much more beautiful without all those unnatural fields."
+                [/message]
+                [message]
+                    speaker=Rimaru
+                    message=_"We will soon find the Crooked Ravine. If they get through it before we reach them, it's too late and baron Burke will send his soldiers here."
+                [/message]
+                [while]
+                    [not]
+                        [variable]
+                            name=done
+                            equals=yes
+                        [/variable]
+                    [/not]
+                    [do]
+                        [message]
+                            speaker=Rimaru
+                            message=_"What shall we do?"
+                            [option]
+                                message=_"We might just rush ahead and fight our way through anything that blocks us."
+                                [command]
+                                    [if]
+                                        [have_unit]
+                                            id=faithful_lieutenant
+                                        [/have_unit]
+                                        [then]
+                                            [message]
+                                                speaker=faithful_lieutenant
+                                                message=_"That will be risky, there can be bandits, more ambushers and other problems."
+                                            [/message]
+                                            [message]
+                                                speaker=bandit_merc
+                                                message=_"Bandits! Not exactly my allies, it's better to avoid them for sure."
+                                            [/message]
+                                        [/then]
+                                    [/if]
                                     [message]
-                                        speaker=faithful_lieutenant
-                                        message=_"That will be risky, there can be bandits, more ambushers and other problems."
+                                        speaker=Rimaru
+                                        message=_"I think too that it would be quite risky, but I don't see many other alternatives."
+                                    [/message]
+                                [/command]
+                            [/option]
+                            [option]
+                                message=_"Our elvish friend might give us some counsel."
+                                [show_if]
+                                    [have_unit]
+                                        id=elf_merc
+                                    [/have_unit]
+                                [/show_if]
+                                [command]
+                                    [message]
+                                        speaker=elf_merc
+                                        message=_"Indeed. I'd prefer to follow the eastern border of the river, we will avoid most enemies preparing ambushes. We might encounter some animals, but that should be far less trouble than human squads."
                                     [/message]
                                     [message]
-                                        speaker=bandit_merc
-                                        message=_"Bandits! Not exactly my allies, it's better to avoid them for sure."
-                                    [/message]
-                                [/then]
-                            [/if]
-                            [message]
-                                speaker=Rimaru
-                                message=_"I think too that it would be quite risky, but I don't see many other alternatives."
-                            [/message]
-                        [/command]
-                        [/option]
-                        [option]
-                        message=_"Our elvish friend might give us some counsel."
-                        [show_if]
-                            [have_unit]
-                                id=elf_merc
-                            [/have_unit]
-                        [/show_if]
-                        [command]
-                            [message]
-                                speaker=elf_merc
-                                message=_"Indeed. I'd prefer to follow the eastern border of the river, we will avoid most enemies preparing ambushes. We might encounter some animals, but that should be far less trouble than human squads."
-                            [/message]
-                            [message]
-                                speaker=Rimaru
-                                message=_"We might miss the Brothers of Light in that case."
-                            [/message]
-                            [message]
-                                speaker=elf_merc
-                                message=_"Yes, but we can wait for them in the ravine. Or search the area for traces and learn where they went."
-                            [/message]
-                        [/command]
-                        [/option]
-                        [option]
-                        message=_"Does our tactician have some suggestions?"
-                        [show_if]
-                            [have_unit]
-                                id=faithful_lieutenant
-                            [/have_unit]
-                        [/show_if]
-                        [command]
-                            [message]
-                                speaker=faithful_lieutenant
-                                message=_"I'd prefer to walk east from the path, not too far to avoid animals, but not too close to avoid hostile encounters."
-                            [/message]
-                            [message]
-                                speaker=Rimaru
-                                message=_"Bandits might expect that too."
-                            [/message]
-                            [message]
-                                speaker=bandit_merc
-                                message=_"Indeed. When we were ambushing, it happened frequently that people knew the area and expected a trap, so we used to place a few sentries around to warn us if they entered the forest so that we could follow them there."
-                            [/message]
-                            [message]
-                                speaker=faithful_lieutenant
-                                message=_"Maybe these don't have sentries around. In that case, it would be the only way without enemies."
-                            [/message]
-                        [/command]
-                        [/option]
-                        [option]
-                        message=_"There are swamps around the river, how about going through there? Nobody likes swamps, and we can't expect bandits or other enemies to wait there."
-                        [command]
-                            [message]
-                                speaker=bandit_merc
-                                message=_"I hate swamps!"
-                            [/message]
-                            [message]
-                                speaker=elf_merc
-                                message=_"I don't mind them. It's quite an exercise for dexterity to jump from one tree stump to another, a practice for eyes to see where the ground is solid enough, and it's fun to look at clumsy humans getting dirty. If we met some enemies there, they would just need a lot of time to come to me, taking arrow after arrow in their chests."
-                            [/message]
-                            [message]
-                                speaker=Rimaru
-                                message=_"I don't like swamps, but it should be quite safe."
-                            [/message]
-                            [message]
-                                speaker=player
-                                message=_"Well, but there might be saurians or bog monsters."
-                            [/message]
-                            [message]
-                                speaker=Rimaru
-                                message=_"Haha, saurians? They don't live here, they live somewhere far away. If they do really exist and aren't just a fairy tale. Bog monsters surely don't exist. I don't believe in such things."
-                            [/message]
-                            [if]
-                                [have_unit]
-                                    id=faithful_lieutenant
-                                [/have_unit]
-                                [then]
-                                    [message]
-                                        speaker=faithful_lieutenant
-                                        message=_"We must avoid swamps. One wrong step and the mud will suck you down and you will drown in it. I don't want to die like that."
+                                        speaker=Rimaru
+                                        message=_"We might miss the Brothers of Light in that case."
                                     [/message]
                                     [message]
                                         speaker=elf_merc
-                                        message=_"If that happens, you should try to lie down on your belly, slowly move your legs to release them and crawl away."
+                                        message=_"Yes, but we can wait for them in the ravine. Or search the area for traces and learn where they went."
                                     [/message]
+                                [/command]
+                            [/option]
+                            [option]
+                                message=_"Does our tactician have some suggestions?"
+                                [show_if]
+                                    [have_unit]
+                                        id=faithful_lieutenant
+                                    [/have_unit]
+                                [/show_if]
+                                [command]
                                     [message]
                                         speaker=faithful_lieutenant
-                                        message=_"Lie down on my belly? That will only make me drown faster!"
+                                        message=_"I'd prefer to walk east from the path, not too far to avoid animals, but not too close to avoid hostile encounters."
                                     [/message]
                                     [message]
                                         speaker=Rimaru
-                                        message=_"No. You cannot drown like that. When your body submerges into quicksand, the soil that was there before is pushed away and above. It has its own weight that presses you out of the quicksand, it's called buoyant force. That force also allows people to swim. Because of it, you can't fully submerge in any material heavier than water. The only way to drown in a swamp is to get stuck there when a flood comes or you fall unconscious face down into it."
+                                        message=_"Bandits might expect that too."
+                                    [/message]
+                                    [message]
+                                        speaker=bandit_merc
+                                        message=_"Indeed. When we were ambushing, it happened frequently that people knew the area and expected a trap, so we used to place a few sentries around to warn us if they entered the forest so that we could follow them there."
                                     [/message]
                                     [message]
                                         speaker=faithful_lieutenant
-                                        message=_"Thank you, Master Swampologist. Now, one of my fears is gone."
+                                        message=_"Maybe these don't have sentries around. In that case, it would be the only way without enemies."
                                     [/message]
-                                [/then]
-                            [/if]
-                        [/command]
-                        [/option]
-                        [option]
-                        message=_"Enough planning, let's go!"
-                        [command]
-                            {VARIABLE done yes}
-                        [/command]
-                        [/option]
-                    [/message]
-                [/do]
-            [/while]
-            {CLEAR_VARIABLE done}
-            {VARIABLE quests.entered_ravine yes}
-        [/else]
-    [/if]
-
-    [if]
-        [variable]
-            name=quests.seen_ravine_camp
-            equals=yes
-        [/variable]
-        [else]
-            [event]
-                name=moveto
-                [filter]
-                    x,y=18-23,25-29
-                    side=1
-                [/filter]
-                [message]
-                    speaker=unit
-                    message=_"They must have built an encampment here. No idea why, but it looks abandoned."
-                [/message]
-                [message]
-                    speaker=player
-                    message=_"Hmm... it can be a trap..."
-                [/message]
-                [message]
-                    speaker=bandit_merc
-                    message=_"Yes, it is a common trick to let the victims investigate some place or camp there for the night. It will let you attack them unexpectedly and in a place you know very well."
-                [/message]
-                {VARIABLE quests.seen_ravine_camp yes}
-            [/event]
-        [/else]
-    [/if]
-    
-    [if]
-        [variable]
-            name=quests.ravine_central_ambush
-            equals=yes
-        [/variable]
-        [else]
-            [event]
-                name=moveto
-                [filter]
-                    x,y=20-26,19-23
-                    side=1
-                [/filter]
-                {TBC_SPAWN_UNITS 2 0.8 "Spearman,Heavy Infantryman,Sergeant,Bowman" 26 24 Cavalryman boss_1}
-                [message]
-                    speaker=boss_1
-                    message=_"It is an ambush, dumb people! Lay down your weapons and we will slay you without pain!"
-                [/message]
-                [message]
-                    speaker=elf_merc
-                    message=_"We should not have gone this way..."
-                [/message]
-                [message]
-                    speaker=player
-                    message=_"They are not numerous enough to defeat us. Attack!"
-                [/message]
-                {VARIABLE quests.ravine_central_ambush yes}
-            [/event]
-        [/else]
-    [/if]
-    
-    [if]
-        [variable]
-            name=quests.ravine_eastern_ambush
-            equals=yes
-        [/variable]
-        [else]
-            [event]
-                name=moveto
-                [filter]
-                    x,y=4-11,28-32
-                    side=1
-                [/filter]
-                {TBC_SPAWN_UNITS 3 0.6 "Thug,Bandit,Poacher" 12 33 Highwayman boss_2}
-                [message]
-                    speaker=boss_2
-                    message=_"I smell weakness..."
-                [/message]
-                [message]
-                    speaker=unit
-                    message=_"Nah, that's your own stink you have just noticed."
-                [/message]
-                [message]
-                    speaker=boss_2
-                    message=_"Attack them, you pieces of dung that move!"
-                [/message]
-                [message]
-                    speaker=Rimaru
-                    message=_"I wonder how he can keep somebody obedient if he speaks like that..."
-                [/message]
-                {VARIABLE quests.ravine_eastern_ambush yes}
-            [/event]
-        [/else]
-    [/if]
-    
-    [if]
-        [variable]
-            name=quests.ravine_northeastern_ambush
-            equals=yes
-        [/variable]
-        [else]
-            [event]
-                name=moveto
-                [filter]
-                    x,y=6-13,16-21
-                    side=1
-                [/filter]
-                {TBC_SPAWN_UNITS 3 0.8 "Thug,Poacher,Footpad,Thief" 9 15 Thug boss_3}
-                [message]
-                    speaker=boss_3
-                    message=_"You lost your way, traveller?"
-                [/message]
-                [message]
-                    speaker=unit
-                    message=_"Not really..."
-                [/message]
-                [message]
-                    speaker=boss_3
-                    message=_"Be careful, there can be some murderous outlaws nearby."
-                [/message]
-                [message]
-                    speaker=unit
-                    message=_"Thanks for warning."
-                [/message]
-                [message]
-                    speaker=boss_3
-                    message=_"Now, you've been warned. There are murderous outlaws ahead and you have money, armour, weapons... plenty of things we need. Hand them over to us or you will learn who these murderous outlaws are!"
-                    [option]
-                    message=_"Hand over <i>your</i> weapons or we will be murderous outlaws too!"
-                    [command]
-                        [message]
-                            speaker=boss_3
-                            message=_"I am not scared of you. Kill them all!"
+                                [/command]
+                            [/option]
+                            [option]
+                                message=_"There are swamps around the river, how about going through there? Nobody likes swamps, and we can't expect bandits or other enemies to wait there."
+                                [command]
+                                    [message]
+                                        speaker=bandit_merc
+                                        message=_"I hate swamps!"
+                                    [/message]
+                                    [message]
+                                        speaker=elf_merc
+                                        message=_"I don't mind them. It's quite an exercise for dexterity to jump from one tree stump to another, a practice for eyes to see where the ground is solid enough, and it's fun to look at clumsy humans getting dirty. If we met some enemies there, they would just need a lot of time to come to me, taking arrow after arrow in their chests."
+                                    [/message]
+                                    [message]
+                                        speaker=Rimaru
+                                        message=_"I don't like swamps, but it should be quite safe."
+                                    [/message]
+                                    [message]
+                                        speaker=player
+                                        message=_"Well, but there might be saurians or bog monsters."
+                                    [/message]
+                                    [message]
+                                        speaker=Rimaru
+                                        message=_"Haha, saurians? They don't live here, they live somewhere far away. If they do really exist and aren't just a fairy tale. Bog monsters surely don't exist. I don't believe in such things."
+                                    [/message]
+                                    [if]
+                                        [have_unit]
+                                            id=faithful_lieutenant
+                                        [/have_unit]
+                                        [then]
+                                            [message]
+                                                speaker=faithful_lieutenant
+                                                message=_"We must avoid swamps. One wrong step and the mud will suck you down and you will drown in it. I don't want to die like that."
+                                            [/message]
+                                            [message]
+                                                speaker=elf_merc
+                                                message=_"If that happens, you should try to lie down on your belly, slowly move your legs to release them and crawl away."
+                                            [/message]
+                                            [message]
+                                                speaker=faithful_lieutenant
+                                                message=_"Lie down on my belly? That will only make me drown faster!"
+                                            [/message]
+                                            [message]
+                                                speaker=Rimaru
+                                                message=_"No. You cannot drown like that. When your body submerges into quicksand, the soil that was there before is pushed away and above. It has its own weight that presses you out of the quicksand, it's called buoyant force. That force also allows people to swim. Because of it, you can't fully submerge in any material heavier than water. The only way to drown in a swamp is to get stuck there when a flood comes or you fall unconscious face down into it."
+                                            [/message]
+                                            [message]
+                                                speaker=faithful_lieutenant
+                                                message=_"Thank you, Master Swampologist. Now, one of my fears is gone."
+                                            [/message]
+                                        [/then]
+                                    [/if]
+                                [/command]
+                            [/option]
+                            [option]
+                                message=_"Enough planning, let's go!"
+                                [command]
+                                    {VARIABLE done yes}
+                                [/command]
+                            [/option]
                         [/message]
-                        [store_unit]
-                            [filter]
-                                side=1
-                                gender=female
-                            [/filter]
-                            variable=women
-                            kill=no
-                        [/store_unit]
-                        [if]
-                            [variable]
-                                name=women.length
-                                greater_than=0
-                            [/variable]
-                            [then]
-                                [message]
-                                    speaker=$women[0].id
-                                    message=_"You're asking them to do the impossible, fool!"
-                                [/message]
+                    [/do]
+                [/while]
+                {CLEAR_VARIABLE done}
+                {VARIABLE quests.entered_ravine yes}
+            [/else]
+        [/if]
+
+        [if]
+            [variable]
+                name=quests.seen_ravine_camp
+                equals=yes
+            [/variable]
+            [else]
+                [event]
+                    name=moveto
+                    [filter]
+                        x,y=18-23,25-29
+                        side=1
+                    [/filter]
+                    [message]
+                        speaker=unit
+                        message=_"They must have built an encampment here. No idea why, but it looks abandoned."
+                    [/message]
+                    [message]
+                        speaker=player
+                        message=_"Hmm... it can be a trap..."
+                    [/message]
+                    [message]
+                        speaker=bandit_merc
+                        message=_"Yes, it is a common trick to let the victims investigate some place or camp there for the night. It will let you attack them unexpectedly and in a place you know very well."
+                    [/message]
+                    {VARIABLE quests.seen_ravine_camp yes}
+                [/event]
+            [/else]
+        [/if]
+
+        [if]
+            [variable]
+                name=quests.ravine_central_ambush
+                equals=yes
+            [/variable]
+            [else]
+                [event]
+                    name=moveto
+                    [filter]
+                        x,y=20-26,19-23
+                        side=1
+                    [/filter]
+                    {TBC_SPAWN_UNITS 2 0.8 "Spearman,Heavy Infantryman,Sergeant,Bowman" 26 24 Cavalryman boss_1}
+                    [message]
+                        speaker=boss_1
+                        message=_"It is an ambush, dumb people! Lay down your weapons and we will slay you without pain!"
+                    [/message]
+                    [message]
+                        speaker=elf_merc
+                        message=_"We should not have gone this way..."
+                    [/message]
+                    [message]
+                        speaker=player
+                        message=_"They are not numerous enough to defeat us. Attack!"
+                    [/message]
+                    {VARIABLE quests.ravine_central_ambush yes}
+                [/event]
+            [/else]
+        [/if]
+
+        [if]
+            [variable]
+                name=quests.ravine_eastern_ambush
+                equals=yes
+            [/variable]
+            [else]
+                [event]
+                    name=moveto
+                    [filter]
+                        x,y=4-11,28-32
+                        side=1
+                    [/filter]
+                    {TBC_SPAWN_UNITS 3 0.6 "Thug,Bandit,Poacher" 12 33 Highwayman boss_2}
+                    [message]
+                        speaker=boss_2
+                        message=_"I smell weakness..."
+                    [/message]
+                    [message]
+                        speaker=unit
+                        message=_"Nah, that's your own stink you have just noticed."
+                    [/message]
+                    [message]
+                        speaker=boss_2
+                        message=_"Attack them, you pieces of dung that move!"
+                    [/message]
+                    [message]
+                        speaker=Rimaru
+                        message=_"I wonder how he can keep somebody obedient if he speaks like that..."
+                    [/message]
+                    {VARIABLE quests.ravine_eastern_ambush yes}
+                [/event]
+            [/else]
+        [/if]
+
+        [if]
+            [variable]
+                name=quests.ravine_northeastern_ambush
+                equals=yes
+            [/variable]
+            [else]
+                [event]
+                    name=moveto
+                    [filter]
+                        x,y=6-13,16-21
+                        side=1
+                    [/filter]
+                    {TBC_SPAWN_UNITS 3 0.8 "Thug,Poacher,Footpad,Thief" 9 15 Thug boss_3}
+                    [message]
+                        speaker=boss_3
+                        message=_"You lost your way, traveller?"
+                    [/message]
+                    [message]
+                        speaker=unit
+                        message=_"Not really..."
+                    [/message]
+                    [message]
+                        speaker=boss_3
+                        message=_"Be careful, there can be some murderous outlaws nearby."
+                    [/message]
+                    [message]
+                        speaker=unit
+                        message=_"Thanks for warning."
+                    [/message]
+                    [message]
+                        speaker=boss_3
+                        message=_"Now, you've been warned. There are murderous outlaws ahead and you have money, armour, weapons... plenty of things we need. Hand them over to us or you will learn who these murderous outlaws are!"
+                        [option]
+                            message=_"Hand over <i>your</i> weapons or we will be murderous outlaws too!"
+                            [command]
                                 [message]
                                     speaker=boss_3
-                                    message=_"Leave the women live, some of us need some fun for long autumn evenings."
+                                    message=_"I am not scared of you. Kill them all!"
+                                [/message]
+                                [store_unit]
+                                    [filter]
+                                        side=1
+                                        gender=female
+                                    [/filter]
+                                    variable=women
+                                    kill=no
+                                [/store_unit]
+                                [if]
+                                    [variable]
+                                        name=women.length
+                                        greater_than=0
+                                    [/variable]
+                                    [then]
+                                        [message]
+                                            speaker=$women[0].id
+                                            message=_"You're asking them to do the impossible, fool!"
+                                        [/message]
+                                        [message]
+                                            speaker=boss_3
+                                            message=_"Leave the women live, some of us need some fun for long autumn evenings."
+                                        [/message]
+                                        [message]
+                                            speaker=$women[0].id
+                                            message=_"Another reason for me to kill you, lowlife!"
+                                        [/message]
+                                    [/then]
+                                [/if]
+                                {CLEAR_VARIABLE women}
+                            [/command]
+                        [/option]
+                        [option]
+                            message=_"Do you really think that bunch of weaklings can kill us all?"
+                            [command]
+                                [message]
+                                    speaker=boss_3
+                                    message=_"Indeed, hehehehee."
+                                [/message]
+                            [/command]
+                        [/option]
+                        [option]
+                            message=_"Oh, I am so afraid!"
+                            [command]
+                                [message]
+                                    speaker=boss_3
+                                    message=_"Haha, easy, a half of them is gonna run away!"
                                 [/message]
                                 [message]
-                                    speaker=$women[0].id
-                                    message=_"Another reason for me to kill you, lowlife!"
+                                    speaker=player
+                                    message=_"He is too dumb to understand the joke..."
                                 [/message]
-                            [/then]
-                        [/if]
-                        {CLEAR_VARIABLE women}
-                    [/command]
-                    [/option]
-                    [option]
-                    message=_"Do you really think that bunch of weaklings can kill us all?"
-                    [command]
-                        [message]
-                            speaker=boss_3
-                            message=_"Indeed, hehehehee."
-                        [/message]
-                    [/command]
-                    [/option]
-                    [option]
-                    message=_"Oh, I am so afraid!"
-                    [command]
-                        [message]
-                            speaker=boss_3
-                            message=_"Haha, easy, a half of them is gonna run away!"
-                        [/message]
-                        [message]
-                            speaker=player
-                            message=_"He is too dumb to understand the joke..."
-                        [/message]
-                    [/command]
-                    [/option]
-                    [option]
-                    message=_"Look at us, fool. We are equally numerous, we have better weapons, we have steel blades, you have knives and wooden weapons. How will your rags protect you from our weapons? Consider it, please."
-                    [command]
-                        [message]
-                            speaker=boss_3
-                            message=_"You... might be right."
-                        [/message]
-                        {TBC_DIPLOMACY_TRIED}
-                        [gold]
-                            side=1
-                            amount=20
-                        [/gold]
-                        [message]
-                            speaker=boss_3
-                            message=_"Here, have this gold and let me go."
-                        [/message]
-                        [move_unit]
-                            id=boss_3
-                            to_x=9
-                            to_y=13
-                            fire_event=no
-                        [/move_unit]
-                        [message]
-                            speaker=boss_3
-                            message=_"I think that my former friends still want to fight. Have fun with them, it's not my problem."
-                        [/message]
-                        [move_unit]
-                            id=boss_3
-                            to_x=18
-                            to_y=1
-                            fire_event=no
-                        [/move_unit]
-                        [kill]
-                            id=boss_3
-                            fire_event=no
-                            animate=no
-                        [/kill]
-                        [message]
-                            speaker=faithful_lieutenant
-                            message=_"Now, that's what I call loyalty and responsibility."
-                        [/message]
-                    [/command]
-                    [/option]
-                [/message]
-                {VARIABLE quests.ravine_northeastern_ambush yes}
-            [/event]
-        [/else]
-    [/if]
+                            [/command]
+                        [/option]
+                        [option]
+                            message=_"Look at us, fool. We are equally numerous, we have better weapons, we have steel blades, you have knives and wooden weapons. How will your rags protect you from our weapons? Consider it, please."
+                            [command]
+                                [message]
+                                    speaker=boss_3
+                                    message=_"You... might be right."
+                                [/message]
+                                {TBC_DIPLOMACY_TRIED}
+                                [gold]
+                                    side=1
+                                    amount=20
+                                [/gold]
+                                [message]
+                                    speaker=boss_3
+                                    message=_"Here, have this gold and let me go."
+                                [/message]
+                                [move_unit]
+                                    id=boss_3
+                                    to_x=9
+                                    to_y=13
+                                    fire_event=no
+                                [/move_unit]
+                                [message]
+                                    speaker=boss_3
+                                    message=_"I think that my former friends still want to fight. Have fun with them, it's not my problem."
+                                [/message]
+                                [move_unit]
+                                    id=boss_3
+                                    to_x=18
+                                    to_y=1
+                                    fire_event=no
+                                [/move_unit]
+                                [kill]
+                                    id=boss_3
+                                    fire_event=no
+                                    animate=no
+                                [/kill]
+                                [message]
+                                    speaker=faithful_lieutenant
+                                    message=_"Now, that's what I call loyalty and responsibility."
+                                [/message]
+                            [/command]
+                        [/option]
+                    [/message]
+                    {VARIABLE quests.ravine_northeastern_ambush yes}
+                [/event]
+            [/else]
+        [/if]
 
-    [if]
-        [variable]
-            name=quests.ravine_found_cave
-            equals=yes
-        [/variable]
-        [else]
-            [event]
-                name=moveto
-                [filter]
-                    x,y=35-40,11-18
-                    side=1
-                [/filter]
-                [message]
-                    speaker=unit
-                    message=_"Look, a cave."
-                [/message]
-                [message]
-                    speaker=Rimaru
-                    message=_"We don't need to hide in a cave..."
-                [/message]
-                [message]
-                    speaker=elf_merc
-                    message=_"Better leave it alone, I hate caves. We cannot know what trouble awaits us there."
-                [/message]
-                [message]
-                    speaker=bandit_merc
-                    message=_"Let's go there, we might use it to ambush our foes. Though I am not sure if they hadn't already passed through here. Maybe some bandits who lived here before forgot some gold inside."
-                [/message]
-                [message]
-                    speaker=faithful_lieutenant
-                    message=_"It will only delay us. We should not slow ourselves here. But we may send somebody to explore it and report the findings he or she catches up with the rest."
-                [/message]
-                {VARIABLE quests.ravine_found_cave yes}
-            [/event]
-        [/else]
-    [/if]
-    {GUARDIAN_UNIT 4 "Skeleton" 44 13}
-    {GUARDIAN_UNIT 4 "Skeleton Archer" 42 7}
-    {GUARDIAN_UNIT 4 "Skeleton" 43 1}
-    {GUARDIAN_UNIT 4 "Deathblade" 38 1}
+        [if]
+            [variable]
+                name=quests.ravine_found_cave
+                equals=yes
+            [/variable]
+            [else]
+                [event]
+                    name=moveto
+                    [filter]
+                        x,y=35-40,11-18
+                        side=1
+                    [/filter]
+                    [message]
+                        speaker=unit
+                        message=_"Look, a cave."
+                    [/message]
+                    [message]
+                        speaker=Rimaru
+                        message=_"We don't need to hide in a cave..."
+                    [/message]
+                    [message]
+                        speaker=elf_merc
+                        message=_"Better leave it alone, I hate caves. We cannot know what trouble awaits us there."
+                    [/message]
+                    [message]
+                        speaker=bandit_merc
+                        message=_"Let's go there, we might use it to ambush our foes. Though I am not sure if they hadn't already passed through here. Maybe some bandits who lived here before forgot some gold inside."
+                    [/message]
+                    [message]
+                        speaker=faithful_lieutenant
+                        message=_"It will only delay us. We should not slow ourselves here. But we may send somebody to explore it and report the findings he or she catches up with the rest."
+                    [/message]
+                    {VARIABLE quests.ravine_found_cave yes}
+                [/event]
+            [/else]
+        [/if]
+        {GUARDIAN_UNIT 4 "Skeleton" 44 13}
+        {GUARDIAN_UNIT 4 "Skeleton Archer" 42 7}
+        {GUARDIAN_UNIT 4 "Skeleton" 43 1}
+        {GUARDIAN_UNIT 4 "Deathblade" 38 1}
 
-    [if]
-        [variable]
-            name=quests.ravine_wolf_ambush
-            equals=yes
-        [/variable]
-        [else]
-            [event]
-                name=moveto
-                [filter]
-                    x,y=29-37,20-25
-                    side=1
-                [/filter]
-                {TBC_SPAWN_UNITS_NO_LEADER 4 0.8 "Wolf,Wolf,Wolf,Wolf,Great Wolf" 30 15}
-                [message]
-                    speaker=unit
-                    message=_"I can hear some howls. Definitely inhuman howls."
-                [/message]
-                {VARIABLE quests.ravine_wolf_ambush yes}
-            [/event]
-        [/else]
-    [/if]
+        [if]
+            [variable]
+                name=quests.ravine_wolf_ambush
+                equals=yes
+            [/variable]
+            [else]
+                [event]
+                    name=moveto
+                    [filter]
+                        x,y=29-37,20-25
+                        side=1
+                    [/filter]
+                    {TBC_SPAWN_UNITS_NO_LEADER 4 0.8 "Wolf,Wolf,Wolf,Wolf,Great Wolf" 30 15}
+                    [message]
+                        speaker=unit
+                        message=_"I can hear some howls. Definitely inhuman howls."
+                    [/message]
+                    {VARIABLE quests.ravine_wolf_ambush yes}
+                [/event]
+            [/else]
+        [/if]
 
-    {TBC_GOLD_CHEST 35 28 ravine_swamp_chest}
-    {TBC_GOLD_CHEST 35 2 ravine_cave_chest}
+        {TBC_GOLD_CHEST 35 28 ravine_swamp_chest}
+        {TBC_GOLD_CHEST 35 2 ravine_cave_chest}
 
-    [if]
-        [variable]
-            name=quests.ravine_elf_and_wolf
-            equals=yes
-        [/variable]
-        [else]
-            [event]
-            name=attack
-            [filter]
-                side=4
-            [/filter]
-            [filter_second]
-                id=elf_merc
-            [/filter_second]
-            [message]
-                speaker=unit
-                message=_"Rrrgh... Hrrr..."
-            [/message]
-            [message]
-                speaker=second_unit
-                message=_"What kind of wolf you are?"
-            [/message]
-            [message]
-                speaker=unit
-                message=_"(stares at her)"
-            [/message]
-            [message]
-                speaker=second_unit
-                message=_"You're not a dog and I am not your human master."
-            [/message]
-            [message]
-                speaker=unit
-                message=_"(keeps staring)"
-            [/message]
-            [message]
-                speaker=second_unit
-                message=_"Do you want to be my... wolf?"
-            [/message]
-            [move_unit]
-                id=$unit.id
-                to_x=18
-                to_y=1
-                fire_event=no
-            [/move_unit]
-            [kill]
-                id=$unit.id
-                fire_event=no
-                animate=no
-            [/kill]
-            [message]
-                speaker=second_unit
-                message=_"I wonder why he behaved like that."
-            [/message]
-            {VARIABLE quests.ravine_elf_and_wolf yes}
-            [/event]
-        [/else]
-    [/if]
+        [if]
+            [variable]
+                name=quests.ravine_elf_and_wolf
+                equals=yes
+            [/variable]
+            [else]
+                [event]
+                    name=attack
+                    [filter]
+                        side=4
+                    [/filter]
+                    [filter_second]
+                        id=elf_merc
+                    [/filter_second]
+                    [message]
+                        speaker=unit
+                        message=_"Rrrgh... Hrrr..."
+                    [/message]
+                    [message]
+                        speaker=second_unit
+                        message=_"What kind of wolf you are?"
+                    [/message]
+                    [message]
+                        speaker=unit
+                        message=_"(stares at her)"
+                    [/message]
+                    [message]
+                        speaker=second_unit
+                        message=_"You're not a dog and I am not your human master."
+                    [/message]
+                    [message]
+                        speaker=unit
+                        message=_"(keeps staring)"
+                    [/message]
+                    [message]
+                        speaker=second_unit
+                        message=_"Do you want to be my... wolf?"
+                    [/message]
+                    [move_unit]
+                        id=$unit.id
+                        to_x=18
+                        to_y=1
+                        fire_event=no
+                    [/move_unit]
+                    [kill]
+                        id=$unit.id
+                        fire_event=no
+                        animate=no
+                    [/kill]
+                    [message]
+                        speaker=second_unit
+                        message=_"I wonder why he behaved like that."
+                    [/message]
+                    {VARIABLE quests.ravine_elf_and_wolf yes}
+                [/event]
+            [/else]
+        [/if]
 
-    [if]
-        [variable]
-            name=quests.overall
-            greater_than=10
-        [/variable]
-        [then]
-            [if]
-                [variable]
-                    name=quests.ravine_later_ambush_1
-                    equals=yes
-                [/variable]
-                [else]
-                    [event]
-                        name=moveto
-                        [filter]
-                            x,y=8-18,16-32
-                            side=1
-                        [/filter]
-                        {TBC_SPAWN_UNITS_NO_LEADER 3 1.3 "Thug,Huntsman,Bandit,Rogue,Trapper,Outlaw,Fugitive" 24 13}
-                        {VARIABLE quests.ravine_later_ambush_1 yes}
-                    [/event]
-                [/else]
-            [/if]
-            [if]
-                [variable]
-                    name=quests.ravine_later_ambush_2
-                    equals=yes
-                [/variable]
-                [else]
-                    [event]
-                        name=moveto
-                        [filter]
-                            x,y=9-22,14-23
-                            side=1
-                        [/filter]
-                        {TBC_SPAWN_UNITS_NO_LEADER 3 1.3 "Thug,Huntsman,Bandit,Rogue,Trapper,Outlaw,Fugitive" 14 18}
-                        {VARIABLE quests.ravine_later_ambush_2 yes}
-                    [/event]
-                [/else]
-            [/if]
-            [if]
-                [variable]
-                    name=quests.ravine_later_ambush_3
-                    equals=yes
-                [/variable]
-                [else]
-                    [event]
-                        name=moveto
-                        [filter]
-                            x,y=21-36,25-35
-                            side=1
-                        [/filter]
-                        {TBC_SPAWN_UNITS_NO_LEADER 3 1.3 "Thug,Huntsman,Bandit,Rogue,Trapper,Outlaw,Fugitive" 27 33}
-                        {VARIABLE quests.ravine_later_ambush_3 yes}
-                    [/event]
-                [/else]
-            [/if]
-        [/then]
-    [/if]
-
+        [if]
+            [variable]
+                name=quests.overall
+                greater_than=10
+            [/variable]
+            [then]
+                [if]
+                    [variable]
+                        name=quests.ravine_later_ambush_1
+                        equals=yes
+                    [/variable]
+                    [else]
+                        [event]
+                            name=moveto
+                            [filter]
+                                x,y=8-18,16-32
+                                side=1
+                            [/filter]
+                            {TBC_SPAWN_UNITS_NO_LEADER 3 1.3 "Thug,Huntsman,Bandit,Rogue,Trapper,Outlaw,Fugitive" 24 13}
+                            {VARIABLE quests.ravine_later_ambush_1 yes}
+                        [/event]
+                    [/else]
+                [/if]
+                [if]
+                    [variable]
+                        name=quests.ravine_later_ambush_2
+                        equals=yes
+                    [/variable]
+                    [else]
+                        [event]
+                            name=moveto
+                            [filter]
+                                x,y=9-22,14-23
+                                side=1
+                            [/filter]
+                            {TBC_SPAWN_UNITS_NO_LEADER 3 1.3 "Thug,Huntsman,Bandit,Rogue,Trapper,Outlaw,Fugitive" 14 18}
+                            {VARIABLE quests.ravine_later_ambush_2 yes}
+                        [/event]
+                    [/else]
+                [/if]
+                [if]
+                    [variable]
+                        name=quests.ravine_later_ambush_3
+                        equals=yes
+                    [/variable]
+                    [else]
+                        [event]
+                            name=moveto
+                            [filter]
+                                x,y=21-36,25-35
+                                side=1
+                            [/filter]
+                            {TBC_SPAWN_UNITS_NO_LEADER 3 1.3 "Thug,Huntsman,Bandit,Rogue,Trapper,Outlaw,Fugitive" 27 33}
+                            {VARIABLE quests.ravine_later_ambush_3 yes}
+                        [/event]
+                    [/else]
+                [/if]
+            [/then]
+        [/if]
     [/event]
 
     [event]
-    name=last breath
-    [filter]
-        id=she_brother
-    [/filter]
-    [message]
-        speaker=she_brother
-        message=_"Have mercy! You always tell that you have mercy, so can you please have some mercy now?"
-    [/message]
-    [message]
-        speaker=Rimaru
-        message=_"You're asking for mercy? You were criticising us so hard, all the time! You seemed to hate on us, strafe us with insults and wish to see us all dead!"
-    [/message]
-    [message]
-        speaker=elf_merc
-        message=_"I think that Rimaru is foul mouthed enough, we don't need another person like him..."
-    [/message]
-    [message]
-        speaker=she_brother
-        message=_"I was... proud. Overly proud, arrogant in my pride. I considered myself and my order far above everyone else, I considered you only a piece of filth that sticks on our boots. Yet... I was shaken when you told me your loss. I didn't know that our order can behave like that. I managed to conceal it with a hostile comment, but..."
-    [/message]
-    [message]
-        speaker=bandit_merc
-        message=_"Hearbreaking... I can feel my heart melting and pouring down my guts."
-    [/message]
-    [message]
-        speaker=she_brother
-        message=_"You have shown me also one more thing. We are weak. Our numbers were superior, yet you defeated us. I thought myself to be a powerful mage, but you proved me wrong. I am defeated like a little child who attacked a bigger child."
-    [/message]
-    [message]
-        speaker=Rimaru
-        message=_"Well, you've earned a lesson and understood how arrogant you were, but you're still our enemy. We aren't supposed to help our enemies, because, well, they would harm us in return."
-    [/message]
-    [message]
-        speaker=she_brother
-        message=_"I... My faith in my order is shaken. I am starting to understand your words about corruption. I tried to deny your words about increases in tithes in the past, but the more I thought of it, the more I was sure that all of this happened. It was a plan that the tithes would be lowered, but it was always delayed to finish some reparations, to fill back our reserves, and it was forgotten afterwards."
-    [/message]
-    [message]
-        speaker=faithful_lieutenant
-        message=_"My faith was shaken too some time ago, I know how you feel."
-    [/message]
-    [message]
-        speaker=she_brother
-        message=_"I was trying not to think about that, to ask some superiors how it really was to see him telling that you're a liar and manipulator, but now... I am laying on the ground, my white robe getting filthy, with rebels prepared to kill me... I see it all. Our superiors were manipulators and corrupted our order from inside."
-    [/message]
-    [message]
-        speaker=she_brother
-        message=_"They needed to detach a Brother from his sister to get a better healer, so they removed her. They got used to increased income, so they worked on making everyone forget that the income was ever increased. We need to cleanse our order, Brother Rimaru. And I will help you with that."
-    [/message]
-    [message]
-        speaker=Rimaru
-        message=_"Do you think it's reasonable to take her to our party? She is quite intelligent, she might be just pretending all of this to save her life and regain some reputation by betraying us. But she had no role in our order's theatre, so I would not think she is a good actress. And believe me, everyone of us wanted to play in that theatre."
-        [option]
-        message=_"We need everyone."
-        [command]
-            [message]
-                speaker=she_brother
-                message=_"Thank you. Those who call themselves Brothers of Light these days would never do that."
-            [/message]
-            [message]
-                speaker=elf_merc
-                message=_"I know."
-            [/message]
-            [store_unit]
-                [filter]
-                    id=she_brother
-                [/filter]
-                variable=she_brother_store
-            [/store_unit]
-            {VARIABLE she_brother_store.canrecruit yes}
-            {VARIABLE she_brother_store.side 1}
-            {VARIABLE she_brother_store.variables.hero yes}
-            {VARIABLE she_brother_store.hitpoints 15}
-            [unstore_unit]
-                variable=she_brother_store
-                find_vacant=no
-            [/unstore_unit]
-            {VARIABLE party_members[$party_members.length].id she_brother}
-            {CLEAR_VARIABLE she_brother_store}
-        [/command]
-        [/option]
-        [option]
-        message=_"I do not trust her. She has always been hateful to us and this conversion has been to sudden."
-        [command]
-            [message]
-                speaker=she_brother
-                message=_"Rimaru! Tell something! Save me!"
-            [/message]
-            [message]
-                speaker=Rimaru
-                message=_"I think that your explanation is insufficient. You can't risk having you with us and otherwise you would continue fighting us. I am sorry, but I am trying to achieve something."
-            [/message]
-        [/command]
-        [/option]
-    [/message]
-    [fire_event]
-        name=brothers_dead_check
-    [/fire_event]
+        name=last breath
+        [filter]
+            id=she_brother
+        [/filter]
+        [message]
+            speaker=she_brother
+            message=_"Have mercy! You always tell that you have mercy, so can you please have some mercy now?"
+        [/message]
+        [message]
+            speaker=Rimaru
+            message=_"You're asking for mercy? You were criticising us so hard, all the time! You seemed to hate on us, strafe us with insults and wish to see us all dead!"
+        [/message]
+        [message]
+            speaker=elf_merc
+            message=_"I think that Rimaru is foul mouthed enough, we don't need another person like him..."
+        [/message]
+        [message]
+            speaker=she_brother
+            message=_"I was... proud. Overly proud, arrogant in my pride. I considered myself and my order far above everyone else, I considered you only a piece of filth that sticks on our boots. Yet... I was shaken when you told me your loss. I didn't know that our order can behave like that. I managed to conceal it with a hostile comment, but..."
+        [/message]
+        [message]
+            speaker=bandit_merc
+            message=_"Hearbreaking... I can feel my heart melting and pouring down my guts."
+        [/message]
+        [message]
+            speaker=she_brother
+            message=_"You have shown me also one more thing. We are weak. Our numbers were superior, yet you defeated us. I thought myself to be a powerful mage, but you proved me wrong. I am defeated like a little child who attacked a bigger child."
+        [/message]
+        [message]
+            speaker=Rimaru
+            message=_"Well, you've earned a lesson and understood how arrogant you were, but you're still our enemy. We aren't supposed to help our enemies, because, well, they would harm us in return."
+        [/message]
+        [message]
+            speaker=she_brother
+            message=_"I... My faith in my order is shaken. I am starting to understand your words about corruption. I tried to deny your words about increases in tithes in the past, but the more I thought of it, the more I was sure that all of this happened. It was a plan that the tithes would be lowered, but it was always delayed to finish some reparations, to fill back our reserves, and it was forgotten afterwards."
+        [/message]
+        [message]
+            speaker=faithful_lieutenant
+            message=_"My faith was shaken too some time ago, I know how you feel."
+        [/message]
+        [message]
+            speaker=she_brother
+            message=_"I was trying not to think about that, to ask some superiors how it really was to see him telling that you're a liar and manipulator, but now... I am laying on the ground, my white robe getting filthy, with rebels prepared to kill me... I see it all. Our superiors were manipulators and corrupted our order from inside."
+        [/message]
+        [message]
+            speaker=she_brother
+            message=_"They needed to detach a Brother from his sister to get a better healer, so they removed her. They got used to increased income, so they worked on making everyone forget that the income was ever increased. We need to cleanse our order, Brother Rimaru. And I will help you with that."
+        [/message]
+        [message]
+            speaker=Rimaru
+            message=_"Do you think it's reasonable to take her to our party? She is quite intelligent, she might be just pretending all of this to save her life and regain some reputation by betraying us. But she had no role in our order's theatre, so I would not think she is a good actress. And believe me, everyone of us wanted to play in that theatre."
+            [option]
+                message=_"We need everyone."
+                [command]
+                    [message]
+                        speaker=she_brother
+                        message=_"Thank you. Those who call themselves Brothers of Light these days would never do that."
+                    [/message]
+                    [message]
+                        speaker=elf_merc
+                        message=_"I know."
+                    [/message]
+                    [store_unit]
+                        [filter]
+                            id=she_brother
+                        [/filter]
+                        variable=she_brother_store
+                    [/store_unit]
+                    {VARIABLE she_brother_store.canrecruit yes}
+                    {VARIABLE she_brother_store.side 1}
+                    {VARIABLE she_brother_store.variables.hero yes}
+                    {VARIABLE she_brother_store.hitpoints 15}
+                    [unstore_unit]
+                        variable=she_brother_store
+                        find_vacant=no
+                    [/unstore_unit]
+                    {VARIABLE party_members[$party_members.length].id she_brother}
+                    {CLEAR_VARIABLE she_brother_store}
+                [/command]
+            [/option]
+            [option]
+                message=_"I do not trust her. She has always been hateful to us and this conversion has been to sudden."
+                [command]
+                    [message]
+                        speaker=she_brother
+                        message=_"Rimaru! Tell something! Save me!"
+                    [/message]
+                    [message]
+                        speaker=Rimaru
+                        message=_"I think that your explanation is insufficient. You can't risk having you with us and otherwise you would continue fighting us. I am sorry, but I am trying to achieve something."
+                    [/message]
+                [/command]
+            [/option]
+        [/message]
+        [fire_event]
+            name=brothers_dead_check
+        [/fire_event]
     [/event]
-        
 
     {TBC_GLOBAL_EVENTS_RPG}
 [/scenario]

--- a/spinoffs/The_Beautiful_Child/scenarios/Faithdome.cfg
+++ b/spinoffs/The_Beautiful_Child/scenarios/Faithdome.cfg
@@ -9,12 +9,12 @@
     {DEFAULT_MUSIC_PLAYLIST}
     {DEFAULT_SCHEDULE_24H}
     [time_area]
-    x,y=0-45,27-34
-    {INDOORS}
+        x,y=0-45,27-34
+        {INDOORS}
     [/time_area]
     [time_area]
-    x,y=32-45,20-26
-    {INDOORS}
+        x,y=32-45,20-26
+        {INDOORS}
     [/time_area]
 
     [side]
@@ -37,47 +37,744 @@
         side=2
         team_name=good,twisted_good
         user_team_name=_"Non-combatants"
-    ai_algorithm=idle_ai
+        ai_algorithm=idle_ai
     [/side]
     [side]
         no_leader=yes
         side=3
         team_name=twisted_good
         user_team_name=_"Twisted Good"
-    [ai]
-        aggression=1.0
-    [/ai]
+        [ai]
+            aggression=1.0
+        [/ai]
     [/side]
 
     {TBC_PLACE_WAYPOINT 25 15}
 
     [event]
-    name=prestart
-    {CLEAR_RECALLS}
-    {VARIABLE current_scenario faithdome}
-    {TBC_ORIGIN fertile_lands 23 3}
-    {TBC_ORIGIN valley_passage 3 7}
-    {TBC_ORIGIN war_rages_on 36 29}
-    {TBC_TRANSITION 3-44 1-2 Fertile_Lands _"Fertile Lands" 25 1}
-    [if]
-        [variable]
-            name=quests.overall
-            greater_than=11
-        [/variable]
-        [then]
-            {TBC_TRANSITION 1-2 1-25 Valley_Passage _"Valley Passage" 2 7}
-            [remove_event]
-                id=forbid_progress
-            [/remove_event]
-            [if]
-                [variable]
-                    name=quests.overall
-                    equals=12
-                [/variable]
-                [then]
+        name=prestart
+        {CLEAR_RECALLS}
+        {VARIABLE current_scenario faithdome}
+        {TBC_ORIGIN fertile_lands 23 3}
+        {TBC_ORIGIN valley_passage 3 7}
+        {TBC_ORIGIN war_rages_on 36 29}
+        {TBC_TRANSITION 3-44 1-2 Fertile_Lands _"Fertile Lands" 25 1}
+        [if]
+            [variable]
+                name=quests.overall
+                greater_than=11
+            [/variable]
+            [then]
+                {TBC_TRANSITION 1-2 1-25 Valley_Passage _"Valley Passage" 2 7}
+                [remove_event]
+                    id=forbid_progress
+                [/remove_event]
+                [if]
+                    [variable]
+                        name=quests.overall
+                        equals=12
+                    [/variable]
+                    [then]
+                        [unit]
+                            side=2
+                            x,y=32,27
+                            type=Master at Arms
+                            id=Konrad_II
+                            name= _"Konrad II"
+                            canrecruit=yes
+                            [modifications]
+                                [advance]
+                                    id=portrait
+                                    [effect]
+                                        apply_to=profile
+                                        portrait="portraits/humans/transparent/fencer.png"
+                                    [/effect]
+                                [/advance]
+                            [/modifications]
+                        [/unit]
+                    [/then]
+                [/if]
+            [/then]
+        [/if]
+        [unit]
+            side=2
+            id=Uver
+            name=_"Uver"
+            x,y=37,30
+            type=Master at Arms
+            canrecruit=yes
+        [/unit]
+    [/event]
+
+    [event]
+        name=start
+        {PLACE_IMAGE scenery/bookshelf-1.png 41 28}
+        {PLACE_IMAGE items/box.png 38 32}
+        {PLACE_IMAGE items/box.png 29 30}
+        {PLACE_IMAGE items/box.png 25 29}
+        {PLACE_IMAGE items/box.png 41 23}
+        {PLACE_IMAGE items/box.png 35 25}
+        {PLACE_IMAGE items/box.png 3 30}
+        {PLACE_IMAGE scenery/bookshelf-2.png 10 29}
+        {PLACE_IMAGE scenery/bookshelf-3.png 42 29}
+        {PLACE_IMAGE cabinet.png 33 27}
+        [remove_shroud]
+            side=1
+        [/remove_shroud]
+        [place_shroud]
+            side=1
+            terrain=Xol,Iwr,Mm^Xm
+        [/place_shroud]
+        [place_shroud]
+            side=1
+            x,y=0-45,27-34
+        [/place_shroud]
+        [place_shroud]
+            side=1
+            x,y=32-45,20-26
+        [/place_shroud]
+        [remove_shroud]
+            side=1
+            x,y=30,25
+        [/remove_shroud]
+        {TBC_GOLD_CHEST 37 27 faithdome_inner_chest}
+        {TBC_GOLD_CHEST 13 33 faithdome_outer_chest}
+        [if]
+            [variable]
+                name=quests.entered_faithdome
+                equals=yes
+            [/variable]
+            [else]
+                {RARE_ITEM 23 30}
+                [message]
+                    speaker=Rimaru
+                    message=_"Faithdome. This town used to have a better name, but Uver changed it to prove his faith to the Brothers. Enough talking, we must hurry."
+                [/message]
+                [message]
+                    speaker=orc
+                    message=_"I was starting to be afraid that we would talk forever... again."
+                [/message]
+                {VARIABLE quests.entered_faithdome yes}
+            [/else]
+        [/if]
+        [if]
+            [variable]
+                name=quests.faithdome_infantryman
+                equals=yes
+            [/variable]
+            [else]
+                [unit]
+                    type=Iron Mauler
+                    x,y=35,23
+                    side=2
+                    id=wise_warrior
+                    generate_name=yes
+                    canrecruit=yes
+                    random_traits=yes
+                    [modifications]
+                        [advance]
+                            id=portrait
+                            [effect]
+                                apply_to=profile
+                                portrait="portraits/humans/transparent/heavy-infantry.png"
+                            [/effect]
+                        [/advance]
+                        {TRAIT_INTELLIGENT}
+                    [/modifications]
+                    [variables]
+                        hero=yes
+                    [/variables]
+                [/unit]
+                [event]
+                    name=moveto
+                    [filter]
+                        side=1
+                        x,y=32-44,20-25
+                    [/filter]
+                    {VARIABLE quests.faithdome_infantryman yes}
+                    [message]
+                        speaker=wise_warrior
+                        message=_"I know. I am the man responsible for arming lord Uver's soldiers and sending them against you. Almost unforgivable. But what could I do, I didn't want to be killed for treason."
+                    [/message]
+                    [message]
+                        speaker=unit
+                        message=_"So, you're trying to save your life?"
+                    [/message]
+                    [message]
+                        speaker=wise_warrior
+                        message=_"I have done my job as bad as I could, it didn't take me long to realise where the truth is."
+                    [/message]
+                    [message]
+                        speaker=unit
+                        message=_"Well, I noticed that your barracks were less active than the others."
+                    [/message]
+                    [message]
+                        speaker=wise_warrior
+                        message=_"You see? I was not faithful to them, but I could not flee. I didn't have the courage like you... So I chose safety, and I decided that I can harm their cause much more if I cause as much trouble as possible by being seemingly incompetent."
+                    [/message]
+                    [message]
+                        speaker=unit
+                        message=_"What made you change your mind?"
+                    [/message]
+                    [message]
+                        speaker=wise_warrior
+                        message=_"As most others, I initially considered the things told by the Brothers of Light sacred, they seemed to be loyal servants of good. But then it changed. They were worse than usual humans, complancent, arrogant, selfish, overly proud, neglectful towards others,... When this war started, they worked a lot with the army where I was in. Lord Uver told us to cooperate, but they weren't cooperative, they were just demanding absolute obedience."
+                    [/message]
+                    [message]
+                        speaker=wise_warrior
+                        message=_"Sometimes, they even ordered us to do silly things so that they could laugh at us. They ignored our advice and were giving orders despite having no experience with warfare. One Brother actually had a talent for warfare tactics and put some limits to their stupid commanding, but you killed him recently. When they were <i>cooperating</i> with us, I realised that talking to a single one was enough to ruin my mood for the whole day."
+                    [/message]
+                    [message]
+                        speaker=wise_warrior
+                        message=_"They made me hate them. I realised how significantly different were the morals contained in their teachings and their own morals. Shortly after, I overheard them talking about bribes and stealing. They also described how they looked forward to taking tithes also from the Sand Empire and taking large shares of the money for themselves. They have no honour, no manners, the only thing that differs them from criminals is that they are intelligent enough to conceal it."
+                    [/message]
+                    [message]
+                        speaker=wise_warrior
+                        message=_"I started thinking about killing them all and turning coat, but they clearly had experience for it and never gave me a good occasion for that. Other soldiers were brainwashed every day and I was sure that I would not succeed to persuade a significant part of soldiers to join me. And the others would not fight their former comrades. I had to stay here and perform as poorly as possible in my duties. Until you came."
+                    [/message]
+                    [message]
+                        speaker=unit
+                        message=_"Interesting story. It sounds like truth."
+                    [/message]
+                    [message]
+                        speaker=wise_warrior
+                        message= _ "May I join you?"
+                        [option]
+                            message=_"Yes. We need people like you."
+                            [command]
+                                [store_unit]
+                                    [filter]
+                                        id=wise_warrior
+                                    [/filter]
+                                    variable=warrior_store
+                                [/store_unit]
+                                {VARIABLE warrior_store.side 1}
+                                [unstore_unit]
+                                    variable=warrior_store
+                                    find_vacant=no
+                                [/unstore_unit]
+                                {CLEAR_VARIABLE warrior_store}
+                                {VARIABLE party_members[$party_members.length].id wise_warrior}
+                                [message]
+                                    speaker=wise_warrior
+                                    message=_"Thank you. It will be a honour to fight by your side."
+                                [/message]
+                            [/command]
+                        [/option]
+                        [option]
+                            message=_"No, I am not sure if I can trust you. You are free to go."
+                            [command]
+                                [message]
+                                    speaker=wise_warrior
+                                    message=_"What a pity. Still, it's good that you fear spies, they are to be feared."
+                                [/message]
+                                [move_unit]
+                                    id=wise_warrior
+                                    to_x=23
+                                    to_y=1
+                                    fire_event=no
+                                [/move_unit]
+                                [kill]
+                                    id=wise_warrior
+                                    animate=no
+                                    fire_event=no
+                                [/kill]
+                            [/command]
+                        [/option]
+                    [/message]
+                [/event]
+            [/else]
+        [/if]
+
+        [if]
+            [variable]
+                name=quests.faithdome_destroyed_barracks
+                equals=yes
+            [/variable]
+            [else]
+                [event]
+                    name=moveto
+                    [filter_condition]
+                        [variable]
+                            name=quests.overall
+                            equals=10
+                        [/variable]
+                    [/filter_condition]
+                    [filter]
+                        side=1
+                        x,y=2-6,27-33
+                    [/filter]
+                    [message]
+                        speaker=unit
+                        message=_"I will destroy these barracks. These walls look prone to a cave in, damaging one of these scaffolds will be enough."
+                    [/message]
+                    [move_unit]
+                        id=$unit.id
+                        to_x=6
+                        to_y=24
+                        fire_event=no
+                    [/move_unit]
+                    {EARTHQUAKE (
+                        [terrain]
+                            x,y=6,26-27
+                            terrain=Xu
+                        [/terrain]
+                        [redraw]
+                        [/redraw]
+                    )}
+                    [message]
+                        speaker=unit
+                        message=_"Now, nobody will annoy us."
+                    [/message]
+                    {VARIABLE quests.faithdome_destroyed_barracks yes}
+                [/event]
+            [/else]
+        [/if]
+
+        [if]
+            [variable]
+                name=quests.overall
+                greater_than=11
+            [/variable]
+            [else]
+                [event]
+                    name=new turn
+                    first_time_only=no
+#define PICK_SPAWN
+#ifdef EASY
+    {VARIABLE_OP unit_type rand "Swordsman,Spearman,Javelineer,Pikeman,Duelist,Fencer,Lieutenant"}
+#endif
+#ifdef NORMAL
+    {VARIABLE_OP unit_type rand "Swordsman,Spearman,Javelineer,Pikeman,Halberdier,Duelist,Fencer,Lieutenant,General"}
+#endif
+#ifdef HARD
+    {VARIABLE_OP unit_type rand "Swordsman,Spearman,Javelineer,Pikeman,Halberdier,Duelist,Master at Arms,Fencer,Royal Guard,Lieutenant,General"}
+#endif
+#enddef
+                    [if]
+                        [variable]
+                            name=quests.faithdome_infantryman
+                            equals=yes
+                        [/variable]
+                        [else]
+                            {PICK_SPAWN}
+                            {GENERIC_UNIT 3 $unit_type 39 23}
+                        [/else]
+                    [/if]
+                    [if]
+                        [variable]
+                            name=quests.faithdome_destroyed_barracks
+                            equals=yes
+                        [/variable]
+                        [else]
+                            {PICK_SPAWN}
+                            {GENERIC_UNIT 3 $unit_type 3 30}
+                            {PICK_SPAWN}
+                            {GENERIC_UNIT 3 $unit_type 5 29}
+                        [/else]
+                    [/if]
+#undef PICK_SPAWN
+                    {CLEAR_VARIABLE spawn_type}
+                [/event]
+
+                [if]
+                    [variable]
+                        name=quests.faithdome_northern_guards
+                        equals=yes
+                    [/variable]
+                    [else]
+                        [event]
+                            name=moveto
+                            [filter]
+                                x,y=16-36,5-16
+                                side=1
+                            [/filter]
+                            {TBC_SPAWN_UNITS_NO_LEADER 3 1.4 "Swordsman,Javelineer,Longbowman" 25 15}
+                            [message]
+                                speaker=unit
+                                message=_"A group of guards have noticed us, I think. They seem to be organising city defences. Fortunately, the best soldiers usually aren't working as town guards."
+                            [/message]
+                            {VARIABLE quests.faithdome_northern_guards yes}
+                        [/event]
+                    [/else]
+                [/if]
+
+                [if]
+                    [variable]
+                        name=quests.faithdome_southern_guards
+                        equals=yes
+                    [/variable]
+                    [else]
+                        [event]
+                            name=moveto
+                            [filter]
+                                x,y=1-21,9,24
+                                side=1
+                            [/filter]
+                            {TBC_SPAWN_UNITS_NO_LEADER 3 1.4 "Shock Trooper,White Mage" 16 22}
+                            [message]
+                                speaker=unit
+                                message=_"We were spotted by a group of guards. I can hear their shouts, they are preparing city defence. Guards should be fine, elite soldiers are a pain."
+                            [/message]
+                            {VARIABLE quests.faithdome_southern_guards yes}
+                        [/event]
+                    [/else]
+                [/if]
+
+                [if]
+                    [variable]
+                        name=quests.faithdome_outer_guards
+                        equals=yes
+                    [/variable]
+                    [else]
+                        [event]
+                            name=moveto
+                            [filter]
+                                x,y=8-24,27-34
+                                side=1
+                            [/filter]
+                            {TBC_SPAWN_UNITS_NO_LEADER 3 0.9 "Royal Guard,Master Bowman,White Mage" 26 30}
+                            [message]
+                                speaker=unit
+                                message=_"Darn, this castle is guarded."
+                            [/message]
+                            {VARIABLE quests.faithdome_outer_guards yes}
+                        [/event]
+                    [/else]
+                [/if]
+
+                [if]
+                    [variable]
+                        name=quests.faithdome_inner_guards
+                        equals=yes
+                    [/variable]
+                    [else]
+                        [event]
+                            name=moveto
+                            [filter]
+                                x,y=22-44,27-33
+                                side=1
+                            [/filter]
+                            {TBC_SPAWN_UNITS_NO_LEADER 3 0.9 "Royal Guard,Master Bowman,White Mage" 37 30}
+                            [message]
+                                speaker=unit
+                                message=_"More guards, but I think that we're close to Uver."
+                            [/message]
+                            {VARIABLE quests.faithdome_inner_guards yes}
+                        [/event]
+                    [/else]
+                [/if]
+
+                [event]
+                    name=moveto,attack end
+                    [filter]
+                        x,y=31-43,26-33
+                    [/filter]
+                    [filter_condition]
+                        [not]
+                            [have_unit]
+                                side=3
+                                x,y=31-43,26-33
+                            [/have_unit]
+                        [/not]
+                    [/filter_condition]
+                    {VARIABLE quests.overall 11}
+                    [message]
+                        speaker=Uver
+                        message=_"I know that you'd expect me to attack and die, but I am not so foolish. I know that there is little I can do to stop you."
+                    [/message]
+                    [message]
+                        speaker=Rimaru
+                        message=_"So are you giving up? If you promise that you'll obey us, we might be merciful."
+                    [/message]
+                    [move_unit]
+                        side=1
+                        to_x=37
+                        to_y=30
+                        fire_event=no
+                    [/move_unit]
+                    [while]
+                        [not]
+                            [variable]
+                                name=done
+                                equals=yes
+                            [/variable]
+                        [/not]
+                        [do]
+                            [message]
+                                speaker=Uver
+                                message=_"I am giving up, as I said, you can trust me."
+                                [option]
+                                    message=_"How can I know I can trust you?"
+                                    [command]
+                                        [message]
+                                            speaker=faithful_lieutenant
+                                            message=_"I turned my coat honestly, maybe you can trust him too."
+                                        [/message]
+                                        [message]
+                                            speaker=Rimaru
+                                            message=_"You can't trust him, but if he's surrounded he will not try any tricks."
+                                        [/message]
+                                        [message]
+                                            speaker=hired_halberdier
+                                            message=_"How about beating him so bad that he would need to recover before being able to try any tricks?"
+                                        [/message]
+                                    [/command]
+                                [/option]
+                                [option]
+                                    message=_"We can never be sure if you aren't planning anything bad, keep your soldiers away from the castle and we can talk."
+                                    [command]
+                                        {VARIABLE done yes}
+                                    [/command]
+                                [/option]
+                                [option]
+                                    message=_"If you'll cooperate with us, you'll receive this beautiful elvish maiden as a wife."
+                                    [show_if]
+                                        [have_unit]
+                                            id=elf_merc
+                                        [/have_unit]
+                                    [/show_if]
+                                    [command]
+                                        [message]
+                                            speaker=elf_merc
+                                            message=_"I have also an idea. Kill yourself."
+                                        [/message]
+                                        [message]
+                                            speaker=player
+                                            message=_"Do you really have to be like this?"
+                                        [/message]
+                                        [if]
+                                            [have_unit]
+                                                id=player
+                                                gender=male
+                                            [/have_unit]
+                                            [then]
+                                                [message]
+                                                    speaker=elf_merc
+                                                    message=_"Do <i>you</i> really have to be like this? Find another way to motivate him."
+                                                [/message]
+                                            [/then]
+                                            [else]
+                                                [message]
+                                                    speaker=elf_merc
+                                                    message=_"Offer yourself to him if you are so fond of this idea."
+                                                [/message]
+                                            [/else]
+                                        [/if]
+                                    [/command]
+                                [/option]
+                                [option]
+                                    message=_"We will reward you with large amounts of gold if you choose to cooperate."
+                                    [command]
+                                        [message]
+                                            speaker=Uver
+                                            message=_"You don't have much gold, I know that."
+                                        [/message]
+                                        [message]
+                                            speaker=Burke
+                                            message=_"Money will not work on this one, he's too powerful for tricks like that."
+                                        [/message]
+                                    [/command]
+                                [/option]
+                                [option]
+                                    message=_"To be sure that you're not lying, our orcish friend will torture you a bit to verify it."
+                                    [show_if]
+                                        [have_unit]
+                                            id=orc
+                                        [/have_unit]
+                                    [/show_if]
+                                    [command]
+                                        [message]
+                                            speaker=orc
+                                            message=_"That's stupid. We will only motivate him to be our enemy that way."
+                                        [/message]
+                                        [message]
+                                            speaker=bandit_merc
+                                            message=_"Why? I don't understand. The torture idea was a good idea."
+                                        [/message]
+                                    [/command]
+                                [/option]
+                            [/message]
+                        [/do]
+                    [/while]
+                    {CLEAR_VARIABLE done}
+                    [message]
+                        speaker=Uver
+                        message=_"Okay, I can do that. Soldiers, I am giving you a command I thought I would never have to give. Lay down your weapons."
+                    [/message]
+                    [move_unit]
+                        side=3
+                        x,y=9-43,26-33
+                        to_x=18
+                        to_y=22
+                        fire_event=no
+                    [/move_unit]
+                    [modify_unit]
+                        [filter]
+                            side=3
+                        [/filter]
+                        side=2
+                    [/modify_unit]
+                    [message]
+                        speaker=hired_swordsman
+                        message=_"No more fighting? Dammit."
+                    [/message]
+                    [message]
+                        speaker=Burke
+                        message=_"So, you've given up. Perfect. There is one story we would like you to know."
+                    [/message]
+                    [message]
+                        id=wise_warrior
+                        side=1
+                        message=_"Do you know how moral are the Brothers of Light? I was tasked to cooperate with them in our war. I overheard them talking about bribes and thefts. Furthermore, they seemed to look forward to taking huge tithes also from the Sand Empire and peculating large shares of the money for themselves. I can say that they are very different from what they tell about themselves, they have no honour, they lie and steal and work hard on concealing it."
+                    [/message]
+                    [message]
+                        speaker=Uver
+                        message=_"I've heard such stories. But where is the evidence? What you say can be just rumours you're spreading to discredit them."
+                    [/message]
+                    [message]
+                        speaker=she_brother
+                        message=_"Do you know what I've seen when I was with them? You have dealt with them many times, you should have noticed the truth too. But it seems that you have eyes that cannot see and ears that cannot hear."
+                    [/message]
+                    [message]
+                        speaker=Rimaru
+                        message=_"Have you ever wondered why I left the order? They let my sister die just to advance one of their schemes."
+                    [/message]
+                    [message]
+                        speaker=Uver
+                        message=_"You could have killed some of them and taken their robes. Or maybe you were kicked from the order, that would explain your healing skills you are surely going to demonstrate. In any case, your testimonials are no evidence."
+                    [/message]
+                    [message]
+                        speaker=orc
+                        message=_"This sounds like if somebody taught him what to tell."
+                    [/message]
+                    [message]
+                        speaker=Rimaru
+                        message=_"Doesn't it seem strange to you how powerful they are? They were supposed to be healers and spreaders of universal good, but instead, they possess incredible power and their order is a powerful economy. They made the king declare war to Sand Empire despite the damage it would cause. They have also strong word in internal politics, haven't you seen how much they command you? They take a ninth of all the land's production, and that is a very significant amount of money."
+                    [/message]
+                    [message]
+                        speaker=Burke
+                        message=_"I think that you will not persuade him. He was being brainwashed for way too long. It's not like in my case, I agreed to support them a bit because I did not want to risk my comfortable life. When I had no other choice, I did the right thing, but this one is different. I have punched a few of them into their unworthy faces when they demanded too much. I can't imagine Uver doing that."
+                    [/message]
+                    [while]
+                        [not]
+                            [variable]
+                                name=done
+                                equals=yes
+                            [/variable]
+                        [/not]
+                        [do]
+                            [message]
+                                speaker=Uver
+                                message=_"Say whatever you want, you won't persuade me."
+                                [option]
+                                    message=_"It's time to give up and seek another solution."
+                                    [command]
+                                        {VARIABLE done yes}
+                                    [/command]
+                                [/option]
+                                [option]
+                                    message=_"How about threatening him with death again? Using weapons to persuade him to surrender wasn't hard..."
+                                    [command]
+                                        [message]
+                                            speaker=Al Ghareeb
+                                            message=_"He knows that he would be as good to us when he is dead as he would be good to us when he's in prison."
+                                        [/message]
+                                        [message]
+                                            speaker=hired_halberdier
+                                            message=_"That's wrong. We're gonna cut you pretty deep if you won't..."
+                                        [/message]
+                                        [message]
+                                            speaker=Rimaru
+                                            message=_"That will not work. He knows that he can't fight now. But changing his opinion and loyalties is a completely different affair than this."
+                                        [/message]
+                                        [message]
+                                            speaker=hired_halberdier
+                                            message=_"Darn. I disagree."
+                                        [/message]
+                                    [/command]
+                                [/option]
+                                [option]
+                                    message=_"Have you noticed how powerful Luke, the Bringer of Light is? Do you think that a human can't be so powerful without embracing the dark forces?"
+                                    [command]
+                                        [message]
+                                            speaker=Uver
+                                            message=_"He was chosen by gods to care about little Reezer."
+                                        [/message]
+                                        [message]
+                                            speaker=player
+                                            message=_"Yes, to care about the child, he was given the ability to make anything burn, bring groups of soldiers through a half of the kingdom, to rain fire from the skies..."
+                                        [/message]
+                                        [message]
+                                            speaker=Uver
+                                            message=_"Protecting may need dealing with threats."
+                                        [/message]
+                                        [message]
+                                            speaker=player
+                                            message=_"How much time do you think he spends with him? I have seen him a few times in Thunderhold, you have surely seen him too... a bit too much for a person supposed to protect a child, no? How can he protect a child that is far away from him?"
+                                        [/message]
+                                    [/command]
+                                [/option]
+                                [option]
+                                    message=_"What would your father do in your place? As far as I know, he was far wiser than you are."
+                                    [command]
+                                        [message]
+                                            speaker=Uver
+                                            message=_"How can I know what would a wiser man do instead of me? I know what would a stupid man do. Attack you right now."
+                                        [/message]
+                                        [message]
+                                            speaker=player
+                                            message=_"Do you think that he would obey a few funny men dressed in womanly robes who demand so much?"
+                                        [/message]
+                                    [/command]
+                                [/option]
+                            [/message]
+                        [/do]
+                    [/while]
+                    {CLEAR_VARIABLE done}
+                    [if]
+                        [have_unit]
+                            id=she_brother
+                        [/have_unit]
+                        [then]
+                            [message]
+                                speaker=she_brother
+                                message=_"I believe that he would remain loyal to them even if he saw Luke kissing the Queen of Darkness."
+                            [/message]
+                            [message]
+                                speaker=Al Ghareeb
+                                message=_"Ha ha ha, try to picture that in your mind."
+                            [/message]
+                            [message]
+                                speaker=bandit_merc
+                                message=_"Heh heh, that's hilarious."
+                            [/message]
+                        [/then]
+                    [/if]
+                    [message]
+                        speaker=Rimaru
+                        message=_"I agree. This one isn't Burke. But what else can we try?"
+                    [/message]
                     [unit]
                         side=2
-                        x,y=32,27
+                        id=Konrad
+                        name=_"Konrad"
+                        x,y=9,2
+                        type=Royal Warrior
+                        canrecruit=yes
+                        [modifications]
+                            [advance]
+                                id=portrait
+                                [effect]
+                                    apply_to=profile
+                                    portrait="portraits/humans/transparent/marshal-2.png"
+                                [/effect]
+                            [/advance]
+                        [/modifications]
+                    [/unit]
+                    [unit]
+                        side=2
+                        x,y=10,2
                         type=Master at Arms
                         id=Konrad_II
                         name= _"Konrad II"
@@ -92,1731 +789,1032 @@
                             [/advance]
                         [/modifications]
                     [/unit]
-                [/then]
-            [/if]
-        [/then]
-    [/if]
-    [unit]
-        side=2
-        id=Uver
-        name=_"Uver"
-        x,y=37,30
-        type=Master at Arms
-        canrecruit=yes
-    [/unit]
-    [/event]
-
-    [event]
-    name=start
-        {PLACE_IMAGE scenery/bookshelf-1.png 41 28}
-        {PLACE_IMAGE items/box.png 38 32}
-        {PLACE_IMAGE items/box.png 29 30}
-        {PLACE_IMAGE items/box.png 25 29}
-        {PLACE_IMAGE items/box.png 41 23}
-        {PLACE_IMAGE items/box.png 35 25}
-        {PLACE_IMAGE items/box.png 3 30}
-        {PLACE_IMAGE scenery/bookshelf-2.png 10 29}
-        {PLACE_IMAGE scenery/bookshelf-3.png 42 29}
-        {PLACE_IMAGE cabinet.png 33 27}
-    [remove_shroud]
-        side=1
-    [/remove_shroud]
-    [place_shroud]
-        side=1
-        terrain=Xol,Iwr,Mm^Xm
-    [/place_shroud]
-    [place_shroud]
-        side=1
-        x,y=0-45,27-34
-    [/place_shroud]
-    [place_shroud]
-        side=1
-        x,y=32-45,20-26
-    [/place_shroud]
-    [remove_shroud]
-        side=1
-        x,y=30,25
-    [/remove_shroud]
-    {TBC_GOLD_CHEST 37 27 faithdome_inner_chest}
-    {TBC_GOLD_CHEST 13 33 faithdome_outer_chest}
-    [if]
-        [variable]
-            name=quests.entered_faithdome
-            equals=yes
-        [/variable]
-        [else] 
-                {RARE_ITEM 23 30}
-            [message]
-                speaker=Rimaru
-                message=_"Faithdome. This town used to have a better name, but Uver changed it to prove his faith to the Brothers. Enough talking, we must hurry."
-            [/message]
-            [message]
-                speaker=orc
-                message=_"I was starting to be afraid that we would talk forever... again."
-            [/message]
-            {VARIABLE quests.entered_faithdome yes}
-        [/else]
-    [/if]
-    [if]
-        [variable]
-            name=quests.faithdome_infantryman
-            equals=yes
-        [/variable]
-        [else] 
-            [unit]
-                type=Iron Mauler
-                x,y=35,23
-                side=2
-                id=wise_warrior
-                generate_name=yes
-                canrecruit=yes
-                random_traits=yes
-                [modifications]
-                [advance]
-                    id=portrait
-                    [effect]
-                        apply_to=profile
-                        portrait="portraits/humans/transparent/heavy-infantry.png"
-                    [/effect]
-                [/advance]
-                {TRAIT_INTELLIGENT}
-                 [/modifications]
-                 [variables]
-                hero=yes
-                 [/variables]
-            [/unit]
-            [event]
-            name=moveto
-            [filter]
-                side=1
-                x,y=32-44,20-25
-            [/filter]
-            {VARIABLE quests.faithdome_infantryman yes}
-            [message]
-                speaker=wise_warrior
-                message=_"I know. I am the man responsible for arming lord Uver's soldiers and sending them against you. Almost unforgivable. But what could I do, I didn't want to be killed for treason."
-            [/message]
-            [message]
-                speaker=unit
-                message=_"So, you're trying to save your life?"
-            [/message]
-            [message]
-                speaker=wise_warrior
-                message=_"I have done my job as bad as I could, it didn't take me long to realise where the truth is."
-            [/message]
-            [message]
-                speaker=unit
-                message=_"Well, I noticed that your barracks were less active than the others."
-            [/message]
-            [message]
-                speaker=wise_warrior
-                message=_"You see? I was not faithful to them, but I could not flee. I didn't have the courage like you... So I chose safety, and I decided that I can harm their cause much more if I cause as much trouble as possible by being seemingly incompetent."
-            [/message]
-            [message]
-                speaker=unit
-                message=_"What made you change your mind?"
-            [/message]
-            [message]
-                speaker=wise_warrior
-                message=_"As most others, I initially considered the things told by the Brothers of Light sacred, they seemed to be loyal servants of good. But then it changed. They were worse than usual humans, complancent, arrogant, selfish, overly proud, neglectful towards others,... When this war started, they worked a lot with the army where I was in. Lord Uver told us to cooperate, but they weren't cooperative, they were just demanding absolute obedience."
-            [/message]
-            [message]
-                speaker=wise_warrior
-                message=_"Sometimes, they even ordered us to do silly things so that they could laugh at us. They ignored our advice and were giving orders despite having no experience with warfare. One Brother actually had a talent for warfare tactics and put some limits to their stupid commanding, but you killed him recently. When they were <i>cooperating</i> with us, I realised that talking to a single one was enough to ruin my mood for the whole day."
-            [/message]
-            [message]
-                speaker=wise_warrior
-                message=_"They made me hate them. I realised how significantly different were the morals contained in their teachings and their own morals. Shortly after, I overheard them talking about bribes and stealing. They also described how they looked forward to taking tithes also from the Sand Empire and taking large shares of the money for themselves. They have no honour, no manners, the only thing that differs them from criminals is that they are intelligent enough to conceal it."
-            [/message]
-            [message]
-                speaker=wise_warrior
-                message=_"I started thinking about killing them all and turning coat, but they clearly had experience for it and never gave me a good occasion for that. Other soldiers were brainwashed every day and I was sure that I would not succeed to persuade a significant part of soldiers to join me. And the others would not fight their former comrades. I had to stay here and perform as poorly as possible in my duties. Until you came."
-            [/message]
-            [message]
-                speaker=unit
-                message=_"Interesting story. It sounds like truth."
-            [/message]
-            [message]
-                speaker=wise_warrior
-                message= _ "May I join you?"
-                [option]
-                message=_"Yes. We need people like you."
-                [command]
-                    [store_unit]
-                        [filter]
-                            id=wise_warrior
-                        [/filter]
-                        variable=warrior_store
-                    [/store_unit]
-                    {VARIABLE warrior_store.side 1}
-                    [unstore_unit]
-                        variable=warrior_store
-                        find_vacant=no
-                    [/unstore_unit]
-                    {CLEAR_VARIABLE warrior_store}
-                    {VARIABLE party_members[$party_members.length].id wise_warrior}
-                    [message]
-                        speaker=wise_warrior
-                        message=_"Thank you. It will be a honour to fight by your side."
-                    [/message]
-                [/command]
-                [/option]
-                [option]
-                message=_"No, I am not sure if I can trust you. You are free to go."
-                [command]
-                    [message]
-                        speaker=wise_warrior
-                        message=_"What a pity. Still, it's good that you fear spies, they are to be feared."
-                    [/message]
                     [move_unit]
-                        id=wise_warrior
-                        to_x=23
-                        to_y=1
+                        id=Konrad
+                        to_x=32
+                        to_y=30
                         fire_event=no
                     [/move_unit]
-                    [kill]
-                        id=wise_warrior
-                        animate=no
+                    [move_unit]
+                        id=Konrad_II
+                        to_x=35
+                        to_y=32
                         fire_event=no
-                    [/kill]
-                [/command]
-                [/option]
-            [/message]
-            [/event]
-        [/else]
-    [/if]
-
-    [if]
-        [variable]
-            name=quests.faithdome_destroyed_barracks
-            equals=yes
-        [/variable]
-        [else] 
-            [event]
-            name=moveto
-            [filter_condition]
-                [variable]
-                    name=quests.overall
-                    equals=10
-                [/variable]
-            [/filter_condition]
-            [filter]
-                side=1
-                x,y=2-6,27-33
-            [/filter]
-            [message]
-                speaker=unit
-                message=_"I will destroy these barracks. These walls look prone to a cave in, damaging one of these scaffolds will be enough."
-            [/message]
-            [move_unit]
-                id=$unit.id
-                to_x=6
-                to_y=24
-                fire_event=no
-            [/move_unit]
-            {EARTHQUAKE (
-                [terrain]
-                    x,y=6,26-27
-                    terrain=Xu
-                [/terrain]
-                [redraw]
-                [/redraw]
-            )}
-            [message]
-                speaker=unit
-                message=_"Now, nobody will annoy us."
-            [/message]
-            {VARIABLE quests.faithdome_destroyed_barracks yes}
-             [/event]
-        [/else]
-    [/if]
-
-    [if]
-        [variable]
-            name=quests.overall
-            greater_than=11
-        [/variable]
-        [else]
-            [event]
-                name=new turn
-                first_time_only=no
-#define PICK_SPAWN
-#ifdef EASY
-{VARIABLE_OP unit_type rand "Swordsman,Spearman,Javelineer,Pikeman,Duelist,Fencer,Lieutenant"}
-#endif
-#ifdef NORMAL
-{VARIABLE_OP unit_type rand "Swordsman,Spearman,Javelineer,Pikeman,Halberdier,Duelist,Fencer,Lieutenant,General"}
-#endif
-#ifdef HARD
-{VARIABLE_OP unit_type rand "Swordsman,Spearman,Javelineer,Pikeman,Halberdier,Duelist,Master at Arms,Fencer,Royal Guard,Lieutenant,General"}
-#endif
-#enddef
-                [if]
-                    [variable]
-                        name=quests.faithdome_infantryman
-                        equals=yes
-                    [/variable]
-                    [else]
-                        {PICK_SPAWN}
-                        {GENERIC_UNIT 3 $unit_type 39 23}
-                    [/else]
-                [/if]
-                [if]
-                    [variable]
-                        name=quests.faithdome_destroyed_barracks
-                        equals=yes
-                    [/variable]
-                    [else]
-                        {PICK_SPAWN}
-                        {GENERIC_UNIT 3 $unit_type 3 30}
-                        {PICK_SPAWN}
-                        {GENERIC_UNIT 3 $unit_type 5 29}
-                    [/else]
-                [/if]
-#undef PICK_SPAWN
-                {CLEAR_VARIABLE spawn_type}	
-            [/event]
-
-            [if]
-                [variable]
-                    name=quests.faithdome_northern_guards
-                    equals=yes
-                [/variable]
-                [else]
-                    [event]
-                        name=moveto
-                        [filter]
-                            x,y=16-36,5-16
-                            side=1
-                        [/filter]
-                        {TBC_SPAWN_UNITS_NO_LEADER 3 1.4 "Swordsman,Javelineer,Longbowman" 25 15}
-                        [message]
-                            speaker=unit
-                            message=_"A group of guards have noticed us, I think. They seem to be organising city defences. Fortunately, the best soldiers usually aren't working as town guards."
-                        [/message]
-                        {VARIABLE quests.faithdome_northern_guards yes}
-                    [/event]
-                [/else]
-            [/if]
-
-            [if]
-                [variable]
-                    name=quests.faithdome_southern_guards
-                    equals=yes
-                [/variable]
-                [else]
-                    [event]
-                        name=moveto
-                        [filter]
-                            x,y=1-21,9,24
-                            side=1
-                        [/filter]
-                        {TBC_SPAWN_UNITS_NO_LEADER 3 1.4 "Shock Trooper,White Mage" 16 22}
-                        [message]
-                            speaker=unit
-                            message=_"We were spotted by a group of guards. I can hear their shouts, they are preparing city defence. Guards should be fine, elite soldiers are a pain."
-                        [/message]
-                        {VARIABLE quests.faithdome_southern_guards yes}
-                    [/event]
-                [/else]
-            [/if]
-
-            [if]
-                [variable]
-                    name=quests.faithdome_outer_guards
-                    equals=yes
-                [/variable]
-                [else]
-                    [event]
-                        name=moveto
-                        [filter]
-                            x,y=8-24,27-34
-                            side=1
-                        [/filter]
-                        {TBC_SPAWN_UNITS_NO_LEADER 3 0.9 "Royal Guard,Master Bowman,White Mage" 26 30}
-                        [message]
-                            speaker=unit
-                            message=_"Darn, this castle is guarded."
-                        [/message]
-                        {VARIABLE quests.faithdome_outer_guards yes}
-                    [/event]
-                [/else]
-            [/if]
-
-            [if]
-                [variable]
-                    name=quests.faithdome_inner_guards
-                    equals=yes
-                [/variable]
-                [else]
-                    [event]
-                        name=moveto
-                        [filter]
-                            x,y=22-44,27-33
-                            side=1
-                        [/filter]
-                        {TBC_SPAWN_UNITS_NO_LEADER 3 0.9 "Royal Guard,Master Bowman,White Mage" 37 30}
-                        [message]
-                            speaker=unit
-                            message=_"More guards, but I think that we're close to Uver."
-                        [/message]
-                        {VARIABLE quests.faithdome_inner_guards yes}
-                    [/event]
-                [/else]
-            [/if]
-
-            [event]
-                name=moveto,attack end
-                [filter]
-                    x,y=31-43,26-33
-                [/filter]
-                [filter_condition]
-                    [not]
-                        [have_unit]
-                            side=3
-                            x,y=31-43,26-33
-                        [/have_unit]
-                    [/not]
-                [/filter_condition]
-                {VARIABLE quests.overall 11}
-                [message]
-                    speaker=Uver
-                    message=_"I know that you'd expect me to attack and die, but I am not so foolish. I know that there is little I can do to stop you."
-                [/message]
-                [message]
-                    speaker=Rimaru
-                    message=_"So are you giving up? If you promise that you'll obey us, we might be merciful."
-                [/message]
-                [move_unit]
-                    side=1
-                    to_x=37
-                    to_y=30
-                    fire_event=no
-                [/move_unit]
-                [while]
-                    [not]
-                        [variable]
-                            name=done
-                            equals=yes
-                        [/variable]
-                    [/not]
-                    [do]
-                        [message]
-                            speaker=Uver
-                            message=_"I am giving up, as I said, you can trust me."
-                            [option]
-                            message=_"How can I know I can trust you?"
-                            [command]
-                                [message]
-                                    speaker=faithful_lieutenant
-                                    message=_"I turned my coat honestly, maybe you can trust him too."
-                                [/message]
-                                [message]
-                                    speaker=Rimaru
-                                    message=_"You can't trust him, but if he's surrounded he will not try any tricks."
-                                [/message]
-                                [message]
-                                    speaker=hired_halberdier
-                                    message=_"How about beating him so bad that he would need to recover before being able to try any tricks?"
-                                [/message]
-                            [/command]
-                            [/option]
-                            [option]
-                            message=_"We can never be sure if you aren't planning anything bad, keep your soldiers away from the castle and we can talk."
-                            [command]
-                                {VARIABLE done yes}
-                            [/command]
-                            [/option]
-                            [option]
-                            message=_"If you'll cooperate with us, you'll receive this beautiful elvish maiden as a wife."
-                            [show_if]
-                                [have_unit]
-                                    id=elf_merc
-                                [/have_unit]
-                            [/show_if]
-                            [command]
-                                [message]
-                                    speaker=elf_merc
-                                    message=_"I have also an idea. Kill yourself."
-                                [/message]
-                                [message]
-                                    speaker=player
-                                    message=_"Do you really have to be like this?"
-                                [/message]
-                                [if]
-                                    [have_unit]
-                                        id=player
-                                        gender=male
-                                    [/have_unit]
-                                    [then]
-                                        [message]
-                                            speaker=elf_merc
-                                            message=_"Do <i>you</i> really have to be like this? Find another way to motivate him."
-                                        [/message]
-                                    [/then]
-                                    [else]
-                                        [message]
-                                            speaker=elf_merc
-                                            message=_"Offer yourself to him if you are so fond of this idea."
-                                        [/message]
-                                    [/else]
-                                [/if]
-                            [/command]
-                            [/option]
-                            [option]
-                            message=_"We will reward you with large amounts of gold if you choose to cooperate."
-                            [command]
-                                [message]
-                                    speaker=Uver
-                                    message=_"You don't have much gold, I know that."
-                                [/message]
-                                [message]
-                                    speaker=Burke
-                                    message=_"Money will not work on this one, he's too powerful for tricks like that."
-                                [/message]
-                            [/command]
-                            [/option]
-                            [option]
-                            message=_"To be sure that you're not lying, our orcish friend will torture you a bit to verify it."
-                            [show_if]
-                                [have_unit]
-                                    id=orc
-                                [/have_unit]
-                            [/show_if]
-                            [command]
-                                [message]
-                                    speaker=orc
-                                    message=_"That's stupid. We will only motivate him to be our enemy that way."
-                                [/message]
-                                [message]
-                                    speaker=bandit_merc
-                                    message=_"Why? I don't understand. The torture idea was a good idea."
-                                [/message]
-                            [/command]
-                            [/option]
-                        [/message]
-                    [/do]
-                [/while]
-                {CLEAR_VARIABLE done}
-                [message]
-                    speaker=Uver
-                    message=_"Okay, I can do that. Soldiers, I am giving you a command I thought I would never have to give. Lay down your weapons."
-                [/message]
-                [move_unit]
-                    side=3
-                    x,y=9-43,26-33
-                    to_x=18
-                    to_y=22
-                    fire_event=no
-                [/move_unit]
-                [modify_unit]
-                    [filter]
-                        side=3
-                    [/filter]
-                    side=2
-                [/modify_unit]
-                [message]
-                    speaker=hired_swordsman
-                    message=_"No more fighting? Dammit."
-                [/message]
-                [message]
-                    speaker=Burke
-                    message=_"So, you've given up. Perfect. There is one story we would like you to know."
-                [/message]
-                [message]
-                    id=wise_warrior
-                    side=1
-                    message=_"Do you know how moral are the Brothers of Light? I was tasked to cooperate with them in our war. I overheard them talking about bribes and thefts. Furthermore, they seemed to look forward to taking huge tithes also from the Sand Empire and peculating large shares of the money for themselves. I can say that they are very different from what they tell about themselves, they have no honour, they lie and steal and work hard on concealing it."
-                [/message]
-                [message]
-                    speaker=Uver
-                    message=_"I've heard such stories. But where is the evidence? What you say can be just rumours you're spreading to discredit them."
-                [/message]
-                [message]
-                    speaker=she_brother
-                    message=_"Do you know what I've seen when I was with them? You have dealt with them many times, you should have noticed the truth too. But it seems that you have eyes that cannot see and ears that cannot hear."
-                [/message]
-                [message]
-                    speaker=Rimaru
-                    message=_"Have you ever wondered why I left the order? They let my sister die just to advance one of their schemes."
-                [/message]
-                [message]
-                    speaker=Uver
-                    message=_"You could have killed some of them and taken their robes. Or maybe you were kicked from the order, that would explain your healing skills you are surely going to demonstrate. In any case, your testimonials are no evidence."
-                [/message]
-                [message]
-                    speaker=orc
-                    message=_"This sounds like if somebody taught him what to tell."
-                [/message]
-                [message]
-                    speaker=Rimaru
-                    message=_"Doesn't it seem strange to you how powerful they are? They were supposed to be healers and spreaders of universal good, but instead, they possess incredible power and their order is a powerful economy. They made the king declare war to Sand Empire despite the damage it would cause. They have also strong word in internal politics, haven't you seen how much they command you? They take a ninth of all the land's production, and that is a very significant amount of money."
-                [/message]
-                [message]
-                    speaker=Burke
-                    message=_"I think that you will not persuade him. He was being brainwashed for way too long. It's not like in my case, I agreed to support them a bit because I did not want to risk my comfortable life. When I had no other choice, I did the right thing, but this one is different. I have punched a few of them into their unworthy faces when they demanded too much. I can't imagine Uver doing that."
-                [/message]
-                [while]
-                    [not]
-                        [variable]
-                            name=done
-                            equals=yes
-                        [/variable]
-                    [/not]
-                    [do]
-                        [message]
-                            speaker=Uver
-                            message=_"Say whatever you want, you won't persuade me."
-                            [option]
-                            message=_"It's time to give up and seek another solution."
-                            [command]
-                                {VARIABLE done yes}
-                            [/command]
-                            [/option]
-                            [option]
-                            message=_"How about threatening him with death again? Using weapons to persuade him to surrender wasn't hard..."
+                    [/move_unit]
+                    [message]
+                        speaker=Konrad
+                        message=_"Hello. I am back from my journey. I don't have good news, though."
+                    [/message]
+                    [message]
+                        speaker=Burke
+                        message=_"What news? How did your attempt to persuade the king go?"
+                    [/message]
+                    [message]
+                        speaker=Konrad_II
+                        message=_"Badly. The king is stupid."
+                    [/message]
+                    [message]
+                        speaker=Konrad
+                        message=_"A few Brothers were following him wherever he went, there was no chance for me to talk to him privately. I managed to persuade a few lesser lords, though. They helped me to lure the Brothers away from the king so that I could talk to him. I tried hard to convince him, but their influence on him was too strong. All three of his counsellors were in the order, and the first thing he did after hearing my carefully prepared speech was to seek their advice."
+                    [/message]
+                    [message]
+                        speaker=Konrad_II
+                        message=_"You should have convinced his eldest son and sent somebody to get rid of the king, men as stupid as our king should not rule."
+                    [/message]
+                    [message]
+                        speaker=Konrad
+                        message=_"That is not the way problems should be dealt with... You can easily guess the rest of the story. The Brothers told him to hang me for treason or send me to their dungeons for blasphemy. For a while, I thought that he would really kill me, but the king understood that getting rid of powerful lords is not the best way to ensure stability of the throne. He told me to go away and never return unless I change my mind and added some brothersoflight-style crap."
+                    [/message]
+                    [message]
+                        speaker=Burke
+                        message=_"So you totally failed, right?"
+                    [/message]
+                    [message]
+                        speaker=Konrad
+                        message=_"Not really. The war will rage on, Brothers will keep spreading their corruption, but I managed to persuade many lords to try to stop their influence. That wasn't as hard as convincing the king, because they certainly didn't enjoy the influence that Brothers have on their soldiers and peasants. And of course, the war isn't very popular, large losses for little profit."
+                    [/message]
+                    [message]
+                        speaker=Al Ghareeb
+                        message=_"I am glad to hear that the war is unpopular in your country too."
+                    [/message]
+                    [message]
+                        speaker=Burke
+                        message=_"In short, we need to win this civil war, right? No legal force will help us and external forces are too far away."
+                    [/message]
+                    [message]
+                        speaker=Konrad_II
+                        message=_"Yes, unfortunately. We should have tried to stop this earlier, it seems to be too late now for a quick end."
+                    [/message]
+                    [message]
+                        speaker=Rimaru
+                        message=_"I initially doubted if my decision to start the peasant rebellion was the best choice, but now I regret that I was reluctant to do it earlier."
+                    [/message]
+                    [message]
+                        speaker=she_brother
+                        message=_"We can never know the consequences of our actions. Fearing bad consequences when they should not be feared is as bad as not fearing them when they should be feared, but we can never know for sure if they should be feared or not."
+                    [/message]
+                    [message]
+                        speaker=Konrad
+                        message=_"We need to talk about our plans."
+                    [/message]
+                    [message]
+                        speaker=Rimaru
+                        message=_"Are you sure that it's a good idea to talk about our plans when Uver is here?"
+                    [/message]
+                    [message]
+                        speaker=Konrad
+                        message=_"He'll cooperate or we'll have to kill him and impersonate him, there is no other choice. Let him hear. What do you suggest to do?"
+                        [option]
+                            message=_"We might hit the spider into his head. Bait Luke somehow and slay him. It will cause instability."
                             [command]
                                 [message]
                                     speaker=Al Ghareeb
-                                    message=_"He knows that he would be as good to us when he is dead as he would be good to us when he's in prison."
+                                    message=_"I second that idea. Bad guys usually have a beautiful tendency to fight other bad guys. Let the chaos devour them."
                                 [/message]
                                 [message]
-                                    speaker=hired_halberdier
-                                    message=_"That's wrong. We're gonna cut you pretty deep if you won't..."
+                                    speaker=Konrad
+                                    message=_"I was considering that option. I have talked with some Brothers and I eventually figured out what might be a good bait for him. I already prepared the bait, some time will need to pass until the bait attracts him and then the trap, namely you, will sprung and he'll die."
+                                [/message]
+                            [/command]
+                        [/option]
+                        [option]
+                            message=_"Our victory was quite unexpected and we have control on Uver's army. And Ziggurat, where the Child is held, isn't far from here. How about storming that place?"
+                            [command]
+                                [message]
+                                    speaker=faithful_lieutenant
+                                    message=_"We might fail at that, a blitzkrieg of that size is no easy feat, but the outcome of a success would be good."
+                                [/message]
+                                [message]
+                                    speaker=Konrad
+                                    message=_"Yes. I was considering that option. However, the total scale of the operation will not be so small, we'll need to prevent them from flanking us and also make sure that they will not evacuate Ziggurat. To facilitate it, we'll need to assassinate Luke, the Bringer of Light."
                                 [/message]
                                 [message]
                                     speaker=Rimaru
-                                    message=_"That will not work. He knows that he can't fight now. But changing his opinion and loyalties is a completely different affair than this."
+                                    message=_"What? Are you crazy? Trying that is lunacy, he's well guarded, good at escaping and we can never be sure that he'll ever come again to us."
                                 [/message]
                                 [message]
-                                    speaker=hired_halberdier
-                                    message=_"Darn. I disagree."
+                                    speaker=Konrad
+                                    message=_"Not if we use a bait to get him somewhere."
                                 [/message]
                             [/command]
-                            [/option]
-                            [option]
-                            message=_"Have you noticed how powerful Luke, the Bringer of Light is? Do you think that a human can't be so powerful without embracing the dark forces?"
+                        [/option]
+                        [option]
+                            message=_"We might help ourselves with their own strategy. We'll hire or train a large group of assassins. They'll slay all people who deny us."
                             [command]
                                 [message]
-                                    speaker=Uver
-                                    message=_"He was chosen by gods to care about little Reezer."
+                                    speaker=bandit_merc
+                                    message=_"You're learning fast, hehe."
+                                [/message]
+                                [message]
+                                    speaker=Konrad
+                                    message=_"That wouldn't be easy, and furthermore there is the problem with consequences of such a strategy. A chain of assassinations of such scale would destabilise the country and cause so much inner struggles that it would result in more deaths than these wars. Utter chaos is worse than war, I learned that from historical records."
                                 [/message]
                                 [message]
                                     speaker=player
-                                    message=_"Yes, to care about the child, he was given the ability to make anything burn, bring groups of soldiers through a half of the kingdom, to rain fire from the skies..."
+                                    message=_"So what should we do instead?"
                                 [/message]
                                 [message]
-                                    speaker=Uver
-                                    message=_"Protecting may need dealing with threats."
-                                [/message]
-                                [message]
-                                    speaker=player
-                                    message=_"How much time do you think he spends with him? I have seen him a few times in Thunderhold, you have surely seen him too... a bit too much for a person supposed to protect a child, no? How can he protect a child that is far away from him?"
+                                    speaker=Konrad
+                                    message=_"A more targeted assassination. We'll bait Luke and slay him."
                                 [/message]
                             [/command]
-                            [/option]
-                            [option]
-                            message=_"What would your father do in your place? As far as I know, he was far wiser than you are."
-                            [command]
-                                [message]
-                                    speaker=Uver
-                                    message=_"How can I know what would a wiser man do instead of me? I know what would a stupid man do. Attack you right now."
-                                [/message]
-                                [message]
-                                    speaker=player
-                                    message=_"Do you think that he would obey a few funny men dressed in womanly robes who demand so much?"
-                                [/message]
-                            [/command]
-                            [/option]
-                        [/message]
-                    [/do]
-                [/while]
-                {CLEAR_VARIABLE done}
-                [if]
-                    [have_unit]
-                        id=she_brother
-                    [/have_unit]
-                    [then]
-                        [message]
-                            speaker=she_brother
-                            message=_"I believe that he would remain loyal to them even if he saw Luke kissing the Queen of Darkness."
-                        [/message]
-                        [message]
-                            speaker=Al Ghareeb
-                            message=_"Ha ha ha, try to picture that in your mind."
-                        [/message]
-                        [message]
-                            speaker=bandit_merc
-                            message=_"Heh heh, that's hilarious."
-                        [/message]
-                    [/then]
-                [/if]
-                [message]
-                    speaker=Rimaru
-                    message=_"I agree. This one isn't Burke. But what else can we try?"
-                [/message]
-                [unit]
-                    side=2
-                    id=Konrad
-                    name=_"Konrad"
-                    x,y=9,2
-                    type=Royal Warrior
-                    canrecruit=yes
-                    [modifications]
-                        [advance]
-                            id=portrait
-                            [effect]
-                                apply_to=profile
-                                portrait="portraits/humans/transparent/marshal-2.png"
-                            [/effect]
-                        [/advance]
-                    [/modifications]
-                [/unit]
-                [unit]
-                    side=2
-                    x,y=10,2
-                    type=Master at Arms
-                    id=Konrad_II
-                    name= _"Konrad II"
-                    canrecruit=yes
-                    [modifications]
-                        [advance]
-                            id=portrait
-                            [effect]
-                                apply_to=profile
-                                portrait="portraits/humans/transparent/fencer.png"
-                            [/effect]
-                        [/advance]
-                    [/modifications]
-                [/unit]
-                [move_unit]
-                    id=Konrad
-                    to_x=32
-                    to_y=30
-                    fire_event=no
-                [/move_unit]
-                [move_unit]
-                    id=Konrad_II
-                    to_x=35
-                    to_y=32
-                    fire_event=no
-                [/move_unit]
-                [message]
-                    speaker=Konrad
-                    message=_"Hello. I am back from my journey. I don't have good news, though."
-                [/message]
-                [message]
-                    speaker=Burke
-                    message=_"What news? How did your attempt to persuade the king go?"
-                [/message]
-                [message]
-                    speaker=Konrad_II
-                    message=_"Badly. The king is stupid."
-                [/message]
-                [message]
-                    speaker=Konrad
-                    message=_"A few Brothers were following him wherever he went, there was no chance for me to talk to him privately. I managed to persuade a few lesser lords, though. They helped me to lure the Brothers away from the king so that I could talk to him. I tried hard to convince him, but their influence on him was too strong. All three of his counsellors were in the order, and the first thing he did after hearing my carefully prepared speech was to seek their advice."
-                [/message]
-                [message]
-                    speaker=Konrad_II
-                    message=_"You should have convinced his eldest son and sent somebody to get rid of the king, men as stupid as our king should not rule."
-                [/message]
-                [message]
-                    speaker=Konrad
-                    message=_"That is not the way problems should be dealt with... You can easily guess the rest of the story. The Brothers told him to hang me for treason or send me to their dungeons for blasphemy. For a while, I thought that he would really kill me, but the king understood that getting rid of powerful lords is not the best way to ensure stability of the throne. He told me to go away and never return unless I change my mind and added some brothersoflight-style crap."
-                [/message]
-                [message]
-                    speaker=Burke
-                    message=_"So you totally failed, right?"
-                [/message]
-                [message]
-                    speaker=Konrad
-                    message=_"Not really. The war will rage on, Brothers will keep spreading their corruption, but I managed to persuade many lords to try to stop their influence. That wasn't as hard as convincing the king, because they certainly didn't enjoy the influence that Brothers have on their soldiers and peasants. And of course, the war isn't very popular, large losses for little profit."
-                [/message]
-                [message]
-                    speaker=Al Ghareeb
-                    message=_"I am glad to hear that the war is unpopular in your country too."
-                [/message]
-                [message]
-                    speaker=Burke
-                    message=_"In short, we need to win this civil war, right? No legal force will help us and external forces are too far away."
-                [/message]
-                [message]
-                    speaker=Konrad_II
-                    message=_"Yes, unfortunately. We should have tried to stop this earlier, it seems to be too late now for a quick end."
-                [/message]
-                [message]
-                    speaker=Rimaru
-                    message=_"I initially doubted if my decision to start the peasant rebellion was the best choice, but now I regret that I was reluctant to do it earlier."
-                [/message]
-                [message]
-                    speaker=she_brother
-                    message=_"We can never know the consequences of our actions. Fearing bad consequences when they should not be feared is as bad as not fearing them when they should be feared, but we can never know for sure if they should be feared or not."
-                [/message]
-                [message]
-                    speaker=Konrad
-                    message=_"We need to talk about our plans."
-                [/message]
-                [message]
-                    speaker=Rimaru
-                    message=_"Are you sure that it's a good idea to talk about our plans when Uver is here?"
-                [/message]
-                [message]
-                    speaker=Konrad
-                    message=_"He'll cooperate or we'll have to kill him and impersonate him, there is no other choice. Let him hear. What do you suggest to do?"
-                    [option]
-                    message=_"We might hit the spider into his head. Bait Luke somehow and slay him. It will cause instability."
-                    [command]
-                        [message]
-                            speaker=Al Ghareeb
-                            message=_"I second that idea. Bad guys usually have a beautiful tendency to fight other bad guys. Let the chaos devour them."
-                        [/message]
-                        [message]
-                            speaker=Konrad
-                            message=_"I was considering that option. I have talked with some Brothers and I eventually figured out what might be a good bait for him. I already prepared the bait, some time will need to pass until the bait attracts him and then the trap, namely you, will sprung and he'll die."
-                        [/message]
-                    [/command]
-                    [/option]
-                    [option]
-                    message=_"Our victory was quite unexpected and we have control on Uver's army. And Ziggurat, where the Child is held, isn't far from here. How about storming that place?"
-                    [command]
-                        [message]
-                            speaker=faithful_lieutenant
-                            message=_"We might fail at that, a blitzkrieg of that size is no easy feat, but the outcome of a success would be good."
-                        [/message]
-                        [message]
-                            speaker=Konrad
-                            message=_"Yes. I was considering that option. However, the total scale of the operation will not be so small, we'll need to prevent them from flanking us and also make sure that they will not evacuate Ziggurat. To facilitate it, we'll need to assassinate Luke, the Bringer of Light."
-                        [/message]
-                        [message]
-                            speaker=Rimaru
-                            message=_"What? Are you crazy? Trying that is lunacy, he's well guarded, good at escaping and we can never be sure that he'll ever come again to us."
-                        [/message]
-                        [message]
-                            speaker=Konrad
-                            message=_"Not if we use a bait to get him somewhere."
-                        [/message]
-                    [/command]
-                    [/option]
-                    [option]
-                    message=_"We might help ourselves with their own strategy. We'll hire or train a large group of assassins. They'll slay all people who deny us."
-                    [command]
-                        [message]
-                            speaker=bandit_merc
-                            message=_"You're learning fast, hehe."
-                        [/message]
-                        [message]
-                            speaker=Konrad
-                            message=_"That wouldn't be easy, and furthermore there is the problem with consequences of such a strategy. A chain of assassinations of such scale would destabilise the country and cause so much inner struggles that it would result in more deaths than these wars. Utter chaos is worse than war, I learned that from historical records."
-                        [/message]
-                        [message]
-                            speaker=player
-                            message=_"So what should we do instead?"
-                        [/message]
-                        [message]
-                            speaker=Konrad
-                            message=_"A more targeted assassination. We'll bait Luke and slay him."
-                        [/message]
-                    [/command]
-                    [/option]
-                [/message]
-                [message]
-                    speaker=player
-                    message=_"What bait?"
-                [/message]
-                [message]
-                    speaker=Konrad
-                    message=_"One of our gods' steps to divinity was phoenix ash. Its effects aren't far from immortality and try to guess how much Luke desires to have it. They've made a few experiments, but the only success was that a few Brothers burned to death when they tried to find a phoenix. I assume that killing an immortal phoenix is a far greater feat than merely finding one, but they could not even succeed at the first step."
-                [/message]
-                [message]
-                    speaker=Konrad
-                    message=_"So I spread some rumours that eons ago Niflheim the Horror from the Northern Wastelands obtained it and hid the leftovers in Hidden Valley. Hidden Valley isn't far away from here, but we still need to wait until the bait attracts him and he starts the excavation."
-                [/message]
-                [message]
-                    speaker=elf_merc
-                    message=_"Beautiful."
-                [/message]
-                [message]
-                    speaker=Burke
-                    message=_"That will weaken the foe, but how exactly do you plan to win the war?"
-                [/message]
-                [message]
-                    speaker=Konrad
-                    message=_"With Luke dead, their leadership will be very uncertain. Power struggles, growing into armed conflicts. Many accusations of treason and executions. We'll strike at that time. We can't try a sharp breakthrough to reach Ziggurat and rescue Reezer, because it might need a siege and that won't be quick. We need to play it safe, we can't rely on our luck. We'll start a large scale invasion to the south, spread our power a few miles south from Ziggurat. With Reezer in our hands, we'll make more plans."
-                [/message]
-                [message]
-                    speaker=Rimaru
-                    message=_"Now it's time to figure out a way how to make sure that Uver will obey us. He's not from the self-sacrifice kind, but he's adamant in his twisted faith."
-                [/message]
-                [message]
-                    speaker=Uver
-                    message=_"Twisted faith? You're planning to seize power in the country and destroy our religion! It is a shame that I have no other options but to cooperate."
-                [/message]
-                [message]
-                    speaker=Rimaru
-                    message=_"We won't make a public speech before his soldiers. They put down their weapons when their boss was surrounded, but..."
-                [/message]
-                [message]
-                    speaker=Konrad
-                    message=_"They also let us in. Following your path wasn't hard, all soldiers we encountered were dead. When we saw the first larger group of enemies, they told us that their lord is surrounded by assassins and asked me to stop you. Well, he'll not die today, so I've fulfilled their wish. But what would make them fight against their former idols?"
-                [/message]
-                [message]
-                    speaker=Uver
-                    message=_"Only me, ha ha."
-                [/message]
-                [message]
-                    speaker=she_brother
-                    message=_"Shut up, idiot."
-                [/message]
-
-
-                [unit]
-                    side=3
-                    type=Manhunter
-                    name=_"???"
-                    x,y=8,11
-                    id=Manhunter
-                    [modifications]
-                        [object]
-                            [effect]
-                                apply_to=attack
-                                increase_damage=30%
-                                heal_full=yes
-                            [/effect]
-                        [/object]
-                    [/modifications]
-                [/unit]
-                [if]
-                    [variable]
-                        name=party_members.length
-                        greater_than=6
-                    [/variable]
-                    [then]
-                        [object]
-                            [filter]
-                                id=Manhunter
-                            [/filter]
-                            silent=yes
-                            [effect]
-                                apply_to=hitpoints
-                                increase_total=50%
-                                heal_full=yes
-                            [/effect]
-                        [/object]
-                    [/then]
-                [/if]
-                [if]
-                    [variable]
-                        name=party_members.length
-                        greater_than=9
-                    [/variable]
-                    [then]
-                        [object]
-                            [filter]
-                                id=Manhunter
-                            [/filter]
-                            silent=yes
-                            [effect]
-                                apply_to=hitpoints
-                                increase_total=50%
-                                heal_full=yes
-                            [/effect]
-                        [/object]
-                    [/then]
-                [/if]
-                [move_unit]
-                    id=Manhunter
-                    to_x=28
-                    to_y=30
-                    fire_event=no
-                [/move_unit]
-                {EARTHQUAKE (
-                    [terrain]
-                        x,y=17,28
-                        terrain=Xu
-                    [/terrain]
-                    [redraw]
-                    [/redraw]
-                )}
-                [message]
-                    speaker=Konrad
-                    message=_"Where have you found the courage to fight us again? Before, you fled like a chicken. Are you going a use a few spells again and run like hell?"
-                [/message]
-                [message]
-                    speaker=Manhunter
-                    message=_"(gazes murderously at Konrad)"
-                [/message]
-                {EARTHQUAKE (
-                    [terrain]
-                        x,y=32,30
-                        terrain=Iwr^De
-                    [/terrain]
-                    [redraw]
-                    [/redraw]
-                )}
-                [harm_unit]
-                    [filter]
-                        id=Konrad
-                    [/filter]
-                    amount=25
-                [/harm_unit]
-                {EARTHQUAKE (
-                    [terrain]
-                        x,y=32,30
-                        terrain=Xu
-                    [/terrain]
-                    [redraw]
-                    [/redraw]
-                )}
-                [harm_unit]
-                    [filter]
-                        id=Konrad
-                    [/filter]
-                    amount=200
-                    kill=yes
-                [/harm_unit]
-                [message]
-                    speaker=Manhunter
-                    message=_"I will cast a few spells, he said."
-                [/message]
-                [message]
-                    speaker=Konrad_II
-                    message=_"How did you dare to do that? How did you dare to kill my father!"
-                [/message]
-                [message]
-                    speaker=Manhunter
-                    message=_"It's so spooky to feel your wrath."
-                [/message]
-                [message]
-                    speaker=Konrad_II
-                    message=_"Help me kill him, my friends. My father's death must be avenged."
-                [/message]
-                [message]
-                    speaker=Rimaru
-                    message=_"You are too precious to risk death by the hands of this assassin. Stay away from this."
-                [/message]
-                [message]
-                    speaker=Konrad_II
-                    message=_"Okay."
-                [/message]
-                [move_unit]
-                    id=Konrad_II
-                    to_x=42
-                    to_y=27
-                    fire_event=no
-                [/move_unit]
-                [message]
-                    speaker=Rimaru
-                    message=_"He'll be a good lord."
-                [/message]
-                [if]
-                    [variable]
-                        name=party_members.length
-                        greater_than=3
-                    [/variable]
-                    [then]
-                        [event]
-                            name=spellcast
-                            first_time_only=no
-                            [store_unit]
-                                [filter]
-                                    type=Magic Missile
-                                    [or]
-                                        type=Soulless
-                                    [/or]
-                                    [not]
-                                        [filter_wml]
-                                            [variables]
-                                                improved=yes
-                                            [/variables]
-                                        [/filter_wml]
-                                    [/not]
-                                [/filter]
-                                variable=summons
-                                kill=no
-                            [/store_unit]
-                            {FOREACH summons i}
-                                [object]
-                                    [filter]
-                                        id=$summons[$i].id
-                                    [/filter]
-                                    silent=yes
-                                    [effect]
-                                        apply_to=hitpoints
-                                        increase_total=200%
-                                        heal_full=yes
-                                    [/effect]
-                                [/object]
-                                {VARIABLE summons[$i].variables.improved yes}
-                                [if]
-                                    [variable]
-                                        name=party_members.length
-                                        greater_than=5
-                                    [/variable]
-                                    [then]
-                                        [object]
-                                            [filter]
-                                                id=$summons[$i].id
-                                            [/filter]
-                                            silent=yes
-                                            [effect]
-                                                apply_to=attack
-                                                increase_damage=3
-                                            [/effect]
-                                        [/object]
-                                    [/then]
-                                [/if]
-                                [if]
-                                    [variable]
-                                        name=party_members.length
-                                        greater_than=7
-                                    [/variable]
-                                    [then]
-                                        [object]
-                                            [filter]
-                                                id=$summons[$i].id
-                                            [/filter]
-                                            silent=yes
-                                            [effect]
-                                                apply_to=attack
-                                                increase_damage=20%
-                                            [/effect]
-                                        [/object]
-                                    [/then]
-                                [/if]
-                                [if]
-                                    [variable]
-                                        name=party_members.length
-                                        greater_than=10
-                                    [/variable]
-                                    [then]
-                                        [object]
-                                            [filter]
-                                                id=$summons[$i].id
-                                            [/filter]
-                                            silent=yes
-                                            [effect]
-                                                apply_to=attack
-                                                increase_damage=30%
-                                            [/effect]
-                                        [/object]
-                                    [/then]
-                                [/if]
-                            {NEXT i}
-                            {CLEAR_VARIABLE summons}
-                        [/event]
-                    [/then]
-                [/if]
-                [event]
-                    name=last breath
-                    [filter]
-                        id=Manhunter
-                    [/filter]
-                    {VARIABLE quests.overall 12}
-                    [message]
-                        speaker=Manhunter
-                        message=_"I will slay you. One by one."
+                        [/option]
                     [/message]
+                    [message]
+                        speaker=player
+                        message=_"What bait?"
+                    [/message]
+                    [message]
+                        speaker=Konrad
+                        message=_"One of our gods' steps to divinity was phoenix ash. Its effects aren't far from immortality and try to guess how much Luke desires to have it. They've made a few experiments, but the only success was that a few Brothers burned to death when they tried to find a phoenix. I assume that killing an immortal phoenix is a far greater feat than merely finding one, but they could not even succeed at the first step."
+                    [/message]
+                    [message]
+                        speaker=Konrad
+                        message=_"So I spread some rumours that eons ago Niflheim the Horror from the Northern Wastelands obtained it and hid the leftovers in Hidden Valley. Hidden Valley isn't far away from here, but we still need to wait until the bait attracts him and he starts the excavation."
+                    [/message]
+                    [message]
+                        speaker=elf_merc
+                        message=_"Beautiful."
+                    [/message]
+                    [message]
+                        speaker=Burke
+                        message=_"That will weaken the foe, but how exactly do you plan to win the war?"
+                    [/message]
+                    [message]
+                        speaker=Konrad
+                        message=_"With Luke dead, their leadership will be very uncertain. Power struggles, growing into armed conflicts. Many accusations of treason and executions. We'll strike at that time. We can't try a sharp breakthrough to reach Ziggurat and rescue Reezer, because it might need a siege and that won't be quick. We need to play it safe, we can't rely on our luck. We'll start a large scale invasion to the south, spread our power a few miles south from Ziggurat. With Reezer in our hands, we'll make more plans."
+                    [/message]
+                    [message]
+                        speaker=Rimaru
+                        message=_"Now it's time to figure out a way how to make sure that Uver will obey us. He's not from the self-sacrifice kind, but he's adamant in his twisted faith."
+                    [/message]
+                    [message]
+                        speaker=Uver
+                        message=_"Twisted faith? You're planning to seize power in the country and destroy our religion! It is a shame that I have no other options but to cooperate."
+                    [/message]
+                    [message]
+                        speaker=Rimaru
+                        message=_"We won't make a public speech before his soldiers. They put down their weapons when their boss was surrounded, but..."
+                    [/message]
+                    [message]
+                        speaker=Konrad
+                        message=_"They also let us in. Following your path wasn't hard, all soldiers we encountered were dead. When we saw the first larger group of enemies, they told us that their lord is surrounded by assassins and asked me to stop you. Well, he'll not die today, so I've fulfilled their wish. But what would make them fight against their former idols?"
+                    [/message]
+                    [message]
+                        speaker=Uver
+                        message=_"Only me, ha ha."
+                    [/message]
+                    [message]
+                        speaker=she_brother
+                        message=_"Shut up, idiot."
+                    [/message]
+
+                    [unit]
+                        side=3
+                        type=Manhunter
+                        name=_"???"
+                        x,y=8,11
+                        id=Manhunter
+                        [modifications]
+                            [object]
+                                [effect]
+                                    apply_to=attack
+                                    increase_damage=30%
+                                    heal_full=yes
+                                [/effect]
+                            [/object]
+                        [/modifications]
+                    [/unit]
+                    [if]
+                        [variable]
+                            name=party_members.length
+                            greater_than=6
+                        [/variable]
+                        [then]
+                            [object]
+                                [filter]
+                                    id=Manhunter
+                                [/filter]
+                                silent=yes
+                                [effect]
+                                    apply_to=hitpoints
+                                    increase_total=50%
+                                    heal_full=yes
+                                [/effect]
+                            [/object]
+                        [/then]
+                    [/if]
+                    [if]
+                        [variable]
+                            name=party_members.length
+                            greater_than=9
+                        [/variable]
+                        [then]
+                            [object]
+                                [filter]
+                                    id=Manhunter
+                                [/filter]
+                                silent=yes
+                                [effect]
+                                    apply_to=hitpoints
+                                    increase_total=50%
+                                    heal_full=yes
+                                [/effect]
+                            [/object]
+                        [/then]
+                    [/if]
+                    [move_unit]
+                        id=Manhunter
+                        to_x=28
+                        to_y=30
+                        fire_event=no
+                    [/move_unit]
                     {EARTHQUAKE (
                         [terrain]
                             x,y=17,28
-                            terrain=Rrc
+                            terrain=Xu
                         [/terrain]
                         [redraw]
                         [/redraw]
                     )}
-                    [move_unit]
-                        id=Manhunter
-                        to_x=26
-                        to_y=31
-                        fire_event=no
-                    [/move_unit]
                     [message]
-                        speaker=Manhunter
-                        message=_"Dammit, I can't..."
-                    [/message]
-                    [message]
-                        speaker=Al Ghareeb
-                        message=_"Now, you will die."
-                    [/message]
-                    [message]
-                        speaker=Rimaru
-                        message=_"You fell for an old magic trick I learned back then at the University. I was really fond of healing, so I learned spells for all kinds of healing. Sometimes illness causes delusions and you need to make sure that your patients will not escape and come to more harm. And you need spells to prevent them from fleeing, that's far better than tying them to their beds with ropes. And so it happened now that I needed to prevent a lunatic from fleeing..."
+                        speaker=Konrad
+                        message=_"Where have you found the courage to fight us again? Before, you fled like a chicken. Are you going a use a few spells again and run like hell?"
                     [/message]
                     [message]
                         speaker=Manhunter
-                        message=_"Rimaru, you are such a monster! You heal people, but you do it only for reverence. It's the only thing you're good at, you are proud of it and do it for pride, but you don't really care about people you heal!"
+                        message=_"(gazes murderously at Konrad)"
                     [/message]
+                    {EARTHQUAKE (
+                        [terrain]
+                            x,y=32,30
+                            terrain=Iwr^De
+                        [/terrain]
+                        [redraw]
+                        [/redraw]
+                    )}
+                    [harm_unit]
+                        [filter]
+                            id=Konrad
+                        [/filter]
+                        amount=25
+                    [/harm_unit]
+                    {EARTHQUAKE (
+                        [terrain]
+                            x,y=32,30
+                            terrain=Xu
+                        [/terrain]
+                        [redraw]
+                        [/redraw]
+                    )}
+                    [harm_unit]
+                        [filter]
+                            id=Konrad
+                        [/filter]
+                        amount=200
+                        kill=yes
+                    [/harm_unit]
                     [message]
-                        speaker=Rimaru
-                        message=_"Now, you're speaking like a little girl. Unmask him. I would like to look into his face, not only at a pair of ghostly eyes."
+                        speaker=Manhunter
+                        message=_"I will cast a few spells, he said."
                     [/message]
                     [message]
                         speaker=Konrad_II
-                        message=_"Kill him. He killed my father!"
+                        message=_"How did you dare to do that? How did you dare to kill my father!"
+                    [/message]
+                    [message]
+                        speaker=Manhunter
+                        message=_"It's so spooky to feel your wrath."
+                    [/message]
+                    [message]
+                        speaker=Konrad_II
+                        message=_"Help me kill him, my friends. My father's death must be avenged."
                     [/message]
                     [message]
                         speaker=Rimaru
-                        message=_"We need to know who it was first. We must know as much information as possible if we want to defeat Luke who was surely behind this."
+                        message=_"You are too precious to risk death by the hands of this assassin. Stay away from this."
                     [/message]
-                    [store_unit]
+                    [message]
+                        speaker=Konrad_II
+                        message=_"Okay."
+                    [/message]
+                    [move_unit]
+                        id=Konrad_II
+                        to_x=42
+                        to_y=27
+                        fire_event=no
+                    [/move_unit]
+                    [message]
+                        speaker=Rimaru
+                        message=_"He'll be a good lord."
+                    [/message]
+                    [if]
+                        [variable]
+                            name=party_members.length
+                            greater_than=3
+                        [/variable]
+                        [then]
+                            [event]
+                                name=spellcast
+                                first_time_only=no
+                                [store_unit]
+                                    [filter]
+                                        type=Magic Missile
+                                        [or]
+                                            type=Soulless
+                                        [/or]
+                                        [not]
+                                            [filter_wml]
+                                                [variables]
+                                                    improved=yes
+                                                [/variables]
+                                            [/filter_wml]
+                                        [/not]
+                                    [/filter]
+                                    variable=summons
+                                    kill=no
+                                [/store_unit]
+                                [for]
+                                    array=summons
+                                    [do]
+                                        [object]
+                                            [filter]
+                                                id=$summons[$i].id
+                                            [/filter]
+                                            silent=yes
+                                            [effect]
+                                                apply_to=hitpoints
+                                                increase_total=200%
+                                                heal_full=yes
+                                            [/effect]
+                                        [/object]
+                                        {VARIABLE summons[$i].variables.improved yes}
+                                        [if]
+                                            [variable]
+                                                name=party_members.length
+                                                greater_than=5
+                                            [/variable]
+                                            [then]
+                                                [object]
+                                                    [filter]
+                                                        id=$summons[$i].id
+                                                    [/filter]
+                                                    silent=yes
+                                                    [effect]
+                                                        apply_to=attack
+                                                        increase_damage=3
+                                                    [/effect]
+                                                [/object]
+                                            [/then]
+                                        [/if]
+                                        [if]
+                                            [variable]
+                                                name=party_members.length
+                                                greater_than=7
+                                            [/variable]
+                                            [then]
+                                                [object]
+                                                    [filter]
+                                                        id=$summons[$i].id
+                                                    [/filter]
+                                                    silent=yes
+                                                    [effect]
+                                                        apply_to=attack
+                                                        increase_damage=20%
+                                                    [/effect]
+                                                [/object]
+                                            [/then]
+                                        [/if]
+                                        [if]
+                                            [variable]
+                                                name=party_members.length
+                                                greater_than=10
+                                            [/variable]
+                                            [then]
+                                                [object]
+                                                    [filter]
+                                                        id=$summons[$i].id
+                                                    [/filter]
+                                                    silent=yes
+                                                    [effect]
+                                                        apply_to=attack
+                                                        increase_damage=30%
+                                                    [/effect]
+                                                [/object]
+                                            [/then]
+                                        [/if]
+                                    [/do]
+                                [/for]
+                                {CLEAR_VARIABLE summons}
+                            [/event]
+                        [/then]
+                    [/if]
+                    [event]
+                        name=last breath
                         [filter]
                             id=Manhunter
                         [/filter]
-                        variable=manhunter_store
-                        kill=yes
-                    [/store_unit]
-                    [unit]
-                        side=1
-                        x,y=$manhunter_store.x,$manhunter_store.y
-                        type=Exterminator
-                        gender=female
-                        id=Sicaria
-                        name= _"Sicaria"
-                        canrecruit=yes
-                        [modifications]
-                            [advance]
-                                id=portrait
-                                [effect]
-                                    apply_to=profile
-                                    portrait="portraits/humans/transparent/assassin+female.png"
-                                [/effect]
-                            [/advance]
-                            [advance]
-                                id=legacy_of_sorrow
-                            [/advance]
-                            [advance]
-                                id=awareness
-                            [/advance]
-                        [/modifications]
-                        animate=yes
-                    [/unit]
-                    {CLEAR_VARIABLE manhunter_store}
-                    [message]
-                        speaker=Rimaru
-                        message=_"I know that it sounds crazy, but aren't you my dead sister Sicaria?"
-                    [/message]
-                    [message]
-                        speaker=Sicaria
-                        message=_"I hate to tell that, but you've guessed that right, monster."
-                    [/message]
-                    [message]
-                        speaker=Konrad_II
-                        message=_"Kill her!"
-                    [/message]
-                    [message]
-                        speaker=Rimaru
-                        message=_"Did somebody raise you from the dead as some sort of enslaved vengeful spirit?"
-                    [/message]
-                    [message]
-                        speaker=Sicaria
-                        message=_"I am alive. And angry."
-                    [/message]
-                    [message]
-                        speaker=she_brother
-                        message=_"Oh, sorry, I didn't know that you were angry."
-                    [/message]
-                    [message]
-                        speaker=Rimaru
-                        message=_"Why do you hate me so much?"
-                    [/message]
-                    [message]
-                        speaker=Sicaria
-                        message=_"That's none of your concern, traitor."
-                    [/message]
-                    [message]
-                        speaker=Rimaru
-                        message=_"I did my best to save your life. I used all spells I could think of, I experimented, tried various healing methods I could brainstorm. I tried to persuade elder healers to help you, I even conspired to force them to save you, but nothing helped. I know that I failed, but you're alive anyway. You hate me like if I was the one who caused that disease, not like somebody who failed. Elder healers could heal worse things, but they refused. They are the ones you should hate."
-                    [/message]
-                    [message]
-                        speaker=Sicaria
-                        message=_"Am I supposed to believe that? I know the truth behind that. You decided that your healing skills need a demonstration, so you infected me with a combination of rare diseases. When your healing attempts failed, you dumped me to the morgue and left me for dead. Fortunately, Luke found me half-dead and saved me."
-                    [/message]
-                    [message]
-                        speaker=she_brother
-                        message=_"What...? I can assure you that Rimaru doesn't behave that way."
-                    [/message]
-                    [message]
-                        speaker=Burke
-                        message=_"We have been comrades with Rimaru for some time and I am sure that he doesn't seem to be overly proud of his healing skills. He is also relatively good at fighting, I must say... I think that the thing he's proud of is his honesty, so he enjoys telling any ugly thing he thinks."
-                    [/message]
-                    [message]
-                        speaker=Uver
-                        message=_"You see? If someone is strong in faith, your silly lies will not work."
-                    [/message]
-                    [message]
-                        speaker=Sicaria
-                        message=_"I am not stupid like you, Uver. To be honest, I would be happy if I could believe my brother. We were so close to each other until he did the crazy thing. If he had some sort of proof..."
-                    [/message]
-                    [message]
-                        speaker=Uver
-                        message=_"Faith is about faith, not about proof."
-                    [/message]
-                    [message]
-                        speaker=Rimaru
-                        message=_"Well, tell me what was Luke doing in the morgue where he found you? He was spending all the days and many nights at the library and left it only to visit a canteen or a toilet. What made him visit the morgue so suddenly?"
-                    [/message]
-                    [message]
-                        speaker=Sicaria
-                        message=_"I never questioned it, because that coincidence saved my life. Weren't you studying healing in the library when you were <i>saving</i> me?"
-                    [/message]
-                    [message]
-                        speaker=Rimaru
-                        message=_"I came there to check for some information, but I was mostly working with the books I had with me. But I can't prove that, right? The fact is that Luke never talked to anyone in the library back then, only if he needed something important. He asked me a few times to free his favourite spot for studying or to ask me to ask for a few candles. You remember him. Do you really think he would be observing what's going on outside the library?"
-                    [/message]
-                    [message]
-                        speaker=Sicaria
-                        message=_"No. But what was he doing in the morgue? He would not go check some dying people if they don't happen to be still alive and try to save them. He was addicted to some sort of research he was conducting all the time, so I suppose that he wanted to do some experiments. He wasn't dissecting the bodies and studying their internals, because when he healed me, I looked around and I would have noticed dissected bodies."
-                    [/message]
-                    [message]
-                        speaker=Sicaria
-                        message=_"We was doing some experiments, that's certain. Some... necromancy? Maybe. He found me, realised that I wasn't dead yet and healed me."
-                    [/message]
-                    [message]
-                        speaker=Rimaru
-                        message=_"I thought you were dead when I brought you there. I could not hear you breathing, I could not sense your heart beating, your feverish body was cooling down slowly. You had to be very close to death when you came there."
-                    [/message]
-                    [message]
-                        speaker=Sicaria
-                        message=_"I can't remember that, I wasn't conscious. The things I remember was that you were struggling and screaming at me to wake up and then I felt Luke's healing powers coming through me, healing me. After a minute or two, I was healthy. He told me what happened, or if your words are true, his version of it."
-                    [/message]
-                    [message]
-                        speaker=Rimaru
-                        message=_"Where have you gone then? I stayed with the order for about a year until my anger grew too strong. The building reminded me of you all the time and I was forced to think about your fate all the time. Then I left them."
-                    [/message]
-                    [message]
-                        speaker=Sicaria
-                        message=_"After a year? Luke told me that you fled before it was decided that you should be beheaded for your choice. I wanted to seek you and kill you for your horrible deed, but he told me that even if you're a healer, you can still use harmful magic and your skill with staff isn't bad. He told me that you will kill me if you learn about me in order to destroy all evidence. So I joined a guild of assassins, so that I could have my revenge later."
-                    [/message]
-                    [message]
-                        speaker=Rimaru
-                        message=_"I suppose that he was performing some experiments on the bodies, maybe stealing souls. Stealing souls would explain why he is so powerful now. When he found that your body was still warm, he healed you. You surely know that healers can't heal so fast, so he probably used some of the power he had from draining souls."
-                    [/message]
-                    [message]
-                        speaker=Sicaria
-                        message=_"Really... Luke has never been revered as a healer, yet he healed me incredibly fast there, as if he wielded some unusual powers. Are you sure that stealing souls can empower somebody so much?"
-                    [/message]
-                    [message]
-                        speaker=Rimaru
-                        message=_"I don't know that for sure, but stories tell that. Some of them are even contained in the tales told by the Brothers. If Luke learned that ancient technique of darkness, it would explain not only how he healed you so fast, but also why he is so powerful now. Also, by healing you, he made himself a very loyal ally, one that is very good for advancing schemes. He knew back then what a powerful beast he would become."
-                    [/message]
-                    [message]
-                        speaker=Sicaria
-                        message=_"Recently, he told me that he was blessed by gods to help him protect the Child. I doubted that, but his power was superior beyond doubt. I did not think of the possibility that some dark abilities granted him that power. When you told it, I was sure that you were just lying."
-                    [/message]
-                    [message]
-                        speaker=Rimaru
-                        message=_"You were also strangely powerful. How?"
-                    [/message]
-                    [message]
-                        speaker=Sicaria
-                        message=_"When I finished my assassin training, he gave me a ring. It was masterfully crafted, beautiful and I could sense some weird magic in it. He told me that if I kill an unrighteous person with the ring on, it will reward me with power. I killed a few criminals and I was suddenly super strong, I could sneak so well that people could look at me and fail to notice me and I could control weather to some extent. The powers faded in a few days, but bits of it remain."
-                    [/message]
-                    [message]
-                        speaker=Sicaria
-                        message=_"However, the temporary powers vanish almost instantly if I take it away. So I had it on almost all the time. When this war started, I killed people every day and I grew very powerful. I started to doubt that all of them were unrighteous, I was starting to feel that every single man is evil, but I understand it now. It was allowing me to drain souls. If you could please return it to me..."
-                    [/message]
-                    [message]
-                        speaker=Rimaru
-                        message=_"Yes."
-                    [/message]
-                    [store_unit]
-                        [filter]
+                        {VARIABLE quests.overall 12}
+                        [message]
+                            speaker=Manhunter
+                            message=_"I will slay you. One by one."
+                        [/message]
+                        {EARTHQUAKE (
+                            [terrain]
+                                x,y=17,28
+                                terrain=Rrc
+                            [/terrain]
+                            [redraw]
+                            [/redraw]
+                        )}
+                        [move_unit]
+                            id=Manhunter
+                            to_x=26
+                            to_y=31
+                            fire_event=no
+                        [/move_unit]
+                        [message]
+                            speaker=Manhunter
+                            message=_"Dammit, I can't..."
+                        [/message]
+                        [message]
+                            speaker=Al Ghareeb
+                            message=_"Now, you will die."
+                        [/message]
+                        [message]
+                            speaker=Rimaru
+                            message=_"You fell for an old magic trick I learned back then at the University. I was really fond of healing, so I learned spells for all kinds of healing. Sometimes illness causes delusions and you need to make sure that your patients will not escape and come to more harm. And you need spells to prevent them from fleeing, that's far better than tying them to their beds with ropes. And so it happened now that I needed to prevent a lunatic from fleeing..."
+                        [/message]
+                        [message]
+                            speaker=Manhunter
+                            message=_"Rimaru, you are such a monster! You heal people, but you do it only for reverence. It's the only thing you're good at, you are proud of it and do it for pride, but you don't really care about people you heal!"
+                        [/message]
+                        [message]
+                            speaker=Rimaru
+                            message=_"Now, you're speaking like a little girl. Unmask him. I would like to look into his face, not only at a pair of ghostly eyes."
+                        [/message]
+                        [message]
+                            speaker=Konrad_II
+                            message=_"Kill him. He killed my father!"
+                        [/message]
+                        [message]
+                            speaker=Rimaru
+                            message=_"We need to know who it was first. We must know as much information as possible if we want to defeat Luke who was surely behind this."
+                        [/message]
+                        [store_unit]
+                            [filter]
+                                id=Manhunter
+                            [/filter]
+                            variable=manhunter_store
+                            kill=yes
+                        [/store_unit]
+                        [unit]
+                            side=1
+                            x,y=$manhunter_store.x,$manhunter_store.y
+                            type=Exterminator
+                            gender=female
                             id=Sicaria
-                        [/filter]
-                        variable=sicaria_store
-                        kill=yes
-                    [/store_unit]
-                    [set_variables]
-                        name=sicaria_store.modifications.advance[$sicaria_store.modifications.advance]
-                        mode=replace
-                        [value]
-                            id=sicarias_ring
-                            [effect]
-                                apply_to=defense
-                                replace=false
-                                [defense]
-                                    frozen=-5
-                                    shallow_water=-5
-                                    reef=-5
-                                    flat=-5
-                                    castle=-5
-                                    village=-5
-                                    forest=-5
-                                    cave=-5
-                                    hills=-5
-                                    mountains=-5
-                                    fungus=-5
-                                    swamp_water=-5
-                                    sand=-5
-                                [/defense]
-                            [/effect]
-                            [effect]
-                                apply_to=image_mod
-                                add="~O(80%)"
-                            [/effect]
-                            [effect]
-                                apply_to=new_ability
-                                [abilities]
-                                    [dummy]
-                                    id=murderlust
-                                    [/dummy]
-                                [/abilities]
-                            [/effect]
-                        [/value]
-                    [/set_variables]
-                    [unit]
-                        side=1
-                        x,y=$sicaria_store.x,$sicaria_store.y
-                        type=Exterminator
-                        gender=female
-                        id=Sicaria
-                        name= _"Sicaria"
-                        canrecruit=yes
-                        [variables]
-                            hero=yes
-                        [/variables]
-                        [insert_tag]
-                            name=advance
-                            variable=sicaria_store.modifications
-                        [/insert_tag]
-                        animate=no
-                    [/unit]
-                    {CLEAR_VARIABLE sicaria_store}
-                    {VARIABLE party_members[$party_members.length].id Sicaria}
-                    [message]
-                        speaker=Sicaria
-                        message=_"Its accumulated power was lost already, but let's hope that it'll come back."
-                    [/message]
-                    [message]
-                        speaker=Rimaru
-                        message=_"Do you trust me now? Are we friends again?"
-                    [/message]
-                    [message]
-                        speaker=Sicaria
-                        message=_"Yes and yes. It's so nice to be with you again, brother."
-                    [/message]
-                    [message]
-                        speaker=Konrad_II
-                        message=_"She killed my father!"
-                    [/message]
-                    [message]
-                        speaker=Rimaru
-                        message=_"Luke gave her the power to do it and manipulated her to do it. Focus your wrath on Luke."
-                    [/message]
-                    [message]
-                        speaker=Konrad_II
-                        message=_"(breathes heavily) Well. But don't expect me to be nice to her."
-                    [/message]
-                    [message]
-                        speaker=Sicaria
-                        message=_"As long as you don't harm me, it's fine."
-                    [/message]
-                    [unit]
-                        side=2
-                        x,y=2,19
-                        type=Swordsman
-                        id=messenger
-                        generate_name=yes
-                        random_traits=yes
-                    [/unit]
-                    [move_unit]
-                        id=messenger
-                        to_x=33
-                        to_y=31
-                        fire_event=no
-                    [/move_unit]
-                    [message]
-                        speaker=messenger
-                        message=_"Lords, we have bad news for you. We are going to be attacked very soon. These soldiers were coming to reinforce Uver's garrison, but when they realised that Uver gave up, they decided to attack. We've seen them assembling southwest from here, preparing for battle."
-                    [/message]
-                    [message]
-                        speaker=Konrad_II
-                        message=_"The problem is that Uver and his soldiers will turn against us very soon. We need to force Uver to order his soldiers to obey us right now. What shall we do? All our previous attempts failed."
-                    [/message]
-                    [message]
-                        speaker=Uver
-                        message=_"So I will watch your doom."
-                    [/message]
-                    [message]
-                        speaker=Sicaria
-                        message=_"No. There is a trick I have learned during my assassin training. I have a poison. It causes terrible pain that gets stronger and stronger over time. The pain will stop if you take an antidote. I have both the poison and the antidote."
-                    [/message]
-                    [move_unit]
-                        id=Sicaria
-                        to_x=37
-                        to_y=30
-                        fire_event=no
-                    [/move_unit]
-                    [message]
-                        speaker=Uver
-                        message=_"Argh, what was that?"
-                    [/message]
-                    [message]
-                        speaker=Sicaria
-                        message=_"Now, you are poisoned. The discomfort you feel now will be getting stronger and stronger, quickly becoming pain and shortly after, it will become such a terrible pain that you will be just rolling on the ground, screaming. Then, you will do anything to make the pain stop, possibly even kill yourself. If you survive it for a few days, you will become insane. Now, go and tell your soldiers what Konrad wants."
-                    [/message]
-                    [message]
-                        speaker=Konrad_II
-                        message=_"I want you to tell them that you have seen Luke's servants draining souls from humans and reports of Luke doing the same. Tell them that the leaders of the Brothers' order are incredibly corrupt and are not only embezzling all they can, but they are also on the edge of undeath. And most importantly, tell them that you've done great mistakes in letting them manipulate you and you're giving all your property and army to me."
-                    [/message]
-                    [message]
-                        speaker=Uver
-                        message=_"I... I will tell that. This pain is getting unbearable."
-                    [/message]
-                    [move_unit]
-                        id=Uver
-                        to_x=31
-                        to_y=26
-                        fire_event=no
-                    [/move_unit]
-                    [message]
-                        speaker=Uver
-                        message=_"Soldiers! Citizens! Please know that I have made a great mistake. Corruption spreaded by the Queen of Darkness has defiled the leadership of the Brothers of Light. I have seen it myself. A close servant of Luke, the Bringer of Light was stealing souls from her victims, becoming inhumanly strong. I was presented evidence that Luke himself is stealing souls. He wasn't appointed by the gods, he is a foul necromancer."
-                    [/message]
-                    [message]
-                        speaker=Uver
-                        message=_"All of you have seen the child of gods. Will you let a monster like the Bringer of Light drain also his soul? Will you let him become so powerful that he'll enslave us all? Will you let him drain the souls of all of us to become so powerful that he'll fight our beloved gods? No, we must resist! We shall prevent those necromancers from seizing power in this kingdom and free Reezer from these leeches of souls."
-                    [/message]
-                    [message]
-                        speaker=Uver
-                        message=_"I have failed my mission, I have trusted them and brought death to many of your companions. I helped these necromancer reach the power they're holding now, and I find myself unworthy of leading you. Instead, obey lord Konrad, he is much wiser than I am and he isn't so easy to manipulate. He also has the most potent of healers, a man who can make lost limbs grow back."
-                    [/message]
-                    [move_unit]
-                        id=Uver
-                        to_x=38
-                        to_y=33
-                        fire_event=no
-                    [/move_unit]
-                    [message]
-                        speaker=Konrad_II
-                        message=_"You spoke well. You might have even persuaded yourself."
-                    [/message]
-                    [message]
-                        speaker=Uver
-                        message=_"Please... stop the pain. I will do anything for you... Give me the antidote."
-                    [/message]
-                    [message]
-                        speaker=Sicaria
-                        message=_"To be honest, I have no antidote. I don't even have the poison. I never had it, I have only read about it in a book. The poison I really used was <i>nocebo</i>. I scratched you, but I used no poison. I know that you tend to believe things told to you by people who you don't expect to lie, so I decided to tell you that you were poisoned. You believed me. Your faith that you were poisoned was strong and it made you feel the pain. Pain from an imagined poison."
-                    [/message]
-                    [message]
-                        speaker=Uver
-                        message=_"So... I wasn't poisoned? The pain..."
-                    [/message]
-                    [message]
-                        speaker=Sicaria
-                        message=_"No. There was no real poison. You made up that pain. You should learn to doubt what you are told. If Luke told you that Burke is in fact Argan the Lich Lord, you'd believe."
-                    [/message]
-                    [message]
-                        speaker=Konrad_II
-                        message=_"Now, when you so wisely gave your power to me, we have no more need for you. You will stay imprisoned until the end of war, then you'll be free. Now, we must hurry to stop the invasion, will you be my commanders?"
-                    [/message]
-                    [endlevel]
-                        result=victory
-                        bonus=no
-                        next_scenario=06_War_Rages_On
-                        {NEW_GOLD_CARRYOVER 100}
-                    [/endlevel]
-
+                            name= _"Sicaria"
+                            canrecruit=yes
+                            [modifications]
+                                [advance]
+                                    id=portrait
+                                    [effect]
+                                        apply_to=profile
+                                        portrait="portraits/humans/transparent/assassin+female.png"
+                                    [/effect]
+                                [/advance]
+                                [advance]
+                                    id=legacy_of_sorrow
+                                [/advance]
+                                [advance]
+                                    id=awareness
+                                [/advance]
+                            [/modifications]
+                            animate=yes
+                        [/unit]
+                        {CLEAR_VARIABLE manhunter_store}
+                        [message]
+                            speaker=Rimaru
+                            message=_"I know that it sounds crazy, but aren't you my dead sister Sicaria?"
+                        [/message]
+                        [message]
+                            speaker=Sicaria
+                            message=_"I hate to tell that, but you've guessed that right, monster."
+                        [/message]
+                        [message]
+                            speaker=Konrad_II
+                            message=_"Kill her!"
+                        [/message]
+                        [message]
+                            speaker=Rimaru
+                            message=_"Did somebody raise you from the dead as some sort of enslaved vengeful spirit?"
+                        [/message]
+                        [message]
+                            speaker=Sicaria
+                            message=_"I am alive. And angry."
+                        [/message]
+                        [message]
+                            speaker=she_brother
+                            message=_"Oh, sorry, I didn't know that you were angry."
+                        [/message]
+                        [message]
+                            speaker=Rimaru
+                            message=_"Why do you hate me so much?"
+                        [/message]
+                        [message]
+                            speaker=Sicaria
+                            message=_"That's none of your concern, traitor."
+                        [/message]
+                        [message]
+                            speaker=Rimaru
+                            message=_"I did my best to save your life. I used all spells I could think of, I experimented, tried various healing methods I could brainstorm. I tried to persuade elder healers to help you, I even conspired to force them to save you, but nothing helped. I know that I failed, but you're alive anyway. You hate me like if I was the one who caused that disease, not like somebody who failed. Elder healers could heal worse things, but they refused. They are the ones you should hate."
+                        [/message]
+                        [message]
+                            speaker=Sicaria
+                            message=_"Am I supposed to believe that? I know the truth behind that. You decided that your healing skills need a demonstration, so you infected me with a combination of rare diseases. When your healing attempts failed, you dumped me to the morgue and left me for dead. Fortunately, Luke found me half-dead and saved me."
+                        [/message]
+                        [message]
+                            speaker=she_brother
+                            message=_"What...? I can assure you that Rimaru doesn't behave that way."
+                        [/message]
+                        [message]
+                            speaker=Burke
+                            message=_"We have been comrades with Rimaru for some time and I am sure that he doesn't seem to be overly proud of his healing skills. He is also relatively good at fighting, I must say... I think that the thing he's proud of is his honesty, so he enjoys telling any ugly thing he thinks."
+                        [/message]
+                        [message]
+                            speaker=Uver
+                            message=_"You see? If someone is strong in faith, your silly lies will not work."
+                        [/message]
+                        [message]
+                            speaker=Sicaria
+                            message=_"I am not stupid like you, Uver. To be honest, I would be happy if I could believe my brother. We were so close to each other until he did the crazy thing. If he had some sort of proof..."
+                        [/message]
+                        [message]
+                            speaker=Uver
+                            message=_"Faith is about faith, not about proof."
+                        [/message]
+                        [message]
+                            speaker=Rimaru
+                            message=_"Well, tell me what was Luke doing in the morgue where he found you? He was spending all the days and many nights at the library and left it only to visit a canteen or a toilet. What made him visit the morgue so suddenly?"
+                        [/message]
+                        [message]
+                            speaker=Sicaria
+                            message=_"I never questioned it, because that coincidence saved my life. Weren't you studying healing in the library when you were <i>saving</i> me?"
+                        [/message]
+                        [message]
+                            speaker=Rimaru
+                            message=_"I came there to check for some information, but I was mostly working with the books I had with me. But I can't prove that, right? The fact is that Luke never talked to anyone in the library back then, only if he needed something important. He asked me a few times to free his favourite spot for studying or to ask me to ask for a few candles. You remember him. Do you really think he would be observing what's going on outside the library?"
+                        [/message]
+                        [message]
+                            speaker=Sicaria
+                            message=_"No. But what was he doing in the morgue? He would not go check some dying people if they don't happen to be still alive and try to save them. He was addicted to some sort of research he was conducting all the time, so I suppose that he wanted to do some experiments. He wasn't dissecting the bodies and studying their internals, because when he healed me, I looked around and I would have noticed dissected bodies."
+                        [/message]
+                        [message]
+                            speaker=Sicaria
+                            message=_"We was doing some experiments, that's certain. Some... necromancy? Maybe. He found me, realised that I wasn't dead yet and healed me."
+                        [/message]
+                        [message]
+                            speaker=Rimaru
+                            message=_"I thought you were dead when I brought you there. I could not hear you breathing, I could not sense your heart beating, your feverish body was cooling down slowly. You had to be very close to death when you came there."
+                        [/message]
+                        [message]
+                            speaker=Sicaria
+                            message=_"I can't remember that, I wasn't conscious. The things I remember was that you were struggling and screaming at me to wake up and then I felt Luke's healing powers coming through me, healing me. After a minute or two, I was healthy. He told me what happened, or if your words are true, his version of it."
+                        [/message]
+                        [message]
+                            speaker=Rimaru
+                            message=_"Where have you gone then? I stayed with the order for about a year until my anger grew too strong. The building reminded me of you all the time and I was forced to think about your fate all the time. Then I left them."
+                        [/message]
+                        [message]
+                            speaker=Sicaria
+                            message=_"After a year? Luke told me that you fled before it was decided that you should be beheaded for your choice. I wanted to seek you and kill you for your horrible deed, but he told me that even if you're a healer, you can still use harmful magic and your skill with staff isn't bad. He told me that you will kill me if you learn about me in order to destroy all evidence. So I joined a guild of assassins, so that I could have my revenge later."
+                        [/message]
+                        [message]
+                            speaker=Rimaru
+                            message=_"I suppose that he was performing some experiments on the bodies, maybe stealing souls. Stealing souls would explain why he is so powerful now. When he found that your body was still warm, he healed you. You surely know that healers can't heal so fast, so he probably used some of the power he had from draining souls."
+                        [/message]
+                        [message]
+                            speaker=Sicaria
+                            message=_"Really... Luke has never been revered as a healer, yet he healed me incredibly fast there, as if he wielded some unusual powers. Are you sure that stealing souls can empower somebody so much?"
+                        [/message]
+                        [message]
+                            speaker=Rimaru
+                            message=_"I don't know that for sure, but stories tell that. Some of them are even contained in the tales told by the Brothers. If Luke learned that ancient technique of darkness, it would explain not only how he healed you so fast, but also why he is so powerful now. Also, by healing you, he made himself a very loyal ally, one that is very good for advancing schemes. He knew back then what a powerful beast he would become."
+                        [/message]
+                        [message]
+                            speaker=Sicaria
+                            message=_"Recently, he told me that he was blessed by gods to help him protect the Child. I doubted that, but his power was superior beyond doubt. I did not think of the possibility that some dark abilities granted him that power. When you told it, I was sure that you were just lying."
+                        [/message]
+                        [message]
+                            speaker=Rimaru
+                            message=_"You were also strangely powerful. How?"
+                        [/message]
+                        [message]
+                            speaker=Sicaria
+                            message=_"When I finished my assassin training, he gave me a ring. It was masterfully crafted, beautiful and I could sense some weird magic in it. He told me that if I kill an unrighteous person with the ring on, it will reward me with power. I killed a few criminals and I was suddenly super strong, I could sneak so well that people could look at me and fail to notice me and I could control weather to some extent. The powers faded in a few days, but bits of it remain."
+                        [/message]
+                        [message]
+                            speaker=Sicaria
+                            message=_"However, the temporary powers vanish almost instantly if I take it away. So I had it on almost all the time. When this war started, I killed people every day and I grew very powerful. I started to doubt that all of them were unrighteous, I was starting to feel that every single man is evil, but I understand it now. It was allowing me to drain souls. If you could please return it to me..."
+                        [/message]
+                        [message]
+                            speaker=Rimaru
+                            message=_"Yes."
+                        [/message]
+                        [store_unit]
+                            [filter]
+                                id=Sicaria
+                            [/filter]
+                            variable=sicaria_store
+                            kill=yes
+                        [/store_unit]
+                        [set_variables]
+                            name=sicaria_store.modifications.advance[$sicaria_store.modifications.advance]
+                            mode=replace
+                            [value]
+                                id=sicarias_ring
+                                [effect]
+                                    apply_to=defense
+                                    replace=false
+                                    [defense]
+                                        frozen=-5
+                                        shallow_water=-5
+                                        reef=-5
+                                        flat=-5
+                                        castle=-5
+                                        village=-5
+                                        forest=-5
+                                        cave=-5
+                                        hills=-5
+                                        mountains=-5
+                                        fungus=-5
+                                        swamp_water=-5
+                                        sand=-5
+                                    [/defense]
+                                [/effect]
+                                [effect]
+                                    apply_to=image_mod
+                                    add="~O(80%)"
+                                [/effect]
+                                [effect]
+                                    apply_to=new_ability
+                                    [abilities]
+                                        [dummy]
+                                            id=murderlust
+                                        [/dummy]
+                                    [/abilities]
+                                [/effect]
+                            [/value]
+                        [/set_variables]
+                        [unit]
+                            side=1
+                            x,y=$sicaria_store.x,$sicaria_store.y
+                            type=Exterminator
+                            gender=female
+                            id=Sicaria
+                            name= _"Sicaria"
+                            canrecruit=yes
+                            [variables]
+                                hero=yes
+                            [/variables]
+                            [insert_tag]
+                                name=advance
+                                variable=sicaria_store.modifications
+                            [/insert_tag]
+                            animate=no
+                        [/unit]
+                        {CLEAR_VARIABLE sicaria_store}
+                        {VARIABLE party_members[$party_members.length].id Sicaria}
+                        [message]
+                            speaker=Sicaria
+                            message=_"Its accumulated power was lost already, but let's hope that it'll come back."
+                        [/message]
+                        [message]
+                            speaker=Rimaru
+                            message=_"Do you trust me now? Are we friends again?"
+                        [/message]
+                        [message]
+                            speaker=Sicaria
+                            message=_"Yes and yes. It's so nice to be with you again, brother."
+                        [/message]
+                        [message]
+                            speaker=Konrad_II
+                            message=_"She killed my father!"
+                        [/message]
+                        [message]
+                            speaker=Rimaru
+                            message=_"Luke gave her the power to do it and manipulated her to do it. Focus your wrath on Luke."
+                        [/message]
+                        [message]
+                            speaker=Konrad_II
+                            message=_"(breathes heavily) Well. But don't expect me to be nice to her."
+                        [/message]
+                        [message]
+                            speaker=Sicaria
+                            message=_"As long as you don't harm me, it's fine."
+                        [/message]
+                        [unit]
+                            side=2
+                            x,y=2,19
+                            type=Swordsman
+                            id=messenger
+                            generate_name=yes
+                            random_traits=yes
+                        [/unit]
+                        [move_unit]
+                            id=messenger
+                            to_x=33
+                            to_y=31
+                            fire_event=no
+                        [/move_unit]
+                        [message]
+                            speaker=messenger
+                            message=_"Lords, we have bad news for you. We are going to be attacked very soon. These soldiers were coming to reinforce Uver's garrison, but when they realised that Uver gave up, they decided to attack. We've seen them assembling southwest from here, preparing for battle."
+                        [/message]
+                        [message]
+                            speaker=Konrad_II
+                            message=_"The problem is that Uver and his soldiers will turn against us very soon. We need to force Uver to order his soldiers to obey us right now. What shall we do? All our previous attempts failed."
+                        [/message]
+                        [message]
+                            speaker=Uver
+                            message=_"So I will watch your doom."
+                        [/message]
+                        [message]
+                            speaker=Sicaria
+                            message=_"No. There is a trick I have learned during my assassin training. I have a poison. It causes terrible pain that gets stronger and stronger over time. The pain will stop if you take an antidote. I have both the poison and the antidote."
+                        [/message]
+                        [move_unit]
+                            id=Sicaria
+                            to_x=37
+                            to_y=30
+                            fire_event=no
+                        [/move_unit]
+                        [message]
+                            speaker=Uver
+                            message=_"Argh, what was that?"
+                        [/message]
+                        [message]
+                            speaker=Sicaria
+                            message=_"Now, you are poisoned. The discomfort you feel now will be getting stronger and stronger, quickly becoming pain and shortly after, it will become such a terrible pain that you will be just rolling on the ground, screaming. Then, you will do anything to make the pain stop, possibly even kill yourself. If you survive it for a few days, you will become insane. Now, go and tell your soldiers what Konrad wants."
+                        [/message]
+                        [message]
+                            speaker=Konrad_II
+                            message=_"I want you to tell them that you have seen Luke's servants draining souls from humans and reports of Luke doing the same. Tell them that the leaders of the Brothers' order are incredibly corrupt and are not only embezzling all they can, but they are also on the edge of undeath. And most importantly, tell them that you've done great mistakes in letting them manipulate you and you're giving all your property and army to me."
+                        [/message]
+                        [message]
+                            speaker=Uver
+                            message=_"I... I will tell that. This pain is getting unbearable."
+                        [/message]
+                        [move_unit]
+                            id=Uver
+                            to_x=31
+                            to_y=26
+                            fire_event=no
+                        [/move_unit]
+                        [message]
+                            speaker=Uver
+                            message=_"Soldiers! Citizens! Please know that I have made a great mistake. Corruption spreaded by the Queen of Darkness has defiled the leadership of the Brothers of Light. I have seen it myself. A close servant of Luke, the Bringer of Light was stealing souls from her victims, becoming inhumanly strong. I was presented evidence that Luke himself is stealing souls. He wasn't appointed by the gods, he is a foul necromancer."
+                        [/message]
+                        [message]
+                            speaker=Uver
+                            message=_"All of you have seen the child of gods. Will you let a monster like the Bringer of Light drain also his soul? Will you let him become so powerful that he'll enslave us all? Will you let him drain the souls of all of us to become so powerful that he'll fight our beloved gods? No, we must resist! We shall prevent those necromancers from seizing power in this kingdom and free Reezer from these leeches of souls."
+                        [/message]
+                        [message]
+                            speaker=Uver
+                            message=_"I have failed my mission, I have trusted them and brought death to many of your companions. I helped these necromancer reach the power they're holding now, and I find myself unworthy of leading you. Instead, obey lord Konrad, he is much wiser than I am and he isn't so easy to manipulate. He also has the most potent of healers, a man who can make lost limbs grow back."
+                        [/message]
+                        [move_unit]
+                            id=Uver
+                            to_x=38
+                            to_y=33
+                            fire_event=no
+                        [/move_unit]
+                        [message]
+                            speaker=Konrad_II
+                            message=_"You spoke well. You might have even persuaded yourself."
+                        [/message]
+                        [message]
+                            speaker=Uver
+                            message=_"Please... stop the pain. I will do anything for you... Give me the antidote."
+                        [/message]
+                        [message]
+                            speaker=Sicaria
+                            message=_"To be honest, I have no antidote. I don't even have the poison. I never had it, I have only read about it in a book. The poison I really used was <i>nocebo</i>. I scratched you, but I used no poison. I know that you tend to believe things told to you by people who you don't expect to lie, so I decided to tell you that you were poisoned. You believed me. Your faith that you were poisoned was strong and it made you feel the pain. Pain from an imagined poison."
+                        [/message]
+                        [message]
+                            speaker=Uver
+                            message=_"So... I wasn't poisoned? The pain..."
+                        [/message]
+                        [message]
+                            speaker=Sicaria
+                            message=_"No. There was no real poison. You made up that pain. You should learn to doubt what you are told. If Luke told you that Burke is in fact Argan the Lich Lord, you'd believe."
+                        [/message]
+                        [message]
+                            speaker=Konrad_II
+                            message=_"Now, when you so wisely gave your power to me, we have no more need for you. You will stay imprisoned until the end of war, then you'll be free. Now, we must hurry to stop the invasion, will you be my commanders?"
+                        [/message]
+                        [endlevel]
+                            result=victory
+                            bonus=no
+                            next_scenario=06_War_Rages_On
+                            {NEW_GOLD_CARRYOVER 100}
+                        [/endlevel]
+                    [/event]
                 [/event]
-
-            [/event]
-        [/else]
-        [then]
-            [if]
-                [variable]
-                    name=previous_scenario
-                    equals=war_rages_on
-                [/variable]
-                [then]
-                    [remove_shroud]
-                        x,y=36,29
-                        radius=5
-                        side=1
-                    [/remove_shroud]
-                    [scroll_to_unit]
-                        id=player
-                    [/scroll_to_unit]
-                    [message]
-                        speaker=Burke
-                        message=_"Reporting that we have led your army into victorious conquest of the southern valleys."
-                    [/message]
-                    [message]
-                        speaker=Konrad_II
-                        message=_"I am glad to see you back. Is my army holding it?"
-                    [/message]
-                    [message]
-                        speaker=Burke
-                        message=_"Indeed. It's well fortified and full of soldiers. Conquering it looks impossible without immense losses. It's not even feasible to lay siege on them, because they have supplies available from this side. If the Brothers send some soldiers at us, it will be most likely through southern Grey Hills."
-                    [/message]
-                    [message]
-                        speaker=Konrad_II
-                        message=_"My soldiers are keeping that place. It may happen that a smaller group of enemies will penetrate, but no larger group will come unseen. Now, regarding our new objectives. Luke has swallowed the bait and he entered the Hidden Valley. However, there is a little problem."
-                    [/message]
-                    [message]
-                        speaker=Sicaria
-                        message=_"What problem?"
-                    [/message]
-                    [message]
-                        speaker=Konrad_II
-                        message=_"I am not talking to you, assassin."
-                    [/message]
-                    [message]
-                        speaker=Rimaru
-                        message=_"Talk to her normally. What's the little problem?"
-                    [/message]
-                    [message]
-                        speaker=Konrad_II
-                        message=_"We don't know where is the Hidden Valley. I've been searching through maps and asking some scholars, but unsuccessfully. It's hidden, as its name suggests."
-                    [/message]
-                    [message]
-                        speaker=Rimaru
-                        message=_"Just tell us all you know."
-                    [/message]
-                    [while]
-                        [not]
-                            [variable]
-                                name=done
-                                equals=yes
-                            [/variable]
-                        [/not]
-                        [do]
-                            [message]
-                                speaker=Konrad_II
-                                message=_"Ask."
-                                [option]
-                                message=_"Were you able to find any information where its entrance might approximately be?"
-                                [command]
-                                    [message]
-                                        speaker=Uver
-                                        message=_"You will never learn, heh heh."
-                                    [/message]
-                                    [message]
-                                        speaker=Konrad_II
-                                        message=_"There is a place where two rivers meet. One valley joins the main gorge there. The entrance was supposed to be somewhere there, probably north."
-                                    [/message]
-                                [/command]
-                                [/option]
-                                [option]
-                                message=_"Do you know how the way there looks?"
-                                [command]
-                                    [message]
-                                        speaker=Konrad_II
-                                        message=_"It should be a cavern. You pass through the cave under the mountains into the valley."
-                                    [/message]
-                                    [message]
-                                        speaker=elf_merc
-                                        message=_"I don't like caves... Can't it be a forest?"
-                                    [/message]
-                                [/command]
-                                [/option]
-                                [option]
-                                message=_"Are you sure it even exists?"
-                                [command]
-                                    [message]
-                                        speaker=faithful_lieutenant
-                                        message=_"It must exist, people would not talk about places that don't exist."
-                                    [/message]
-                                    [message]
-                                        speaker=Konrad_II
-                                        message=_"There is a map of the valley. It looks quite specific. There are some records about trading with its inhabitants, and they aren't too old, just a couple of years. But no sign of them afterwards."
-                                    [/message]
-                                    [message]
-                                        speaker=Rimaru
-                                        message=_"I'd assume that it exists."
-                                    [/message]
-                                [/command]
-                                [/option]
-                                [option]
-                                message=_"What if it isn't a real place, but a location made up for the purpose of concealing something?"
-                                [command]
-                                    [message]
-                                        speaker=Rimaru
-                                        message=_"What do you mean?"
-                                    [/message]
-                                    [message]
-                                        speaker=player
-                                        message=_"Suppose there was a group of thieves. They need to sell the stolen goods. They might add a lot of credibility to their business if they tell that they were trading with a mythical Hidden Valley. It would be very useful for them to make up the myth."
-                                    [/message]
-                                    [message]
-                                        speaker=bandit_merc
-                                        message=_"Yes, we thieves like giving uncommon names to places to make sure that eavesdroppers will not understand our plans."
-                                    [/message]
-                                    [message]
-                                        speaker=Konrad_II
-                                        message=_"That is possible. You can profit from trading with a mythical location. And our best evidence of its existence comes from business records, which..."
-                                    [/message]
-                                    [message]
-                                        speaker=Rimaru
-                                        message=_"Uver, how much problems with thefts did you have in the past?"
-                                    [/message]
-                                    [message]
-                                        speaker=Uver
-                                        message=_"This land had little problems with thieves."
-                                    [/message]
-                                    [message]
-                                        speaker=Sicaria
-                                        message=_"How, you asked for taxes from stealing and thieves preferred paying taxes than risk punishment?"
-                                    [/message]
-                                    [message]
-                                        speaker=Rimaru
-                                        message=_"Hm, I must accept that there is a chance that the Valley is not a real place... But in that case, Luke would be somewhere near its supposed entrance. We might find him in that case. When did the deals with them stop?"
-                                    [/message]
-                                    [message]
-                                        speaker=Konrad_II
-                                        message=_"About the time when the Child became known and the war begun."
-                                    [/message]
-                                    [message]
-                                        speaker=Rimaru
-                                        message=_"Whoever was behind it, he must be afraid of the order. Maybe just some peasants with a rational leader."
-                                    [/message]
-                                [/command]
-                                [/option]
-                                [option]
-                                message=_"I think I know enough."
-                                [command]
-                                    {VARIABLE done yes}
-                                [/command]
-                                [/option]
-                            [/message]
-                        [/do]
-                    [/while]
-                    {CLEAR_VARIABLE done}
-                    [message]
-                        speaker=Burke
-                        message=_"Okay, thank you for the information, we'll look for it."
-                    [/message]
-                    [move_unit]
-                        id=Konrad_II
-                        to_x=1
-                        to_y=20
-                        fire_event=no
-                    [/move_unit]
-                    [kill]
-                        id=Konrad_II
-                        fire_event=no
-                        animate=no
-                    [/kill]
-                [/then]
-            [/if]
-        [/then]
-    [/if]
-
+            [/else]
+            [then]
+                [if]
+                    [variable]
+                        name=previous_scenario
+                        equals=war_rages_on
+                    [/variable]
+                    [then]
+                        [remove_shroud]
+                            x,y=36,29
+                            radius=5
+                            side=1
+                        [/remove_shroud]
+                        [scroll_to_unit]
+                            id=player
+                        [/scroll_to_unit]
+                        [message]
+                            speaker=Burke
+                            message=_"Reporting that we have led your army into victorious conquest of the southern valleys."
+                        [/message]
+                        [message]
+                            speaker=Konrad_II
+                            message=_"I am glad to see you back. Is my army holding it?"
+                        [/message]
+                        [message]
+                            speaker=Burke
+                            message=_"Indeed. It's well fortified and full of soldiers. Conquering it looks impossible without immense losses. It's not even feasible to lay siege on them, because they have supplies available from this side. If the Brothers send some soldiers at us, it will be most likely through southern Grey Hills."
+                        [/message]
+                        [message]
+                            speaker=Konrad_II
+                            message=_"My soldiers are keeping that place. It may happen that a smaller group of enemies will penetrate, but no larger group will come unseen. Now, regarding our new objectives. Luke has swallowed the bait and he entered the Hidden Valley. However, there is a little problem."
+                        [/message]
+                        [message]
+                            speaker=Sicaria
+                            message=_"What problem?"
+                        [/message]
+                        [message]
+                            speaker=Konrad_II
+                            message=_"I am not talking to you, assassin."
+                        [/message]
+                        [message]
+                            speaker=Rimaru
+                            message=_"Talk to her normally. What's the little problem?"
+                        [/message]
+                        [message]
+                            speaker=Konrad_II
+                            message=_"We don't know where is the Hidden Valley. I've been searching through maps and asking some scholars, but unsuccessfully. It's hidden, as its name suggests."
+                        [/message]
+                        [message]
+                            speaker=Rimaru
+                            message=_"Just tell us all you know."
+                        [/message]
+                        [while]
+                            [not]
+                                [variable]
+                                    name=done
+                                    equals=yes
+                                [/variable]
+                            [/not]
+                            [do]
+                                [message]
+                                    speaker=Konrad_II
+                                    message=_"Ask."
+                                    [option]
+                                        message=_"Were you able to find any information where its entrance might approximately be?"
+                                        [command]
+                                            [message]
+                                                speaker=Uver
+                                                message=_"You will never learn, heh heh."
+                                            [/message]
+                                            [message]
+                                                speaker=Konrad_II
+                                                message=_"There is a place where two rivers meet. One valley joins the main gorge there. The entrance was supposed to be somewhere there, probably north."
+                                            [/message]
+                                        [/command]
+                                    [/option]
+                                    [option]
+                                        message=_"Do you know how the way there looks?"
+                                        [command]
+                                            [message]
+                                                speaker=Konrad_II
+                                                message=_"It should be a cavern. You pass through the cave under the mountains into the valley."
+                                            [/message]
+                                            [message]
+                                                speaker=elf_merc
+                                                message=_"I don't like caves... Can't it be a forest?"
+                                            [/message]
+                                        [/command]
+                                    [/option]
+                                    [option]
+                                        message=_"Are you sure it even exists?"
+                                        [command]
+                                            [message]
+                                                speaker=faithful_lieutenant
+                                                message=_"It must exist, people would not talk about places that don't exist."
+                                            [/message]
+                                            [message]
+                                                speaker=Konrad_II
+                                                message=_"There is a map of the valley. It looks quite specific. There are some records about trading with its inhabitants, and they aren't too old, just a couple of years. But no sign of them afterwards."
+                                            [/message]
+                                            [message]
+                                                speaker=Rimaru
+                                                message=_"I'd assume that it exists."
+                                            [/message]
+                                        [/command]
+                                    [/option]
+                                    [option]
+                                        message=_"What if it isn't a real place, but a location made up for the purpose of concealing something?"
+                                        [command]
+                                            [message]
+                                                speaker=Rimaru
+                                                message=_"What do you mean?"
+                                            [/message]
+                                            [message]
+                                                speaker=player
+                                                message=_"Suppose there was a group of thieves. They need to sell the stolen goods. They might add a lot of credibility to their business if they tell that they were trading with a mythical Hidden Valley. It would be very useful for them to make up the myth."
+                                            [/message]
+                                            [message]
+                                                speaker=bandit_merc
+                                                message=_"Yes, we thieves like giving uncommon names to places to make sure that eavesdroppers will not understand our plans."
+                                            [/message]
+                                            [message]
+                                                speaker=Konrad_II
+                                                message=_"That is possible. You can profit from trading with a mythical location. And our best evidence of its existence comes from business records, which..."
+                                            [/message]
+                                            [message]
+                                                speaker=Rimaru
+                                                message=_"Uver, how much problems with thefts did you have in the past?"
+                                            [/message]
+                                            [message]
+                                                speaker=Uver
+                                                message=_"This land had little problems with thieves."
+                                            [/message]
+                                            [message]
+                                                speaker=Sicaria
+                                                message=_"How, you asked for taxes from stealing and thieves preferred paying taxes than risk punishment?"
+                                            [/message]
+                                            [message]
+                                                speaker=Rimaru
+                                                message=_"Hm, I must accept that there is a chance that the Valley is not a real place... But in that case, Luke would be somewhere near its supposed entrance. We might find him in that case. When did the deals with them stop?"
+                                            [/message]
+                                            [message]
+                                                speaker=Konrad_II
+                                                message=_"About the time when the Child became known and the war begun."
+                                            [/message]
+                                            [message]
+                                                speaker=Rimaru
+                                                message=_"Whoever was behind it, he must be afraid of the order. Maybe just some peasants with a rational leader."
+                                            [/message]
+                                        [/command]
+                                    [/option]
+                                    [option]
+                                        message=_"I think I know enough."
+                                        [command]
+                                            {VARIABLE done yes}
+                                        [/command]
+                                    [/option]
+                                [/message]
+                            [/do]
+                        [/while]
+                        {CLEAR_VARIABLE done}
+                        [message]
+                            speaker=Burke
+                            message=_"Okay, thank you for the information, we'll look for it."
+                        [/message]
+                        [move_unit]
+                            id=Konrad_II
+                            to_x=1
+                            to_y=20
+                            fire_event=no
+                        [/move_unit]
+                        [kill]
+                            id=Konrad_II
+                            fire_event=no
+                            animate=no
+                        [/kill]
+                    [/then]
+                [/if]
+            [/then]
+        [/if]
     [/event]
 
-
     [event]
-    id=forbid_progress
-    name=moveto
-    [filter]
-        side=1
-        x,y=1-2,1-25
-    [/filter]
-    [message]
-        speaker=Rimaru
-        message=_"Not that way. We'll only find more enemies there and I think that we have enough enemies here."
-    [/message]
+        id=forbid_progress
+        name=moveto
+        [filter]
+            side=1
+            x,y=1-2,1-25
+        [/filter]
+        [message]
+            speaker=Rimaru
+            message=_"Not that way. We'll only find more enemies there and I think that we have enough enemies here."
+        [/message]
     [/event]
 
     {TBC_GLOBAL_EVENTS_RPG}

--- a/spinoffs/The_Beautiful_Child/scenarios/Farborough.cfg
+++ b/spinoffs/The_Beautiful_Child/scenarios/Farborough.cfg
@@ -46,501 +46,61 @@
     {TBC_PLACE_WAYPOINT 33 22}
 
     [event]
-    name=prestart
-    {VARIABLE current_scenario farborough}
-    {TBC_ORIGIN intro 36 28}
-    {TBC_ORIGIN crooked_ravine 21 3}
-    {TBC_TRANSITION 0-45 0-2 Crooked_Ravine _"Crooked Ravine" 21 2}
-    {PLACE_IMAGE scenery/castle-ruins.png 33 16}
+        name=prestart
+        {VARIABLE current_scenario farborough}
+        {TBC_ORIGIN intro 36 28}
+        {TBC_ORIGIN crooked_ravine 21 3}
+        {TBC_TRANSITION 0-45 0-2 Crooked_Ravine _"Crooked Ravine" 21 2}
+        {PLACE_IMAGE scenery/castle-ruins.png 33 16}
     [/event]
 
     [event]
-    name=start
-    {GUARDIAN_UNIT 2 "Peasant" 38 25}
-    {GUARDIAN_UNIT 2 "Peasant" 33 30}
-    {GUARDIAN_UNIT 2 "Woodsman" 38 41}
-    {GUARDIAN_UNIT 2 "Peasant" 34 24}
-    {GUARDIAN_UNIT 2 "Peasant" 37 30}
-    {GUARDIAN_UNIT 2 "Peasant" 31 28}
-    [+unit]
-        id=peasant_speaker
-    [/unit]
-    [if]
-        [variable]
-            name=quests.post_intro_fight_victory
-            equals=yes
-        [/variable]
-        [else]
-            {GENERIC_UNIT 3 "Spearman" 34 26}
-            {GENERIC_UNIT 3 "Bowman" 41 28}
-            {GENERIC_UNIT 3 "Bowman" 41 28}
-            [unit]
-                side=3
-                type=White Mage
-                id=brother
-                generate_name=yes
-                x,y=39,31
-                random_traits=yes
-                gender=male
-                upkeep=full
-            [/unit]
-            [if]
-                [have_unit]
-                    id=elf_merc
-                [/have_unit]
-                [then]
-                    {GENERIC_UNIT 3 "Fencer" 36 24}
-                [/then]
-            [/if]
-#ifdef HARD
-            {GENERIC_UNIT 3 "Cavalryman" 32 30}
-#endif
-            [unit]
-                side=3
-                type=Lieutenant
-                id=faithful_lieutenant
-                generate_name=yes
-                x,y=39,29
-                random_traits=yes
-                upkeep=full
-                [modifications]
-                    [advance]
-                        id=portrait
-                        [effect]
-                            apply_to=profile
-                            portrait="portraits/humans/transparent/lieutenant.png"
-                        [/effect]
-                    [/advance]
-                [/modifications]
-            [/unit]
-        [/else]
-    [/if]
-    [if]
-        [variable]
-            name=quests.post_intro_fight
-            equals=yes
-        [/variable]
-        [else]
-            [message]
-                speaker=brother
-                message=_"...and because of that, we need more than a tenth of your income, a nineth of your income."
-            [/message]
-            [message]
-                speaker=peasant_speaker
-                message=_"That is a trick, a nineth is not less than a tenth!"
-            [/message]
-            [message]
-                speaker=brother
-                message=_"I was never telling that. We need more, that is what I said. We will use the money to bring a better future!"
-            [/message]
-            [message]
-                speaker=peasant_speaker
-                message=_"Will the future be really so bright? Nothing changed since the time of my grandfathers."
-            [/message]
-            [message]
-                speaker=Rimaru
-                message=_"It will not. They only need more and more money, they are greedy and they love luxury. Remember what happened a decade ago. They reported that they were fighting a dark cult trying to unleash darkness upon us and needed to fund an army, so they increased the tithes. There is no such cult anymore. And I have seen no credible evidence that it ever existed. Yet, they did not decrease the tithes when the fights were over."
-            [/message]
-            [message]
-                speaker=peasant_speaker
-                message=_"You're right..."
-            [/message]
-            [message]
-                speaker=Rimaru
-                message=_"The older of you will also remember how they fought the plot of necromancers to force the king to allow them to use our graveyards. They increased the tithes to fund their campaign, however, they never reduced it back. What are you paying for? From the tenth of your income, you're already paying their war against a dark cult and a campaign against a necromancers' plot, yet neither of these is active. They're just keeping the money for themselves!"
-            [/message]
-            [message]
-                speaker=peasant_speaker
-                message=_"My father told me about that. We waited until the horribly great tithes decrease, until we got used to that and forgot that they should have been decreased. If you need money, use those we are already paying for your other campaigns that are no longer active."
-            [/message]
-            [message]
-                speaker=brother
-                message=_"This rebellion, it is all your fault. I was told to arrest you anyway, so..."
-            [/message]
-            [message]
-                speaker=faithful_lieutenant
-                message=_"Good man, can you please come with us?"
-            [/message]
-            [message]
-                speaker=Rimaru
-                message=_"Why should I? I see a group of armed men. How do I know that you don't bear ill intentions?"
-            [/message]
-            [message]
-                speaker=faithful_lieutenant
-                message=_"Don't worry, I have this piece of paper proving that we are loyal servants of the Brothers of Light. I was told that you can read."
-            [/message]
-            [message]
-                speaker=Rimaru
-                message=_"How can you be so sure that the Brothers of Light don't bear ill intentions themselves?"
-            [/message]
-            [message]
-                speaker=faithful_lieutenant
-                message=_"They can't be evil, they are the Brothers of Light. And you seem to be their enemy."
-                [option]
-                message=_"Their order is corrupt. Their path has gone far too long from helping those who need it to hoarding gold. And this time, they seem be starting a new scheme to earn even more gold. We are only trying to save the peasants from having to pay even greater tithes."
-                [command]
-                    {SCENARIO_DURATION_VARIABLE explained_problem yes}
-                    [message]
-                        speaker=faithful_lieutenant
-                        message=_"I've seen their pride, how they put themselves above anything. But I will not believe that their goals are selfish."
-                    [/message]
-                    [message]
-                        speaker=brother
-                        message=_"You shall speak such words no more."
-                    [/message]
-                    {VARIABLE quests.diplomacy_attempts 1}
-                [/command]
-                [/option]
-                [option]
-                message=_"You don't have to obey them. They are only misusing you, you're nothing to them but an animal that does the dirty job of fighting their enemies."
-                [command]
-                    {SCENARIO_DURATION_VARIABLE explained_problem yes}
-                    [message]
-                        speaker=faithful_lieutenant
-                        message=_"I don't like it, but it is my duty to protect the kingdom and its servants."
-                    [/message]
-                    [message]
-                        speaker=brother
-                        message=_"If you'll speak like that again, we will skin you alive!"
-                    [/message]
-                    {VARIABLE quests.diplomacy_attempts 1}
-                [/command]
-                [/option]
-                [option]
-                message=_"You've chosen to be my enemy. I am not merciful to my enemies. Remember that it was you who chose this path. This is your last occasion to regret your words."
-                [command]
-                    [message]
-                        speaker=faithful_lieutenant
-                        message=_"I will never come to need your mercy. You will need my mercy very soon, and I don't think that I'll be merciful to the merciless."
-                    [/message]
-                    [message]
-                        speaker=brother
-                        message=_"No mercy on these blasphemers!"
-                    [/message]
-                    {VARIABLE quests.diplomacy_attempts 0}
-                [/command]
-                [/option]
-                [option]
-                message=_"I know that you want to fight, jackass! Come on and die like an animal. I will hack you to pieces and feed them to my neighbour's hounds!"
-                [command]
-                    [message]
-                        speaker=faithful_lieutenant
-                        message=_"Die, scoundrel!"
-                    [/message]
-                    [message]
-                        speaker=brother
-                        message=_"Well said, Lieutenant!"
-                    [/message]
-                    {VARIABLE quests.diplomacy_attempts 0}
-                [/command]
-                [/option]
-            [/message]
-            [message]
-                speaker=Rimaru
-                message=_"I doubt there was ever a chance to persuade these guys..."
-            [/message]
-            {VARIABLE quests.post_intro_fight yes}
-            {VARIABLE quests.overall 1}
-        [/else]
-    [/if]
-    
-    [if]
-        [variable]
-            name=quests.farborough_southwest_ambush
-            equals=yes
-        [/variable]
-        [else]
-            [event]
-                name=moveto
-                [filter]
-                    x,y=2-6,22-25
-                    side=1
-                [/filter]
-                [message]
-                    speaker=unit
-                    message=_"This place looks like a very good spot for an ambush."
-                [/message]
-                {TBC_SPAWN_UNITS 3 0.7 "Spearman,Heavy Infantryman,Sergeant,Bowman" 8 21 Cavalryman boss_1}
-                [message]
-                    speaker=boss_1
-                    message=_"Good intuition, goon. A pity that it won't save you. Nothing will save you from us, hahahahaaa."
-                [/message]
-                {VARIABLE quests.farborough_southwest_ambush yes}
-            [/event]
-        [/else]
-    [/if]
-
-    [if]
-        [variable]
-            name=quests.farborough_east_ambush
-            equals=yes
-        [/variable]
-        [else]
-            [event]
-                name=moveto
-                [filter]
-                    x,y=31-36,14-18
-                    side=1
-                [/filter]
-                [message]
-                    speaker=unit
-                    message=_"These traces around... They look like if somebody had... there is an ambush!"
-                [/message]
-                {TBC_SPAWN_UNITS 3 0.7 "Spearman,Heavy Infantryman,Sergeant,Bowman" 39 18 Cavalryman boss_2}
-                [message]
-                    speaker=boss_2
-                    message=_"Who the hell left the trash there? Now we were discovered! Attack them before they regroup!"
-                [/message]
-                {VARIABLE quests.farborough_east_ambush yes}
-            [/event]
-        [/else]
-    [/if]
-
-    [if]
-        [variable]
-            name=quests.farborough_northeast_ambush
-            equals=yes
-        [/variable]
-        [else]
-            [event]
-                name=moveto
-                [filter]
-                    x,y=38-43,8-11
-                    side=1
-                [/filter]
-                [message]
-                    speaker=unit
-                    message=_"Somebody is here, hiding from us. Hey, you, friend or foe?"
-                [/message]
-                {TBC_SPAWN_UNITS 3 0.7 "Spearman,Heavy Infantryman,Cavalryman,Bowman" 43 12 Sergeant boss_3}
-                [message]
-                    speaker=boss_3
-                    message=_"Foe!"
-                [/message]
-                [message]
-                    speaker=Rimaru
-                    message=_"I don't wish to fight you. You may pretend that you have never seen us here. I can keep a secret untold."
-                [/message]
-                [message]
-                    speaker=boss_3
-                    message=_"Why should I betray my superiors? Why should I risk being hung just for you?"
-                [/message]
-                [message]
-                    speaker=player
-                    message=_"We are stronger than you think. If you attack us, you shall die. This is my final word!"
-                [/message]
-                [message]
-                    speaker=boss_3
-                    message=_"I will have your head on a stick!"
-                [/message]
-                {VARIABLE quests.farborough_northeast_ambush yes}
-            [/event]
-        [/else]
-    [/if]
-
-    [if]
-        [variable]
-            name=quests.farborough_northwest_ambush
-            equals=yes
-        [/variable]
-        [else]
-            [event]
-                name=moveto
-                [filter]
-                    x,y=3-10,2-7
-                    side=1
-                [/filter]
-                [message]
-                    speaker=Rimaru
-                    message=_"Hey, don't go there, you will be ambushed!"
-                [/message]
-                [message]
-                    id=$unit.id
-                    [not]
-                    id=Rimaru
-                    [/not]
-                    message=_"Yes, it looks like a good place for ambush. I'll come back."
-                [/message]
-                {TBC_SPAWN_UNITS 3 1 "Spearman,Heavy Infantryman,Sergeant,Bowman,Cavalryman" 3 3 Swordsman boss_4}
-                [message]
-                    speaker=boss_4
-                    message=_"Nice try, but you realised it too late. Kill them, leave no man alive."
-                    [option]
-                    message=_"Why do you want them to kill us all? I know. Brothers of Light would torture us to no end, as they always do to those who are a part of plots against them to reveal their co-conspirators. Or just to fabricate evidence against somebody they need to get rid of. Your decision to kill us all is merciful."
-                    [command]
-                        [message]
-                            speaker=boss_4
-                            message=_"No. I only wanted to see you die, I will not leave that pleasure to those smug Brothers of Light."
-                        [/message]
-                        [message]
-                            speaker=Rimaru
-                            message=_"That was a beautiful attempt at diplomacy, but it failed. Some people are just too dumb to be persuaded."
-                        [/message]
-                        [message]
-                            speaker=player
-                            message=_"I'd rather call him ferocious than dumb, but I got your point."
-                        [/message]
-                        {TBC_DIPLOMACY_TRIED}
-                    [/command]
-                    [/option]
-                    [option]
-                    message=_"You desire death? So have it!"
-                    [command]
-                        [message]
-                            speaker=boss_4
-                            message=_"I will heave your ugly head on a stick!"
-                        [/message]
-                    [/command]
-                    [/option]
-                [/message]
-                {VARIABLE quests.farborough_northwest_ambush yes}
-            [/event]
-        [/else]
-    [/if]
-
-    [if]
-        [variable]
-            name=quests.farborough_central_ambush_talk
-            equals=yes
-        [/variable]
-        [else]
-            [event]
-                name=moveto
-                [filter]
-                    x,y=12-30,7-15
-                    side=1
-                [/filter]
-                [filter_condition]
-                    [not]
-                        [variable]
-                            name=quests.farborough_central_ambush
-                            equals=yes
-                        [/variable]
-                    [/not]
-                [/filter_condition]
-                [message]
-                    speaker=Rimaru
-                    message=_"There is a forest. We should be careful, they might have prepared an ambush there. We might avoid the area through the hills, but some bandits might be waiting there."
-                [/message]
-                [while]
-                    [not]
-                        [variable]
-                            name=done
-                            equals=yes
-                        [/variable]
-                    [/not]
-                    [do]
-                        [message]
-                            speaker=Rimaru
-                            message=_"What shall we do?"
-                            [option]
-                            message=_"We might just rush ahead and kill everything we come across."
-                            [command]
-                                [message]
-                                    speaker=faithful_lieutenant
-                                    message=_"They might be more numerous than my squad was. And you don't have the help of locals."
-                                [/message]
-                                [message]
-                                    speaker=Rimaru
-                                    message=_"I think too that it would be too risky."
-                                [/message]
-                            [/command]
-                            [/option]
-                            [option]
-                            message=_"Our elvish friend might outrun them in the forest and lure them into a place we prepare for them."
-                            [show_if]
-                                [have_unit]
-                                    id=elf_merc
-                                [/have_unit]
-                            [/show_if]
-                            [command]
-                                [message]
-                                    speaker=elf_merc
-                                    message=_"I like that idea. I hope we'll find a good spot."
-                                [/message]
-                            [/command]
-                            [/option]
-                            [option]
-                            message=_"How about hiring the bandits?"
-                            [command]
-                                [message]
-                                    speaker=elf_merc
-                                    message=_"To me, it sounds good. Bandits can be easily turned into mercenaries."
-                                [/message]
-                                [message]
-                                    speaker=Rimaru
-                                    message=_"But they may decide that they will kill you and get your gold instead of working for you to get your gold. Bandits are dangerous. But, we can promise them what we promised to our mercenary. Loot."
-                                [/message]
-                                [message]
-                                    speaker=faithful_lieutenant
-                                    message=_"If it fails, we may try to lure them into the soldiers to have our enemies fight each other instead of fighting us."
-                                [/message]
-                            [/command]
-                            [/option]
-                            [option]
-                            message=_"Enough planning, let's go!"
-                            [command]
-                                {VARIABLE done yes}
-                            [/command]
-                            [/option]
-                        [/message]
-                    [/do]
-                [/while]
-                {CLEAR_VARIABLE done}
-                {VARIABLE quests.farborough_central_ambush_talk yes}
-            [/event]
-        [/else]
-    [/if]
-
-    [if]
-        [variable]
-            name=quests.farborough_central_ambush
-            equals=yes
-        [/variable]
-        [else]
-            [event]
-                name=moveto
-                [filter]
-                    x,y=10-16,6-10
-                    side=1
-                [/filter]
-                {TBC_SPAWN_UNITS 3 0.6 "Spearman,Heavy Infantryman,Sergeant,Bowman" 12 8 "White Mage" boss_5}
-                {TBC_SPAWN_UNITS_NO_LEADER 3 0.6 "Spearman,Heavy Infantryman,Sergeant,Bowman" 14 8}
-                [message]
-                    speaker=boss_5
-                    message=_"Found you. Now you will not escape so easily!"
-                [/message]
-                [message]
-                    speaker=Rimaru
-                    message=_"This is insane! Leave your weapons on the ground, fools, there is no need to make war. We only want you to manage your resources more economically."
-                [/message]
-                [message]
-                    speaker=boss_5
-                    message=_"Who cares about that? We were ordered to kill you, we aren't going to disobey!"
-                [/message]
-                {VARIABLE quests.farborough_central_ambush yes}
-            [/event]
-        [/else]
-    [/if]
-
-    [if]
-        [variable]
-            name=quests.farborough_central_ambush_bandits
-            equals=yes
-        [/variable]
-        [else]
-            [event]
-                name=moveto
-                [filter]
-                    x,y=19-26,7-10
-                    side=1
-                [/filter]
+        name=start
+        {GUARDIAN_UNIT 2 "Peasant" 38 25}
+        {GUARDIAN_UNIT 2 "Peasant" 33 30}
+        {GUARDIAN_UNIT 2 "Woodsman" 38 41}
+        {GUARDIAN_UNIT 2 "Peasant" 34 24}
+        {GUARDIAN_UNIT 2 "Peasant" 37 30}
+        {GUARDIAN_UNIT 2 "Peasant" 31 28}
+        [+unit]
+            id=peasant_speaker
+        [/unit]
+        [if]
+            [variable]
+                name=quests.post_intro_fight_victory
+                equals=yes
+            [/variable]
+            [else]
+                {GENERIC_UNIT 3 "Spearman" 34 26}
+                {GENERIC_UNIT 3 "Bowman" 41 28}
+                {GENERIC_UNIT 3 "Bowman" 41 28}
                 [unit]
-                    side=4
-                    type=Outlaw
-                    id=bandit_merc
+                    side=3
+                    type=White Mage
+                    id=brother
                     generate_name=yes
-                    x,y=23,8
+                    x,y=39,31
+                    random_traits=yes
+                    gender=male
+                    upkeep=full
+                [/unit]
+                [if]
+                    [have_unit]
+                        id=elf_merc
+                    [/have_unit]
+                    [then]
+                        {GENERIC_UNIT 3 "Fencer" 36 24}
+                    [/then]
+                [/if]
+#ifdef HARD
+                {GENERIC_UNIT 3 "Cavalryman" 32 30}
+#endif
+                [unit]
+                    side=3
+                    type=Lieutenant
+                    id=faithful_lieutenant
+                    generate_name=yes
+                    x,y=39,29
                     random_traits=yes
                     upkeep=full
                     [modifications]
@@ -548,205 +108,788 @@
                             id=portrait
                             [effect]
                                 apply_to=profile
-                                portrait="portraits/humans/transparent/outlaw.png"
+                                portrait="portraits/humans/transparent/lieutenant.png"
                             [/effect]
                         [/advance]
                     [/modifications]
                 [/unit]
-                {TBC_SPAWN_UNITS_NO_LEADER 4 0.8 "Thug,Footpad,Poacher,Thief" 23 8}
+            [/else]
+        [/if]
+        [if]
+            [variable]
+                name=quests.post_intro_fight
+                equals=yes
+            [/variable]
+            [else]
                 [message]
-                    speaker=bandit_merc
-                    message=_"How do you dare to trespass here? Pay with your life or with money, that's your choice. What do you choose?"
+                    speaker=brother
+                    message=_"...and because of that, we need more than a tenth of your income, a nineth of your income."
+                [/message]
+                [message]
+                    speaker=peasant_speaker
+                    message=_"That is a trick, a nineth is not less than a tenth!"
+                [/message]
+                [message]
+                    speaker=brother
+                    message=_"I was never telling that. We need more, that is what I said. We will use the money to bring a better future!"
+                [/message]
+                [message]
+                    speaker=peasant_speaker
+                    message=_"Will the future be really so bright? Nothing changed since the time of my grandfathers."
+                [/message]
+                [message]
+                    speaker=Rimaru
+                    message=_"It will not. They only need more and more money, they are greedy and they love luxury. Remember what happened a decade ago. They reported that they were fighting a dark cult trying to unleash darkness upon us and needed to fund an army, so they increased the tithes. There is no such cult anymore. And I have seen no credible evidence that it ever existed. Yet, they did not decrease the tithes when the fights were over."
+                [/message]
+                [message]
+                    speaker=peasant_speaker
+                    message=_"You're right..."
+                [/message]
+                [message]
+                    speaker=Rimaru
+                    message=_"The older of you will also remember how they fought the plot of necromancers to force the king to allow them to use our graveyards. They increased the tithes to fund their campaign, however, they never reduced it back. What are you paying for? From the tenth of your income, you're already paying their war against a dark cult and a campaign against a necromancers' plot, yet neither of these is active. They're just keeping the money for themselves!"
+                [/message]
+                [message]
+                    speaker=peasant_speaker
+                    message=_"My father told me about that. We waited until the horribly great tithes decrease, until we got used to that and forgot that they should have been decreased. If you need money, use those we are already paying for your other campaigns that are no longer active."
+                [/message]
+                [message]
+                    speaker=brother
+                    message=_"This rebellion, it is all your fault. I was told to arrest you anyway, so..."
+                [/message]
+                [message]
+                    speaker=faithful_lieutenant
+                    message=_"Good man, can you please come with us?"
+                [/message]
+                [message]
+                    speaker=Rimaru
+                    message=_"Why should I? I see a group of armed men. How do I know that you don't bear ill intentions?"
+                [/message]
+                [message]
+                    speaker=faithful_lieutenant
+                    message=_"Don't worry, I have this piece of paper proving that we are loyal servants of the Brothers of Light. I was told that you can read."
+                [/message]
+                [message]
+                    speaker=Rimaru
+                    message=_"How can you be so sure that the Brothers of Light don't bear ill intentions themselves?"
+                [/message]
+                [message]
+                    speaker=faithful_lieutenant
+                    message=_"They can't be evil, they are the Brothers of Light. And you seem to be their enemy."
                     [option]
-                    message=_"We can offer you money."
-                    [command]
-                        [message]
-                            speaker=bandit_merc
-                            message=_"How much?"
-                        [/message]
-                        [message]
-                            speaker=Rimaru
-                            message=_"If you join us on our anarchic campaign trying to destroy the Brothers of Light, you will get a share of the wealth we'll take when raiding the castle."
-                        [/message]
-                        [message]
-                            speaker=bandit_merc
-                            message=_"Those are just empty promises. I want gold. Right now."
-                        [/message]
-                        [message]
-                            speaker=elf_merc
-                            message=_"You will change our mind over time."
-                        [/message]
-                    [/command]
+                        message=_"Their order is corrupt. Their path has gone far too long from helping those who need it to hoarding gold. And this time, they seem be starting a new scheme to earn even more gold. We are only trying to save the peasants from having to pay even greater tithes."
+                        [command]
+                            {SCENARIO_DURATION_VARIABLE explained_problem yes}
+                            [message]
+                                speaker=faithful_lieutenant
+                                message=_"I've seen their pride, how they put themselves above anything. But I will not believe that their goals are selfish."
+                            [/message]
+                            [message]
+                                speaker=brother
+                                message=_"You shall speak such words no more."
+                            [/message]
+                            {VARIABLE quests.diplomacy_attempts 1}
+                        [/command]
                     [/option]
                     [option]
-                    message=_"It is you who will pay. With life."
-                    [command]
-                        [message]
-                            speaker=bandit_merc
-                            message=_"Me? Is that a joke? You will die. You all will die!"
-                        [/message]
-                    [/command]
+                        message=_"You don't have to obey them. They are only misusing you, you're nothing to them but an animal that does the dirty job of fighting their enemies."
+                        [command]
+                            {SCENARIO_DURATION_VARIABLE explained_problem yes}
+                            [message]
+                                speaker=faithful_lieutenant
+                                message=_"I don't like it, but it is my duty to protect the kingdom and its servants."
+                            [/message]
+                            [message]
+                                speaker=brother
+                                message=_"If you'll speak like that again, we will skin you alive!"
+                            [/message]
+                            {VARIABLE quests.diplomacy_attempts 1}
+                        [/command]
+                    [/option]
+                    [option]
+                        message=_"You've chosen to be my enemy. I am not merciful to my enemies. Remember that it was you who chose this path. This is your last occasion to regret your words."
+                        [command]
+                            [message]
+                                speaker=faithful_lieutenant
+                                message=_"I will never come to need your mercy. You will need my mercy very soon, and I don't think that I'll be merciful to the merciless."
+                            [/message]
+                            [message]
+                                speaker=brother
+                                message=_"No mercy on these blasphemers!"
+                            [/message]
+                            {VARIABLE quests.diplomacy_attempts 0}
+                        [/command]
+                    [/option]
+                    [option]
+                        message=_"I know that you want to fight, jackass! Come on and die like an animal. I will hack you to pieces and feed them to my neighbour's hounds!"
+                        [command]
+                            [message]
+                                speaker=faithful_lieutenant
+                                message=_"Die, scoundrel!"
+                            [/message]
+                            [message]
+                                speaker=brother
+                                message=_"Well said, Lieutenant!"
+                            [/message]
+                            {VARIABLE quests.diplomacy_attempts 0}
+                        [/command]
                     [/option]
                 [/message]
-                {VARIABLE quests.farborough_central_ambush_bandits yes}
-            [/event]
-        [/else]
-    [/if]
+                [message]
+                    speaker=Rimaru
+                    message=_"I doubt there was ever a chance to persuade these guys..."
+                [/message]
+                {VARIABLE quests.post_intro_fight yes}
+                {VARIABLE quests.overall 1}
+            [/else]
+        [/if]
 
-    [if]
-        [variable]
-            name=quests.overall
-            greater_than=9
-        [/variable]
-        [then]
-            [if]
-                [variable]
-                    name=quests.farborough_later_ambush_1
-                    equals=yes
-                [/variable]
-                [else]
-                    [event]
-                        name=moveto
-                        [filter]
-                            x,y=10-23,20-30
-                            side=1
-                        [/filter]
-                        {TBC_SPAWN_UNITS_NO_LEADER 4 1.4 "Thug,Poacher,Bandit,Rogue,Trapper,Outlaw" 22 2}
-                        {VARIABLE quests.farborough_later_ambush_1 yes}
-                    [/event]
-                [/else]
-            [/if]
-            [if]
-                [variable]
-                    name=quests.farborough_later_ambush_2
-                    equals=yes
-                [/variable]
-                [else]
-                    [event]
-                        name=moveto
-                        [filter]
-                            x,y=31-43,6-17
-                            side=1
-                        [/filter]
-                        {TBC_SPAWN_UNITS_NO_LEADER 4 1.4 "Thug,Poacher,Bandit,Rogue,Trapper,Outlaw" 33 11}
-                        {VARIABLE quests.farborough_later_ambush_2 yes}
-                    [/event]
-                [/else]
-            [/if]
-            [if]
-                [variable]
-                    name=quests.farborough_later_ambush_3
-                    equals=yes
-                [/variable]
-                [else]
-                    [event]
-                        name=moveto
-                        [filter]
-                            x,y=5-22,3-15
-                            side=1
-                        [/filter]
-                        {TBC_SPAWN_UNITS_NO_LEADER 4 1.4 "Thug,Poacher,Bandit,Rogue,Trapper,Outlaw" 14 8}
-                        {VARIABLE quests.farborough_later_ambush_3 yes}
-                    [/event]
-                [/else]
-            [/if]
-        [/then]
-    [/if]
+        [if]
+            [variable]
+                name=quests.farborough_southwest_ambush
+                equals=yes
+            [/variable]
+            [else]
+                [event]
+                    name=moveto
+                    [filter]
+                        x,y=2-6,22-25
+                        side=1
+                    [/filter]
+                    [message]
+                        speaker=unit
+                        message=_"This place looks like a very good spot for an ambush."
+                    [/message]
+                    {TBC_SPAWN_UNITS 3 0.7 "Spearman,Heavy Infantryman,Sergeant,Bowman" 8 21 Cavalryman boss_1}
+                    [message]
+                        speaker=boss_1
+                        message=_"Good intuition, goon. A pity that it won't save you. Nothing will save you from us, hahahahaaa."
+                    [/message]
+                    {VARIABLE quests.farborough_southwest_ambush yes}
+                [/event]
+            [/else]
+        [/if]
+
+        [if]
+            [variable]
+                name=quests.farborough_east_ambush
+                equals=yes
+            [/variable]
+            [else]
+                [event]
+                    name=moveto
+                    [filter]
+                        x,y=31-36,14-18
+                        side=1
+                    [/filter]
+                    [message]
+                        speaker=unit
+                        message=_"These traces around... They look like if somebody had... there is an ambush!"
+                    [/message]
+                    {TBC_SPAWN_UNITS 3 0.7 "Spearman,Heavy Infantryman,Sergeant,Bowman" 39 18 Cavalryman boss_2}
+                    [message]
+                        speaker=boss_2
+                        message=_"Who the hell left the trash there? Now we were discovered! Attack them before they regroup!"
+                    [/message]
+                    {VARIABLE quests.farborough_east_ambush yes}
+                [/event]
+            [/else]
+        [/if]
+
+        [if]
+            [variable]
+                name=quests.farborough_northeast_ambush
+                equals=yes
+            [/variable]
+            [else]
+                [event]
+                    name=moveto
+                    [filter]
+                        x,y=38-43,8-11
+                        side=1
+                    [/filter]
+                    [message]
+                        speaker=unit
+                        message=_"Somebody is here, hiding from us. Hey, you, friend or foe?"
+                    [/message]
+                    {TBC_SPAWN_UNITS 3 0.7 "Spearman,Heavy Infantryman,Cavalryman,Bowman" 43 12 Sergeant boss_3}
+                    [message]
+                        speaker=boss_3
+                        message=_"Foe!"
+                    [/message]
+                    [message]
+                        speaker=Rimaru
+                        message=_"I don't wish to fight you. You may pretend that you have never seen us here. I can keep a secret untold."
+                    [/message]
+                    [message]
+                        speaker=boss_3
+                        message=_"Why should I betray my superiors? Why should I risk being hung just for you?"
+                    [/message]
+                    [message]
+                        speaker=player
+                        message=_"We are stronger than you think. If you attack us, you shall die. This is my final word!"
+                    [/message]
+                    [message]
+                        speaker=boss_3
+                        message=_"I will have your head on a stick!"
+                    [/message]
+                    {VARIABLE quests.farborough_northeast_ambush yes}
+                [/event]
+            [/else]
+        [/if]
+
+        [if]
+            [variable]
+                name=quests.farborough_northwest_ambush
+                equals=yes
+            [/variable]
+            [else]
+                [event]
+                    name=moveto
+                    [filter]
+                        x,y=3-10,2-7
+                        side=1
+                    [/filter]
+                    [message]
+                        speaker=Rimaru
+                        message=_"Hey, don't go there, you will be ambushed!"
+                    [/message]
+                    [message]
+                        id=$unit.id
+                        [not]
+                            id=Rimaru
+                        [/not]
+                        message=_"Yes, it looks like a good place for ambush. I'll come back."
+                    [/message]
+                    {TBC_SPAWN_UNITS 3 1 "Spearman,Heavy Infantryman,Sergeant,Bowman,Cavalryman" 3 3 Swordsman boss_4}
+                    [message]
+                        speaker=boss_4
+                        message=_"Nice try, but you realised it too late. Kill them, leave no man alive."
+                        [option]
+                            message=_"Why do you want them to kill us all? I know. Brothers of Light would torture us to no end, as they always do to those who are a part of plots against them to reveal their co-conspirators. Or just to fabricate evidence against somebody they need to get rid of. Your decision to kill us all is merciful."
+                            [command]
+                                [message]
+                                    speaker=boss_4
+                                    message=_"No. I only wanted to see you die, I will not leave that pleasure to those smug Brothers of Light."
+                                [/message]
+                                [message]
+                                    speaker=Rimaru
+                                    message=_"That was a beautiful attempt at diplomacy, but it failed. Some people are just too dumb to be persuaded."
+                                [/message]
+                                [message]
+                                    speaker=player
+                                    message=_"I'd rather call him ferocious than dumb, but I got your point."
+                                [/message]
+                                {TBC_DIPLOMACY_TRIED}
+                            [/command]
+                        [/option]
+                        [option]
+                            message=_"You desire death? So have it!"
+                            [command]
+                                [message]
+                                    speaker=boss_4
+                                    message=_"I will heave your ugly head on a stick!"
+                                [/message]
+                            [/command]
+                        [/option]
+                    [/message]
+                    {VARIABLE quests.farborough_northwest_ambush yes}
+                [/event]
+            [/else]
+        [/if]
+
+        [if]
+            [variable]
+                name=quests.farborough_central_ambush_talk
+                equals=yes
+            [/variable]
+            [else]
+                [event]
+                    name=moveto
+                    [filter]
+                        x,y=12-30,7-15
+                        side=1
+                    [/filter]
+                    [filter_condition]
+                        [not]
+                            [variable]
+                                name=quests.farborough_central_ambush
+                                equals=yes
+                            [/variable]
+                        [/not]
+                    [/filter_condition]
+                    [message]
+                        speaker=Rimaru
+                        message=_"There is a forest. We should be careful, they might have prepared an ambush there. We might avoid the area through the hills, but some bandits might be waiting there."
+                    [/message]
+                    [while]
+                        [not]
+                            [variable]
+                                name=done
+                                equals=yes
+                            [/variable]
+                        [/not]
+                        [do]
+                            [message]
+                                speaker=Rimaru
+                                message=_"What shall we do?"
+                                [option]
+                                    message=_"We might just rush ahead and kill everything we come across."
+                                    [command]
+                                        [message]
+                                            speaker=faithful_lieutenant
+                                            message=_"They might be more numerous than my squad was. And you don't have the help of locals."
+                                        [/message]
+                                        [message]
+                                            speaker=Rimaru
+                                            message=_"I think too that it would be too risky."
+                                        [/message]
+                                    [/command]
+                                [/option]
+                                [option]
+                                    message=_"Our elvish friend might outrun them in the forest and lure them into a place we prepare for them."
+                                    [show_if]
+                                        [have_unit]
+                                            id=elf_merc
+                                        [/have_unit]
+                                    [/show_if]
+                                    [command]
+                                        [message]
+                                            speaker=elf_merc
+                                            message=_"I like that idea. I hope we'll find a good spot."
+                                        [/message]
+                                    [/command]
+                                [/option]
+                                [option]
+                                    message=_"How about hiring the bandits?"
+                                    [command]
+                                        [message]
+                                            speaker=elf_merc
+                                            message=_"To me, it sounds good. Bandits can be easily turned into mercenaries."
+                                        [/message]
+                                        [message]
+                                            speaker=Rimaru
+                                            message=_"But they may decide that they will kill you and get your gold instead of working for you to get your gold. Bandits are dangerous. But, we can promise them what we promised to our mercenary. Loot."
+                                        [/message]
+                                        [message]
+                                            speaker=faithful_lieutenant
+                                            message=_"If it fails, we may try to lure them into the soldiers to have our enemies fight each other instead of fighting us."
+                                        [/message]
+                                    [/command]
+                                [/option]
+                                [option]
+                                    message=_"Enough planning, let's go!"
+                                    [command]
+                                        {VARIABLE done yes}
+                                    [/command]
+                                [/option]
+                            [/message]
+                        [/do]
+                    [/while]
+                    {CLEAR_VARIABLE done}
+                    {VARIABLE quests.farborough_central_ambush_talk yes}
+                [/event]
+            [/else]
+        [/if]
+
+        [if]
+            [variable]
+                name=quests.farborough_central_ambush
+                equals=yes
+            [/variable]
+            [else]
+                [event]
+                    name=moveto
+                    [filter]
+                        x,y=10-16,6-10
+                        side=1
+                    [/filter]
+                    {TBC_SPAWN_UNITS 3 0.6 "Spearman,Heavy Infantryman,Sergeant,Bowman" 12 8 "White Mage" boss_5}
+                    {TBC_SPAWN_UNITS_NO_LEADER 3 0.6 "Spearman,Heavy Infantryman,Sergeant,Bowman" 14 8}
+                    [message]
+                        speaker=boss_5
+                        message=_"Found you. Now you will not escape so easily!"
+                    [/message]
+                    [message]
+                        speaker=Rimaru
+                        message=_"This is insane! Leave your weapons on the ground, fools, there is no need to make war. We only want you to manage your resources more economically."
+                    [/message]
+                    [message]
+                        speaker=boss_5
+                        message=_"Who cares about that? We were ordered to kill you, we aren't going to disobey!"
+                    [/message]
+                    {VARIABLE quests.farborough_central_ambush yes}
+                [/event]
+            [/else]
+        [/if]
+
+        [if]
+            [variable]
+                name=quests.farborough_central_ambush_bandits
+                equals=yes
+            [/variable]
+            [else]
+                [event]
+                    name=moveto
+                    [filter]
+                        x,y=19-26,7-10
+                        side=1
+                    [/filter]
+                    [unit]
+                        side=4
+                        type=Outlaw
+                        id=bandit_merc
+                        generate_name=yes
+                        x,y=23,8
+                        random_traits=yes
+                        upkeep=full
+                        [modifications]
+                            [advance]
+                                id=portrait
+                                [effect]
+                                    apply_to=profile
+                                    portrait="portraits/humans/transparent/outlaw.png"
+                                [/effect]
+                            [/advance]
+                        [/modifications]
+                    [/unit]
+                    {TBC_SPAWN_UNITS_NO_LEADER 4 0.8 "Thug,Footpad,Poacher,Thief" 23 8}
+                    [message]
+                        speaker=bandit_merc
+                        message=_"How do you dare to trespass here? Pay with your life or with money, that's your choice. What do you choose?"
+                        [option]
+                            message=_"We can offer you money."
+                            [command]
+                                [message]
+                                    speaker=bandit_merc
+                                    message=_"How much?"
+                                [/message]
+                                [message]
+                                    speaker=Rimaru
+                                    message=_"If you join us on our anarchic campaign trying to destroy the Brothers of Light, you will get a share of the wealth we'll take when raiding the castle."
+                                [/message]
+                                [message]
+                                    speaker=bandit_merc
+                                    message=_"Those are just empty promises. I want gold. Right now."
+                                [/message]
+                                [message]
+                                    speaker=elf_merc
+                                    message=_"You will change our mind over time."
+                                [/message]
+                            [/command]
+                        [/option]
+                        [option]
+                            message=_"It is you who will pay. With life."
+                            [command]
+                                [message]
+                                    speaker=bandit_merc
+                                    message=_"Me? Is that a joke? You will die. You all will die!"
+                                [/message]
+                            [/command]
+                        [/option]
+                    [/message]
+                    {VARIABLE quests.farborough_central_ambush_bandits yes}
+                [/event]
+            [/else]
+        [/if]
+
+        [if]
+            [variable]
+                name=quests.overall
+                greater_than=9
+            [/variable]
+            [then]
+                [if]
+                    [variable]
+                        name=quests.farborough_later_ambush_1
+                        equals=yes
+                    [/variable]
+                    [else]
+                        [event]
+                            name=moveto
+                            [filter]
+                                x,y=10-23,20-30
+                                side=1
+                            [/filter]
+                            {TBC_SPAWN_UNITS_NO_LEADER 4 1.4 "Thug,Poacher,Bandit,Rogue,Trapper,Outlaw" 22 2}
+                            {VARIABLE quests.farborough_later_ambush_1 yes}
+                        [/event]
+                    [/else]
+                [/if]
+                [if]
+                    [variable]
+                        name=quests.farborough_later_ambush_2
+                        equals=yes
+                    [/variable]
+                    [else]
+                        [event]
+                            name=moveto
+                            [filter]
+                                x,y=31-43,6-17
+                                side=1
+                            [/filter]
+                            {TBC_SPAWN_UNITS_NO_LEADER 4 1.4 "Thug,Poacher,Bandit,Rogue,Trapper,Outlaw" 33 11}
+                            {VARIABLE quests.farborough_later_ambush_2 yes}
+                        [/event]
+                    [/else]
+                [/if]
+                [if]
+                    [variable]
+                        name=quests.farborough_later_ambush_3
+                        equals=yes
+                    [/variable]
+                    [else]
+                        [event]
+                            name=moveto
+                            [filter]
+                                x,y=5-22,3-15
+                                side=1
+                            [/filter]
+                            {TBC_SPAWN_UNITS_NO_LEADER 4 1.4 "Thug,Poacher,Bandit,Rogue,Trapper,Outlaw" 14 8}
+                            {VARIABLE quests.farborough_later_ambush_3 yes}
+                        [/event]
+                    [/else]
+                [/if]
+            [/then]
+        [/if]
     [/event]
 
     [event]
-    name=last breath
-    [filter]
-        id=faithful_lieutenant
-    [/filter]
-    {VARIABLE quests.post_intro_fight_victory yes}
-    [message]
-        speaker=faithful_lieutenant
-        message=_"Scoundrels... you're much stronger than I thought. You're a much greater problem than I thought..."
-    [/message]
-    [message]
-        speaker=Rimaru
-        message=_"We are not scoundrels. It's you whose loyalties are twisted."
-    [/message]
-    [if]
-        [variable]
-            name=explained_problem
-            equals=yes
-        [/variable]
-        [then]
-            [message]
-                speaker=faithful_lieutenant
-                message=_"I know, you have spoken about that. And I must say that your determination is much better than the determination of usual outlaws. And I was never rewarded enough for my work, they just kept giving me orders... I hate my job. Will you let me go?"
-            [/message]
-            [message]
-                speaker=Rimaru
-                message=_"What would you do as a deserter? You'd end up as a dreg of society, bandit or beggar. Shall we let him join us?"
-                [option]
-                message=_"A tactician would be useful for our quest. Okay, you may come with us. If Rimaru manages to save your life."
+        name=last breath
+        [filter]
+            id=faithful_lieutenant
+        [/filter]
+        {VARIABLE quests.post_intro_fight_victory yes}
+        [message]
+            speaker=faithful_lieutenant
+            message=_"Scoundrels... you're much stronger than I thought. You're a much greater problem than I thought..."
+        [/message]
+        [message]
+            speaker=Rimaru
+            message=_"We are not scoundrels. It's you whose loyalties are twisted."
+        [/message]
+        [if]
+            [variable]
+                name=explained_problem
+                equals=yes
+            [/variable]
+            [then]
+                [message]
+                    speaker=faithful_lieutenant
+                    message=_"I know, you have spoken about that. And I must say that your determination is much better than the determination of usual outlaws. And I was never rewarded enough for my work, they just kept giving me orders... I hate my job. Will you let me go?"
+                [/message]
+                [message]
+                    speaker=Rimaru
+                    message=_"What would you do as a deserter? You'd end up as a dreg of society, bandit or beggar. Shall we let him join us?"
+                    [option]
+                        message=_"A tactician would be useful for our quest. Okay, you may come with us. If Rimaru manages to save your life."
+                        [command]
+                            [message]
+                                speaker=faithful_lieutenant
+                                message=_"Thank you. I will never forget that."
+                            [/message]
+                            [message]
+                                speaker=elf_merc
+                                message=_"Welcome to the team."
+                            [/message]
+                            [store_unit]
+                                [filter]
+                                    id=faithful_lieutenant
+                                [/filter]
+                                variable=lieutenant_store
+                            [/store_unit]
+                            {VARIABLE lieutenant_store.canrecruit yes}
+                            {VARIABLE lieutenant_store.side 1}
+                            {VARIABLE lieutenant_store.variables.hero yes}
+                            {VARIABLE lieutenant_store.hitpoints 15}
+                            [unstore_unit]
+                                variable=lieutenant_store
+                                find_vacant=no
+                            [/unstore_unit]
+                            {VARIABLE party_members[$party_members.length].id faithful_lieutenant}
+                            [store_unit]
+                                [filter]
+                                    [filter_location]
+                                        x,y=$lieutenant_store.x,$lieutenant_store.y
+                                        radius=3
+                                    [/filter_location]
+                                    side=3
+                                [/filter]
+                                variable=scared_soldiers
+                                kill=no
+                            [/store_unit]
+                            [if]
+                                [variable]
+                                    name=scared_soldiers.length
+                                    greater_than=0
+                                [/variable]
+                                [then]
+                                    [message]
+                                        speaker=$scared_soldiers[0].id
+                                        message=_"He deserted! Run! Run to the hills!"
+                                    [/message]
+                                    [for]
+                                        array=scared_soldiers
+                                        [do]
+                                            [move_unit]
+                                                id=$scared_soldiers[$i].id
+                                                to_x=1
+                                                to_y=1
+                                                fire_event=no
+                                            [/move_unit]
+                                            [kill]
+                                                id=$scared_soldiers[$i].id
+                                                fire_event=no
+                                                animate=no
+                                            [/kill]
+                                        [/do]
+                                    [/for]
+                                [/then]
+                            [/if]
+                            {CLEAR_VARIABLE lieutenant_store,scared_soldiers}
+                        [/command]
+                    [/option]
+                    [option]
+                        message=_"No. I don't like him. He might switch loyalty in the worst moment and betray us when we expect it the least."
+                        [command]
+                            [message]
+                                speaker=faithful_lieutenant
+                                message=_"I wish you'll become a black soul after death, scoundrel."
+                            [/message]
+                            [message]
+                                speaker=elf_merc
+                                message=_"You talk too much. Can't you just die?"
+                            [/message]
+                        [/command]
+                    [/option]
+                [/message]
+            [/then]
+            [else]
+                [message]
+                    speaker=faithful_lieutenant
+                    message=_"You are scoundrels, a band of hired mercenaries to help a revolt. I will die now, but you will be caught and rot alive in the darkest dungeons. And then, you'll become undead and suffer eternally."
+                [/message]
+                [message]
+                    speaker=elf_merc
+                    message=_"Why are you calling me a mercenary with so much hate? You're fighting for those who pay you, just like me."
+                [/message]
+            [/else]
+        [/if]
+        [message]
+            speaker=Rimaru
+            message=_"Now when we are done fighting, we must make a plan. We must catch those Brothers we met in the tavern before they bring reinforcements."
+            [option]
+                message=_"The nearest place where soldiers reside is north from here, on the court of baron Burke."
                 [command]
                     [message]
-                        speaker=faithful_lieutenant
-                        message=_"Thank you. I will never forget that."
+                        speaker=Rimaru
+                        message=_"Yes, they most likely went north from here."
                     [/message]
+                [/command]
+            [/option]
+            [option]
+                message=_"Maybe they just ran to the hills, northwest from here, to save their miserable lives."
+                [command]
+                    [message]
+                        speaker=Rimaru
+                        message=_"They don't give up so easily. They went most likely north, to the court of baron Burke, he is loyal to them as far as I know and would send an army to kill us all. And we aren't numerous enough for that."
+                    [/message]
+                [/command]
+            [/option]
+            [option]
+                message=_"Can you track them, elf?"
+                [show_if]
+                    [have_unit]
+                        id=elf_merc
+                    [/have_unit]
+                [/show_if]
+                [command]
                     [message]
                         speaker=elf_merc
-                        message=_"Welcome to the team."
+                        message=_"Hm, let me see... they ran north. What is there?"
+                    [/message]
+                    [message]
+                        speaker=Rimaru
+                        message=_"Indeed. Baron Burke is there. He is loyal to them and he has soldiers."
+                    [/message]
+                [/command]
+            [/option]
+        [/message]
+        [message]
+            speaker=player
+            message=_"Okay, to the north!"
+        [/message]
+        [message]
+            speaker=Rimaru
+            message=_"I'd like you to be aware of other groups of their soldiers that may be skulking around, hoping to ambush us."
+        [/message]
+    [/event]
+
+    [event]
+        name=last breath
+        [filter]
+            id=bandit_merc
+        [/filter]
+        [message]
+            speaker=bandit_merc
+            message=_"You are stronger than I thought... These are the risks of plundering."
+        [/message]
+        [message]
+            speaker=Rimaru
+            message=_"Shall we let him join us after what he tried to do?"
+            [option]
+                message=_"We need anybody who can fight."
+                [command]
+                    [message]
+                        speaker=Rimaru
+                        message=_"If you promise that you'll fight with us against the Brothers of Light, I will let you live."
+                    [/message]
+                    [message]
+                        speaker=bandit_merc
+                        message=_"Anything is better than death! I will be glad to join you."
                     [/message]
                     [store_unit]
                         [filter]
-                            id=faithful_lieutenant
+                            id=bandit_merc
                         [/filter]
-                        variable=lieutenant_store
+                        variable=bandit_store
                     [/store_unit]
-                    {VARIABLE lieutenant_store.canrecruit yes}
-                    {VARIABLE lieutenant_store.side 1}
-                    {VARIABLE lieutenant_store.variables.hero yes}
-                    {VARIABLE lieutenant_store.hitpoints 15}
+                    {VARIABLE bandit_store.canrecruit yes}
+                    {VARIABLE bandit_store.side 1}
+                    {VARIABLE bandit_store.variables.hero yes}
+                    {VARIABLE bandit_store.hitpoints 15}
                     [unstore_unit]
-                        variable=lieutenant_store
+                        variable=bandit_store
                         find_vacant=no
                     [/unstore_unit]
-                    {VARIABLE party_members[$party_members.length].id faithful_lieutenant}
+                    {VARIABLE party_members[$party_members.length].id bandit_merc}
                     [store_unit]
                         [filter]
                             [filter_location]
-                                x,y=$lieutenant_store.x,$lieutenant_store.y
+                                x,y=$bandit_store.x,$bandit_store.y
                                 radius=3
                             [/filter_location]
-                            side=3
+                            side=4
                         [/filter]
-                        variable=scared_soldiers
+                        variable=scared_bandits
                         kill=no
                     [/store_unit]
                     [if]
                         [variable]
-                            name=scared_soldiers.length
+                            name=scared_bandits.length
                             greater_than=0
                         [/variable]
                         [then]
                             [message]
-                                speaker=$scared_soldiers[0].id
-                                message=_"He deserted! Run! Run to the hills!"
+                                speaker=$scared_bandits[0].id
+                                message=_"He changed allegiance! We will have to kill him as well!"
                             [/message]
-                            {FOREACH scared_soldiers i}
-                                [move_unit]
-                                    id=$scared_soldiers[$i].id
-                                    to_x=1
-                                    to_y=1
-                                    fire_event=no
-                                [/move_unit]
-                                [kill]
-                                    id=$scared_soldiers[$i].id
-                                    fire_event=no
-                                    animate=no
-                                [/kill]
-                            {NEXT i}
                         [/then]
                     [/if]
-                    {CLEAR_VARIABLE lieutenant_store,scared_soldiers}
+                    {CLEAR_VARIABLE bandit_store,scared_bandits}
                 [/command]
-                [/option]
-                [option]
+            [/option]
+            [option]
                 message=_"No. I don't like him. He might switch loyalty in the worst moment and betray us when we expect it the least."
                 [command]
                     [message]
@@ -758,148 +901,8 @@
                         message=_"You talk too much. Can't you just die?"
                     [/message]
                 [/command]
-                [/option]
-            [/message]
-        [/then]
-        [else]
-            [message]
-                speaker=faithful_lieutenant
-                message=_"You are scoundrels, a band of hired mercenaries to help a revolt. I will die now, but you will be caught and rot alive in the darkest dungeons. And then, you'll become undead and suffer eternally."
-            [/message]
-            [message]
-                speaker=elf_merc
-                message=_"Why are you calling me a mercenary with so much hate? You're fighting for those who pay you, just like me."
-            [/message]
-        [/else]
-    [/if]
-    [message]
-        speaker=Rimaru
-        message=_"Now when we are done fighting, we must make a plan. We must catch those Brothers we met in the tavern before they bring reinforcements."
-        [option]
-        message=_"The nearest place where soldiers reside is north from here, on the court of baron Burke."
-        [command]
-            [message]
-                speaker=Rimaru
-                message=_"Yes, they most likely went north from here."
-            [/message]
-        [/command]
-        [/option]
-        [option]
-        message=_"Maybe they just ran to the hills, northwest from here, to save their miserable lives."
-        [command]
-            [message]
-                speaker=Rimaru
-                message=_"They don't give up so easily. They went most likely north, to the court of baron Burke, he is loyal to them as far as I know and would send an army to kill us all. And we aren't numerous enough for that."
-            [/message]
-        [/command]
-        [/option]
-        [option]
-        message=_"Can you track them, elf?"
-        [show_if]
-            [have_unit]
-                id=elf_merc
-            [/have_unit]
-        [/show_if]
-        [command]
-            [message]
-                speaker=elf_merc
-                message=_"Hm, let me see... they ran north. What is there?"
-            [/message]
-            [message]
-                speaker=Rimaru
-                message=_"Indeed. Baron Burke is there. He is loyal to them and he has soldiers."
-            [/message]
-        [/command]
-        [/option]
-    [/message]
-    [message]
-        speaker=player
-        message=_"Okay, to the north!"
-    [/message]
-    [message]
-        speaker=Rimaru
-        message=_"I'd like you to be aware of other groups of their soldiers that may be skulking around, hoping to ambush us."
-    [/message]
-    [/event]
-
-    [event]
-    name=last breath
-    [filter]
-        id=bandit_merc
-    [/filter]
-    [message]
-        speaker=bandit_merc
-        message=_"You are stronger than I thought... These are the risks of plundering."
-    [/message]
-    [message]
-        speaker=Rimaru
-        message=_"Shall we let him join us after what he tried to do?"
-        [option]
-        message=_"We need anybody who can fight."
-        [command]
-            [message]
-                speaker=Rimaru
-                message=_"If you promise that you'll fight with us against the Brothers of Light, I will let you live."
-            [/message]
-            [message]
-                speaker=bandit_merc
-                message=_"Anything is better than death! I will be glad to join you."
-            [/message]
-            [store_unit]
-                [filter]
-                    id=bandit_merc
-                [/filter]
-                variable=bandit_store
-            [/store_unit]
-            {VARIABLE bandit_store.canrecruit yes}
-            {VARIABLE bandit_store.side 1}
-            {VARIABLE bandit_store.variables.hero yes}
-            {VARIABLE bandit_store.hitpoints 15}
-            [unstore_unit]
-                variable=bandit_store
-                find_vacant=no
-            [/unstore_unit]
-            {VARIABLE party_members[$party_members.length].id bandit_merc}
-            [store_unit]
-                [filter]
-                    [filter_location]
-                        x,y=$bandit_store.x,$bandit_store.y
-                        radius=3
-                    [/filter_location]
-                    side=4
-                [/filter]
-                variable=scared_bandits
-                kill=no
-            [/store_unit]
-            [if]
-                [variable]
-                    name=scared_bandits.length
-                    greater_than=0
-                [/variable]
-                [then]
-                    [message]
-                        speaker=$scared_bandits[0].id
-                        message=_"He changed allegiance! We will have to kill him as well!"
-                    [/message]
-                [/then]
-            [/if]
-            {CLEAR_VARIABLE bandit_store,scared_bandits}
-        [/command]
-        [/option]
-        [option]
-        message=_"No. I don't like him. He might switch loyalty in the worst moment and betray us when we expect it the least."
-        [command]
-            [message]
-                speaker=faithful_lieutenant
-                message=_"I wish you'll become a black soul after death, scoundrel."
-            [/message]
-            [message]
-                speaker=elf_merc
-                message=_"You talk too much. Can't you just die?"
-            [/message]
-        [/command]
-        [/option]
-    [/message]
+            [/option]
+        [/message]
     [/event]
 
     {TBC_GLOBAL_EVENTS_RPG}

--- a/spinoffs/The_Beautiful_Child/scenarios/Thunderhold.cfg
+++ b/spinoffs/The_Beautiful_Child/scenarios/Thunderhold.cfg
@@ -29,9 +29,9 @@
         side=2
         team_name=good,twisted_good
         user_team_name=_"Peaceful Citizens"
-    [ai]
-        passive_leader=yes
-    [/ai]
+        [ai]
+            passive_leader=yes
+        [/ai]
         [unit]
             type=Dwarvish Hero
             x,y=9,19
@@ -98,71 +98,71 @@
         side=3
         team_name=twisted_good
         user_team_name=_"Twisted Good"
-    [ai]
-        aggression=1.0
-    [/ai]
+        [ai]
+            aggression=1.0
+        [/ai]
     [/side]
 
     {TBC_PLACE_WAYPOINT 9 13}
 
     [event]
-    name=prestart
-    [label]
-        x,y=9,19
-        text=_"Armour shop"
-        color=255,255,255
-    [/label]
-    [label]
-        x,y=14,19
-        text=_"Weapons shop"
-        color=255,255,255
-    [/label]
-    [label]
-        x,y=11,21
-        text=_"Magical trinkets shop"
-        color=255,255,255
-    [/label]
-    [label]
-        x,y=16,16
-        text=_"Precious gems shop"
-        color=255,255,255
-    [/label]
-    {CLEAR_RECALLS}
-    {VARIABLE current_scenario thunderhold}
-    {TBC_ORIGIN grey_hills 42 19}
-    {TBC_ORIGIN fertile_lands 9 32}
-    [if]
-        [variable]
-            name=quests.overall
-            greater_than=6
-        [/variable]
-        [then]
-            [fire_event]
-                name=open fertile lands
-            [/fire_event]
-        [/then]
-    [/if]
-    [time_area]
-        terrain=Iwr,Xol
-        {INDOORS}
-    [/time_area]
+        name=prestart
+        [label]
+            x,y=9,19
+            text=_"Armour shop"
+            color=255,255,255
+        [/label]
+        [label]
+            x,y=14,19
+            text=_"Weapons shop"
+            color=255,255,255
+        [/label]
+        [label]
+            x,y=11,21
+            text=_"Magical trinkets shop"
+            color=255,255,255
+        [/label]
+        [label]
+            x,y=16,16
+            text=_"Precious gems shop"
+            color=255,255,255
+        [/label]
+        {CLEAR_RECALLS}
+        {VARIABLE current_scenario thunderhold}
+        {TBC_ORIGIN grey_hills 42 19}
+        {TBC_ORIGIN fertile_lands 9 32}
+        [if]
+            [variable]
+                name=quests.overall
+                greater_than=6
+            [/variable]
+            [then]
+                [fire_event]
+                    name=open fertile lands
+                [/fire_event]
+            [/then]
+        [/if]
+        [time_area]
+            terrain=Iwr,Xol
+            {INDOORS}
+        [/time_area]
     [/event]
 
     [event]
-    name=open fertile lands
-    [remove_event]
-        id=forbid_progress
-    [/remove_event]
-    {TBC_TRANSITION 1-41 32-33 Fertile_Lands _"Fertile Lands" 10 32}
+        name=open fertile lands
+        [remove_event]
+            id=forbid_progress
+        [/remove_event]
+        {TBC_TRANSITION 1-41 32-33 Fertile_Lands _"Fertile Lands" 10 32}
     [/event]
 
     [event]
-    name=allow return
-    {TBC_TRANSITION 43-44 10-31 Grey_Hills _"Grey Hills" 43 19}
+        name=allow return
+        {TBC_TRANSITION 43-44 10-31 Grey_Hills _"Grey Hills" 43 19}
     [/event]
 
     [event]
-    name=start
+        name=start
         {PLACE_IMAGE scenery/bookshelf-1.png 1 3}
         {PLACE_IMAGE items/box.png 14 1}
         {PLACE_IMAGE items/box.png 7 6}
@@ -170,459 +170,186 @@
         {PLACE_IMAGE scenery/bookshelf-2.png 6 1}
         {PLACE_IMAGE scenery/bookshelf-3.png 3 2}
         {PLACE_IMAGE cabinet.png 2 2}
-    [remove_shroud]
-        side=1
-    [/remove_shroud]
-    [place_shroud]
-        side=1
-        terrain=Xol,Iwr,Mm^Xm
-    [/place_shroud]
-    [if]
-        [variable]
-            name=quests.overall
-            less_than=9
-        [/variable]
-        [then]
-            [unit]
-                side=2
-                id=Konrad
-                name=_"Konrad"
-                x,y=3,3
-                type=Royal Warrior
-                canrecruit=yes
-                [modifications]
-                    [advance]
-                        id=portrait
-                        [effect]
-                            apply_to=profile
-                            portrait="portraits/humans/transparent/marshal-2.png"
-                        [/effect]
-                    [/advance]
-                [/modifications]
-            [/unit]
-        [/then]
-    [/if]
-    [if]
-        [variable]
-            name=quests.thunderhold_recruited_pikeman
-            equals=yes
-        [/variable]
-        [else] 
-            [unit]
-                type=Halberdier
-                x,y=14,13
-                side=2
-                id=hired_halberdier
-                generate_name=yes
-                ai_special=guardian
-                canrecruit=yes
-                random_traits=yes
-                [modifications]
-                [advance]
-                    id=portrait
-                    [effect]
-                        apply_to=profile
-                        portrait="portraits/humans/transparent/halberdier.png"
-                    [/effect]
-                [/advance]
-                 [/modifications]
-            [/unit]
-            [if]
+        [remove_shroud]
+            side=1
+        [/remove_shroud]
+        [place_shroud]
+            side=1
+            terrain=Xol,Iwr,Mm^Xm
+        [/place_shroud]
+        [if]
             [variable]
-                name=party_members.length
-                less_than=5
+                name=quests.overall
+                less_than=9
             [/variable]
-            [not]
-                [variable]
-                    name=quests.thunderhold_told_about_merc
-                    equals=yes
-                [/variable]
-            [/not]
             [then]
-                [event]
-                    name=moveto
-                    [filter]
-                        x,y=1-25,1-28
-                        side=1
-                    [/filter]
-                    [message]
-                        speaker=Rimaru
-                        message=_"Have you noticed that we aren't very numerous? We need more people or we won't defeat our enemies."
-                    [/message]
-                    [message]
-                        speaker=Burke
-                        message=_"You're the manager of this team, what do you suggest?"
-                    [/message]
-                    [message]
-                        speaker=Rimaru
-                        message=_"I was told that one skilled fighter lives here, in Thunderhold. He likes adventure, and he likes being hired. Unlike most mercenaries, he does not pick the highest bid, be prefers the choice that looks reliable and righteous to him, so he might be quite reliable. How about hiring him?"
-                    [/message]
-                    {VARIABLE quests.thunderhold_told_about_merc yes}
-                [/event]
+                [unit]
+                    side=2
+                    id=Konrad
+                    name=_"Konrad"
+                    x,y=3,3
+                    type=Royal Warrior
+                    canrecruit=yes
+                    [modifications]
+                        [advance]
+                            id=portrait
+                            [effect]
+                                apply_to=profile
+                                portrait="portraits/humans/transparent/marshal-2.png"
+                            [/effect]
+                        [/advance]
+                    [/modifications]
+                [/unit]
             [/then]
-            [/if]
-            [event]
-            name=moveto
-            first_time_only=no
-            id=halberdier_hiring
-            [filter]
-                side=1
-                [filter_adjacent]
-                x,y=14,13
-                [/filter_adjacent]
-            [/filter]
-            [store_gold]
-                side=1
-                variable=gold
-            [/store_gold]
-            [message]
-                speaker=hired_halberdier
-                message= _ "Hello. You look like good adventurers to me. I can be yours during the adventure, all I need is you to pay me 80 gold."
-                [option]
-                message=_"Indeed. We need anybody. Here's the money."
-                [show_if]
-                    [variable]
-                        name=gold
-                        greater_than_equal_to=80
-                    [/variable]
-                [/show_if]
-                [command]
-                    {VARIABLE quests.thunderhold_recruited_pikeman yes}
-                    [store_unit]
-                        [filter]
-                            id=hired_halberdier
-                        [/filter]
-                        variable=merc_store
-                    [/store_unit]
-                    {VARIABLE merc_store.side 1}
-                    {VARIABLE merc_store.variables.hero yes}
-                    [unstore_unit]
-                        variable=merc_store
-                        find_vacant=no
-                    [/unstore_unit]
-                    {CLEAR_VARIABLE merc_store}
-                    {VARIABLE party_members[$party_members.length].id hired_halberdier}
-                    [remove_event]
-                        id=halberdier_hiring
-                    [/remove_event]
-                [/command]
-                [/option]
-                [option]
-                message=_"No, maybe later."
-                [show_if]
-                    [variable]
-                        name=gold
-                        greater_than_equal_to=80
-                    [/variable]
-                [/show_if]
-                [command]
-                [/command]
-                [/option]
-                [option]
-                message=_"I think that we don't have enough gold to afford your services at the moment."
-                [show_if]
-                    [variable]
-                        name=gold
-                        less_than=80
-                    [/variable]
-                [/show_if]
-                [command]
-                [/command]
-                [/option]
-            [/message]
-            {CLEAR_VARIABLE gold}
-            [/event]
-        [/else]
-    [/if]
-
-    [if]
-        [variable]
-            name=quests.entered_thunderhold
-            equals=yes
-        [/variable]
-        [then]
-            [fire_event]
-                name=allow return
-            [/fire_event]
-        [/then]
-        [else] 
-            [message]
-                speaker=Burke
-                message=_"I hope that the help with bandits will be sufficient for him to help us in return. It costed me almost my entire army!"
-            [/message]
-            [unit]
-                x,y=34,1
-                side=3
-                gender=male
-                type=Bringer of Light
-                id=Luke
-                name=_"Luke, The Bringer of Light"
-                canrecruit=yes
-            [/unit]
-            [move_unit]
-                id=Luke
-                to_x=34
-                to_y=19
-                fire_event=no
-            [/move_unit]
-            [message]
-                speaker=she_brother
-                message=_"Oh, no! That's Luke, the Bringer of Light, the leader of Brothers of Light. He claims that he is a close descendant of gods' children and that he possesses such knowledge of gods that they contacted him and gave him great power. Truth is that he spent a lot of time in libraries, about two decades, then he travelled around the world and came back recently, as powerful as nobody ever was before. In fact, he has brought the Child."
-            [/message]
-            [message]
-                speaker=she_brother
-                message=_"I believe that he learned some dark secrets in the library and experimented with the new knowledge during his travels. I have no idea if the Child is merely an illusion or something greater like an idol that gains power from the redirected power of prayers of believers. In any case, I am sure that the things he's doing were not ordered by gods."
-            [/message]
-            [message]
-                speaker=Rimaru
-                message=_"I like to see you here, Luke. We can slay you here and finish your foul game, without having to kill your minions and lackeys."
-            [/message]
-            [message]
-                speaker=faithful_lieutenant
-                message=_"He's allmighty, we cannot defeat him. I suggest to escape."
-            [/message]
-            [message]
-                speaker=Luke
-                message=_"Well, you can try anything you want. It does not really matter, because you will die regardless of your choice. And your petty rebellion will die with you. Nobody turns away from gods and survives for long."
-                [option]
-                message=_"We know who you are, necromancer. Stop pretending to be what you are something you are not."
-                [command]
-                    [message]
-                        speaker=Luke
-                        message=_"I am not a necromancer. Rather the opposite, I am not an unholy cultist, I was blessed by gods..."
-                    [/message]
-                    [message]
-                        speaker=Rimaru
-                        message=_"What gods, T'Om the God of Blood and Ba Draas the Thief God?"
-                    [/message]
-                    [message]
-                        speaker=Luke
-                        message=_"You shall pay with blood for this."
-                    [/message]
-                    [message]
-                        speaker=bandit_merc
-                        message=_"So you want a sacrifice for your old pal T'Om?"
-                    [/message]
-                [/command]
-                [/option]
-                [option]
-                message=_"It is not too late. Lay down your weapons and repent for your misdeeds, Luke."
-                [command]
-                    {TBC_DIPLOMACY_TRIED}
-                    [message]
-                        speaker=Luke
-                        message=_"Who do you think you are? You're nobody. I am the leader of the Brothers of Light, blessed by gods and I never make mistakes nor commit misdeeds. Do you really think that you are right if I say otherwise?"
-                    [/message]
-                    [message]
-                        speaker=Rimaru
-                        message=_"I care about none of your titles, monster. None of them speaks the truth anyway."
-                    [/message]
-                    [message]
-                        speaker=Luke
-                        message=_"Me neither when it comes to killing the atheists."
-                    [/message]
-                [/command]
-                [/option]
-                [option]
-                message=_"Die, villain!"
-                [command]
-                    [message]
-                        speaker=Luke
-                        message=_"Do you think that you can kill the Chosen One, the Guardian of the Child of Gods?"
-                    [/message]
-                    [message]
-                        speaker=player
-                        message=_"Indeed."
-                    [/message]
-                    [message]
-                        speaker=Luke
-                        message=_"So face the consequences of your own naïvety, puny human!"
-                    [/message]
-                [/command]
-                [/option]
-            [/message]
-            [message]
-                speaker=elf_merc
-                message=_"Now this one has a pride so big that I would hit it with an arrow with closed eyes, at night, while standing on a running horse's back during a thunderstorm!"
-            [/message]
-            [message]
-                speaker=Burke
-                message=_"Okay, so nice that he came himself, so let's surround him and attack him collectively to make it hard for him to defend."
-            [/message]
-            [message]
-                speaker=Luke
-                message=_"I can move my soldiers across large distances with ease. This deadly squad will slay you without getting my hands dirty. Behold and say your last wishes, which... shall not be fulfilled."
-            [/message]
-            [unit]
-                side=3
-                type=General
-                id=boss_1
-                generate_name=yes
-                x,y=36,18
-                random_traits=yes
-                animate=yes
-            [/unit]
-            {VARIABLE quantity $party_members.length}
-#ifdef HARD
-                {VARIABLE_OP quantity multiply 1.8}
-#endif
-#ifdef NORMAL
-                {VARIABLE_OP quantity multiply 1.5}
-#endif
-#ifdef EASY
-                {VARIABLE_OP quantity multiply 1.2}
-#endif
-            [while]
-                [variable]
-                    name=quantity
-                    greater_than=0
-                [/variable]
-                [do]
-                    {VARIABLE_OP unit_type rand "Spearman,Javelineer,Swordsman,Pikeman,Bowman,Longbowman,Heavy Infantryman,Shock Trooper,Lieutenant,White Mage"}
-                    {GENERIC_UNIT 3 $unit_type 36 18}
-                    [+unit]
-                        animate=yes
-                    [/unit]
-                    {VARIABLE_OP quantity sub 1}
-                [/do]
-            [/while]
-            {CLEAR_VARIABLE quantity,unit_type}
-            [message]
-                speaker=Luke
-                message=_"Kill them all! You can sell their corpses to necromancers, they deserve it and our order needs any gold that can be gained."
-            [/message]
-            [message]
-                speaker=Rimaru
-                message=_"Tell them the truth, villain! Tell them and us what dark secrets have you found in libraries and what foul magic you used to create that idol you call the Child of Gods. Gods would not order you to kill people, so don't pretend that you're their closest servant! You are nothing but a black sorcerer dressed in white robes, who learned to disguise the utter darkness of his heart by white robes and shining halo of a white mage!"
-            [/message]
-            [message]
-                speaker=Luke
-                message=_"Do you really think that your prattle will change the opinion of my loyal warriors? Why are you so sure that your sacrilegious words can befoul the minds of the righteous? Do you really believe that your heretic lies will shadow the truth my pious followers know?"
-            [/message]
-            [message]
-                speaker=Rimaru
-                message=_"Truth? You are spreading lies on every step, and they thrive and form webs that cover this world. You are a spider that enveloped this world in his lies so densely that he's considered to be a god. You were supposed to be a healer who protects other from disease, yet you are commanding the king and ruling your world from your throne built on lies."
-            [/message]
-            [message]
-                speaker=Luke
-                message=_"I can't stand his lunatic talks, deal with him!"
-            [/message]
-            [move_unit]
-                id=Luke
-                to_x=29
-                to_y=1
-                fire_event=no
-            [/move_unit]
-            [kill]
-                id=Luke
-                fire_event=no
-                animate=no
-            [/kill]
-            [message]
-                speaker=boss_1
-                message=_"To battle, brave heroes!"
-                [option]
-                message=_"Stop. Why are you so sure that your leader is right?"
-                [command]
-                    [message]
-                        speaker=boss_1
-                        message=_"Because he is the Chosen One."
-                    [/message]
-                    [message]
-                        speaker=player
-                        message=_"If you see a man capable of unleashing great magical power, what would you think he is under normal circumstances? A demon? A mighty wizard? A man possessed by the Queen of Darkness?"
-                    [/message]
-                    [message]
-                        speaker=boss_1
-                        message=_"Well, demons have horns. They're easy to identify. Wizards rarely have limitless power, so I'd think that he would be possessed by the Queen of Darkness if he had no horns."
-                    [/message]
-                    [message]
-                        speaker=player
-                        message=_"So why are you so sure that your beloved Luke isn't possessed by the Queen of Darkness? There are stories about her possessing various people in important positions and trying to seize power without needing a huge army."
-                    [/message]
-                    [message]
-                        speaker=boss_1
-                        message=_"The Queen of Darkness brings Darkness, not Light. Luke brought us the brightest of lights, the Divine Child."
-                    [/message]
-                    [message]
-                        speaker=player
-                        message=_"Why are you so sure that it isn't just a deceptive plot of Queen of Darkness? She can hide her darkness and convert it to a dark essence that looks like light."
-                    [/message]
-                    [message]
-                        speaker=she_brother
-                        message=_"He studied for long and travelled for long. What if he found a way how to become a vessel for the Queen of Darkness and became her host to bring power to both of them?"
-                    [/message]
-                    [message]
-                        speaker=boss_1
-                        message=_"Maybe his nature can be questioned, but I have seen the Child. He is... amazing. One look at him removes all doubts about his nature. If you saw him too..."
-                    [/message]
-                    [message]
-                        speaker=player
-                        message=_"I would not be tricked by some mind-affecting drugs evaporated into air with other incense."
-                    [/message]
-                    [message]
-                        speaker=boss_1
-                        message=_"You're wrong. If you changed your mind, I would be merciful, but not when you think like this."
-                    [/message]
-                    {TBC_DIPLOMACY_TRIED}
-                [/command]
-                [/option]
-                [option]
-                message=_"Come at me. Die fighting for a necromancer so that he could use your bodies for the next fight!"
-                [command]
-                    [message]
-                        speaker=boss_1
-                        message=_"He's not a necromancer! Attack them with divine wrath, my soldiers!"
-                    [/message]
-                    [message]
-                        speaker=Rimaru
-                        message=_"I think that it was wrath that caused a lot of problems to our gods in mythical times. Overcoming it was the key to success."
-                    [/message]
-                    [message]
-                        speaker=boss_1
-                        message=_"Kill him first! Bring me the head of that twister of words!"
-                    [/message]
-                [/command]
-                [/option]
-                [option]
-                message=_"You have chosen your destiny. We'll kill you all without mercy, because you're a load of imbeciles and you don't deserve compassion."
-                [command]
-                    [message]
-                        speaker=boss_1
-                        message=_"That courage will abandon you very soon."
-                    [/message]
-                [/command]
-                [/option]
-            [/message]
-            {VARIABLE quests.entered_thunderhold yes}
-        [/else]
-    [/if]
-
-    [if]
-        [variable]
-            name=quests.overall
-            equals=8
-        [/variable]
-        [not]
+        [/if]
+        [if]
             [variable]
-                name=quests.luke_told_rimaru_about_sister
+                name=quests.thunderhold_recruited_pikeman
                 equals=yes
             [/variable]
-        [/not]
-        [then]
-            [event]
-                name=moveto
-                [filter]
-                    side=1
-                    y=16-22
-                [/filter]
-                [store_unit]
+            [else]
+                [unit]
+                    type=Halberdier
+                    x,y=14,13
+                    side=2
+                    id=hired_halberdier
+                    generate_name=yes
+                    ai_special=guardian
+                    canrecruit=yes
+                    random_traits=yes
+                    [modifications]
+                        [advance]
+                            id=portrait
+                            [effect]
+                                apply_to=profile
+                                portrait="portraits/humans/transparent/halberdier.png"
+                            [/effect]
+                        [/advance]
+                    [/modifications]
+                [/unit]
+                [if]
+                    [variable]
+                        name=party_members.length
+                        less_than=5
+                    [/variable]
+                    [not]
+                        [variable]
+                            name=quests.thunderhold_told_about_merc
+                            equals=yes
+                        [/variable]
+                    [/not]
+                    [then]
+                        [event]
+                            name=moveto
+                            [filter]
+                                x,y=1-25,1-28
+                                side=1
+                            [/filter]
+                            [message]
+                                speaker=Rimaru
+                                message=_"Have you noticed that we aren't very numerous? We need more people or we won't defeat our enemies."
+                            [/message]
+                            [message]
+                                speaker=Burke
+                                message=_"You're the manager of this team, what do you suggest?"
+                            [/message]
+                            [message]
+                                speaker=Rimaru
+                                message=_"I was told that one skilled fighter lives here, in Thunderhold. He likes adventure, and he likes being hired. Unlike most mercenaries, he does not pick the highest bid, be prefers the choice that looks reliable and righteous to him, so he might be quite reliable. How about hiring him?"
+                            [/message]
+                            {VARIABLE quests.thunderhold_told_about_merc yes}
+                        [/event]
+                    [/then]
+                [/if]
+                [event]
+                    name=moveto
+                    first_time_only=no
+                    id=halberdier_hiring
                     [filter]
-                        id=Rimaru
+                        side=1
+                        [filter_adjacent]
+                            x,y=14,13
+                        [/filter_adjacent]
                     [/filter]
-                    variable=rimaru_coords
-                    kill=no
-                [/store_unit]
+                    [store_gold]
+                        side=1
+                        variable=gold
+                    [/store_gold]
+                    [message]
+                        speaker=hired_halberdier
+                        message= _ "Hello. You look like good adventurers to me. I can be yours during the adventure, all I need is you to pay me 80 gold."
+                        [option]
+                            message=_"Indeed. We need anybody. Here's the money."
+                            [show_if]
+                                [variable]
+                                    name=gold
+                                    greater_than_equal_to=80
+                                [/variable]
+                            [/show_if]
+                            [command]
+                                {VARIABLE quests.thunderhold_recruited_pikeman yes}
+                                [store_unit]
+                                    [filter]
+                                        id=hired_halberdier
+                                    [/filter]
+                                    variable=merc_store
+                                [/store_unit]
+                                {VARIABLE merc_store.side 1}
+                                {VARIABLE merc_store.variables.hero yes}
+                                [unstore_unit]
+                                    variable=merc_store
+                                    find_vacant=no
+                                [/unstore_unit]
+                                {CLEAR_VARIABLE merc_store}
+                                {VARIABLE party_members[$party_members.length].id hired_halberdier}
+                                [remove_event]
+                                    id=halberdier_hiring
+                                [/remove_event]
+                            [/command]
+                        [/option]
+                        [option]
+                            message=_"No, maybe later."
+                            [show_if]
+                                [variable]
+                                    name=gold
+                                    greater_than_equal_to=80
+                                [/variable]
+                            [/show_if]
+                            [command]
+                            [/command]
+                        [/option]
+                        [option]
+                            message=_"I think that we don't have enough gold to afford your services at the moment."
+                            [show_if]
+                                [variable]
+                                    name=gold
+                                    less_than=80
+                                [/variable]
+                            [/show_if]
+                            [command]
+                            [/command]
+                        [/option]
+                    [/message]
+                    {CLEAR_VARIABLE gold}
+                [/event]
+            [/else]
+        [/if]
+
+        [if]
+            [variable]
+                name=quests.entered_thunderhold
+                equals=yes
+            [/variable]
+            [then]
+                [fire_event]
+                    name=allow return
+                [/fire_event]
+            [/then]
+            [else]
+                [message]
+                    speaker=Burke
+                    message=_"I hope that the help with bandits will be sufficient for him to help us in return. It costed me almost my entire army!"
+                [/message]
                 [unit]
                     x,y=34,1
                     side=3
@@ -634,78 +361,155 @@
                 [/unit]
                 [move_unit]
                     id=Luke
-                    to_x=$rimaru_coords.x
-                    to_y=$rimaru_coords.y
+                    to_x=34
+                    to_y=19
                     fire_event=no
                 [/move_unit]
-                {CLEAR_VARIABLE rimaru_coords}
                 [message]
-                    speaker=Luke
-                    message=_"Rimaru, there is one thing I decided to let you know."
+                    speaker=she_brother
+                    message=_"Oh, no! That's Luke, the Bringer of Light, the leader of Brothers of Light. He claims that he is a close descendant of gods' children and that he possesses such knowledge of gods that they contacted him and gave him great power. Truth is that he spent a lot of time in libraries, about two decades, then he travelled around the world and came back recently, as powerful as nobody ever was before. In fact, he has brought the Child."
+                [/message]
+                [message]
+                    speaker=she_brother
+                    message=_"I believe that he learned some dark secrets in the library and experimented with the new knowledge during his travels. I have no idea if the Child is merely an illusion or something greater like an idol that gains power from the redirected power of prayers of believers. In any case, I am sure that the things he's doing were not ordered by gods."
                 [/message]
                 [message]
                     speaker=Rimaru
-                    message=_"What? I already know that you're a necromancer."
+                    message=_"I like to see you here, Luke. We can slay you here and finish your foul game, without having to kill your minions and lackeys."
+                [/message]
+                [message]
+                    speaker=faithful_lieutenant
+                    message=_"He's allmighty, we cannot defeat him. I suggest to escape."
                 [/message]
                 [message]
                     speaker=Luke
-                    message=_"No, it's about your sister."
+                    message=_"Well, you can try anything you want. It does not really matter, because you will die regardless of your choice. And your petty rebellion will die with you. Nobody turns away from gods and survives for long."
+                    [option]
+                        message=_"We know who you are, necromancer. Stop pretending to be what you are something you are not."
+                        [command]
+                            [message]
+                                speaker=Luke
+                                message=_"I am not a necromancer. Rather the opposite, I am not an unholy cultist, I was blessed by gods..."
+                            [/message]
+                            [message]
+                                speaker=Rimaru
+                                message=_"What gods, T'Om the God of Blood and Ba Draas the Thief God?"
+                            [/message]
+                            [message]
+                                speaker=Luke
+                                message=_"You shall pay with blood for this."
+                            [/message]
+                            [message]
+                                speaker=bandit_merc
+                                message=_"So you want a sacrifice for your old pal T'Om?"
+                            [/message]
+                        [/command]
+                    [/option]
+                    [option]
+                        message=_"It is not too late. Lay down your weapons and repent for your misdeeds, Luke."
+                        [command]
+                            {TBC_DIPLOMACY_TRIED}
+                            [message]
+                                speaker=Luke
+                                message=_"Who do you think you are? You're nobody. I am the leader of the Brothers of Light, blessed by gods and I never make mistakes nor commit misdeeds. Do you really think that you are right if I say otherwise?"
+                            [/message]
+                            [message]
+                                speaker=Rimaru
+                                message=_"I care about none of your titles, monster. None of them speaks the truth anyway."
+                            [/message]
+                            [message]
+                                speaker=Luke
+                                message=_"Me neither when it comes to killing the atheists."
+                            [/message]
+                        [/command]
+                    [/option]
+                    [option]
+                        message=_"Die, villain!"
+                        [command]
+                            [message]
+                                speaker=Luke
+                                message=_"Do you think that you can kill the Chosen One, the Guardian of the Child of Gods?"
+                            [/message]
+                            [message]
+                                speaker=player
+                                message=_"Indeed."
+                            [/message]
+                            [message]
+                                speaker=Luke
+                                message=_"So face the consequences of your own naïvety, puny human!"
+                            [/message]
+                        [/command]
+                    [/option]
                 [/message]
                 [message]
-                    speaker=Rimaru
-                    message=_"You resurrected her body with your necromantic abilities and made her your mistress?"
+                    speaker=elf_merc
+                    message=_"Now this one has a pride so big that I would hit it with an arrow with closed eyes, at night, while standing on a running horse's back during a thunderstorm!"
+                [/message]
+                [message]
+                    speaker=Burke
+                    message=_"Okay, so nice that he came himself, so let's surround him and attack him collectively to make it hard for him to defend."
                 [/message]
                 [message]
                     speaker=Luke
-                    message=_"No, nothing like that. Our refusal to help her that made you eventually leave our order wasn't done because of laziness. It was done on purpose. A great talent was seen within you, so it was decided to use your relative's sickness to force you to work as hard as you could and improve your skill with an amazing leap. They were sure that you could do that, but you spent too much effort conspiring, trying to get somebody to help her instead of finding a cure yourself."
+                    message=_"I can move my soldiers across large distances with ease. This deadly squad will slay you without getting my hands dirty. Behold and say your last wishes, which... shall not be fulfilled."
                 [/message]
-                [message]
-                    speaker=Rimaru
-                    message=_"Now I hear from your own mouth how futile is it to rely on any Brother of Larceny."
-                [/message]
-                [message]
-                    speaker=Luke
-                    message=_"You should have relied on one particular Brother of Light. Yourself. But you had no faith in yourself, you didn't try hard enough. There was no doubt that you could do it, but you didn't put enough effort into it. You decided to pick another strategy and it was too late when your superiors realised that you were conspiring how to get any of us to save her instead of saving her yourself."
-                [/message]
-                [message]
-                    speaker=Rimaru
-                    message=_"So she died because I didn't have enough faith in myself? I think that the amount of enough faith in myself I have is just fine, you are the one who has way too much faith in himself and the justness of his deeds. You put a person into great danger only to make me learn faster, to achieve some level of skill in a few days instead of a year it would take me normally."
-                [/message]
-                [message]
-                    speaker=Luke
-                    message=_"Don't blame me, it was your failure. You were capable of saving her, and you failed. As you will fail now, when my army meets you in a bloody clash."
-                [/message]
-                {TBC_SPAWN_UNITS_NO_LEADER 3 0.7 "Spearman,Heavy Infantryman,Fencer,Bowman" 11 31}
-                {TBC_SPAWN_UNITS_NO_LEADER 3 0.4 "Swordsman,Pikeman,Javelineer,Duelist,Longbowman" 24 30}
-                {TBC_SPAWN_UNITS_NO_LEADER 3 0.4 "Swordsman,Pikeman,Javelineer,Duelist,Longbowman" 3 27}
-                {TBC_SPAWN_UNITS_NO_LEADER 3 0.3 "Royal Guard,Halberdier,Pilum Master,Master Bowman" 10 13}
-                {TBC_SPAWN_UNITS_NO_LEADER 3 0.4 "Swordsman,Pikeman,Javelineer,Duelist,Longbowman" 25 18}
                 [unit]
-                    # Make sure that nobody will sneak into the castle and finish the scenario too early.
                     side=3
-                    x,y=8,7
-                    type=Iron Mauler
+                    type=General
+                    id=boss_1
                     generate_name=yes
-                    [modifications]
-                        [advance]
-                            [effect]
-                            apply_to=movement
-                            set=0
-                            [/effect]
-                        [/advance]
-                    [/modifications]
+                    x,y=36,18
+                    random_traits=yes
+                    animate=yes
                 [/unit]
+                {VARIABLE quantity $party_members.length}
+#ifdef HARD
+                {VARIABLE_OP quantity multiply 1.8}
+#endif
+#ifdef NORMAL
+                {VARIABLE_OP quantity multiply 1.5}
+#endif
+#ifdef EASY
+                {VARIABLE_OP quantity multiply 1.2}
+#endif
+                [while]
+                    [variable]
+                        name=quantity
+                        greater_than=0
+                    [/variable]
+                    [do]
+                        {VARIABLE_OP unit_type rand "Spearman,Javelineer,Swordsman,Pikeman,Bowman,Longbowman,Heavy Infantryman,Shock Trooper,Lieutenant,White Mage"}
+                        {GENERIC_UNIT 3 $unit_type 36 18}
+                        [+unit]
+                            animate=yes
+                        [/unit]
+                        {VARIABLE_OP quantity sub 1}
+                    [/do]
+                [/while]
+                {CLEAR_VARIABLE quantity,unit_type}
+                [message]
+                    speaker=Luke
+                    message=_"Kill them all! You can sell their corpses to necromancers, they deserve it and our order needs any gold that can be gained."
+                [/message]
                 [message]
                     speaker=Rimaru
-                    message=_"Do you think that your gibberish can make me feel guilty, Luke the Impostor of Light? No, it can't. Now, I'll kill you. With my friends, we can face you."
+                    message=_"Tell them the truth, villain! Tell them and us what dark secrets have you found in libraries and what foul magic you used to create that idol you call the Child of Gods. Gods would not order you to kill people, so don't pretend that you're their closest servant! You are nothing but a black sorcerer dressed in white robes, who learned to disguise the utter darkness of his heart by white robes and shining halo of a white mage!"
                 [/message]
                 [message]
                     speaker=Luke
-                    message=_"Yes, we might fight, but I don't want to debase myself with that. I might get a bruise and that can be quite annoying. My army will take care of you. Goodbye."
+                    message=_"Do you really think that your prattle will change the opinion of my loyal warriors? Why are you so sure that your sacrilegious words can befoul the minds of the righteous? Do you really believe that your heretic lies will shadow the truth my pious followers know?"
+                [/message]
+                [message]
+                    speaker=Rimaru
+                    message=_"Truth? You are spreading lies on every step, and they thrive and form webs that cover this world. You are a spider that enveloped this world in his lies so densely that he's considered to be a god. You were supposed to be a healer who protects other from disease, yet you are commanding the king and ruling your world from your throne built on lies."
+                [/message]
+                [message]
+                    speaker=Luke
+                    message=_"I can't stand his lunatic talks, deal with him!"
                 [/message]
                 [move_unit]
                     id=Luke
-                    to_x=34
+                    to_x=29
                     to_y=1
                     fire_event=no
                 [/move_unit]
@@ -715,937 +519,1137 @@
                     animate=no
                 [/kill]
                 [message]
-                    speaker=Rimaru
-                    message=_"Coward! Come back!"
+                    speaker=boss_1
+                    message=_"To battle, brave heroes!"
+                    [option]
+                        message=_"Stop. Why are you so sure that your leader is right?"
+                        [command]
+                            [message]
+                                speaker=boss_1
+                                message=_"Because he is the Chosen One."
+                            [/message]
+                            [message]
+                                speaker=player
+                                message=_"If you see a man capable of unleashing great magical power, what would you think he is under normal circumstances? A demon? A mighty wizard? A man possessed by the Queen of Darkness?"
+                            [/message]
+                            [message]
+                                speaker=boss_1
+                                message=_"Well, demons have horns. They're easy to identify. Wizards rarely have limitless power, so I'd think that he would be possessed by the Queen of Darkness if he had no horns."
+                            [/message]
+                            [message]
+                                speaker=player
+                                message=_"So why are you so sure that your beloved Luke isn't possessed by the Queen of Darkness? There are stories about her possessing various people in important positions and trying to seize power without needing a huge army."
+                            [/message]
+                            [message]
+                                speaker=boss_1
+                                message=_"The Queen of Darkness brings Darkness, not Light. Luke brought us the brightest of lights, the Divine Child."
+                            [/message]
+                            [message]
+                                speaker=player
+                                message=_"Why are you so sure that it isn't just a deceptive plot of Queen of Darkness? She can hide her darkness and convert it to a dark essence that looks like light."
+                            [/message]
+                            [message]
+                                speaker=she_brother
+                                message=_"He studied for long and travelled for long. What if he found a way how to become a vessel for the Queen of Darkness and became her host to bring power to both of them?"
+                            [/message]
+                            [message]
+                                speaker=boss_1
+                                message=_"Maybe his nature can be questioned, but I have seen the Child. He is... amazing. One look at him removes all doubts about his nature. If you saw him too..."
+                            [/message]
+                            [message]
+                                speaker=player
+                                message=_"I would not be tricked by some mind-affecting drugs evaporated into air with other incense."
+                            [/message]
+                            [message]
+                                speaker=boss_1
+                                message=_"You're wrong. If you changed your mind, I would be merciful, but not when you think like this."
+                            [/message]
+                            {TBC_DIPLOMACY_TRIED}
+                        [/command]
+                    [/option]
+                    [option]
+                        message=_"Come at me. Die fighting for a necromancer so that he could use your bodies for the next fight!"
+                        [command]
+                            [message]
+                                speaker=boss_1
+                                message=_"He's not a necromancer! Attack them with divine wrath, my soldiers!"
+                            [/message]
+                            [message]
+                                speaker=Rimaru
+                                message=_"I think that it was wrath that caused a lot of problems to our gods in mythical times. Overcoming it was the key to success."
+                            [/message]
+                            [message]
+                                speaker=boss_1
+                                message=_"Kill him first! Bring me the head of that twister of words!"
+                            [/message]
+                        [/command]
+                    [/option]
+                    [option]
+                        message=_"You have chosen your destiny. We'll kill you all without mercy, because you're a load of imbeciles and you don't deserve compassion."
+                        [command]
+                            [message]
+                                speaker=boss_1
+                                message=_"That courage will abandon you very soon."
+                            [/message]
+                        [/command]
+                    [/option]
                 [/message]
-                [message]
-                    speaker=bandit_merc
-                    message=_"This dude must really hate bruises, I can tell."
-                [/message]
-                {VARIABLE quests.luke_told_rimaru_about_sister yes}
-            [/event]
-        [/then]
-    [/if]
+                {VARIABLE quests.entered_thunderhold yes}
+            [/else]
+        [/if]
 
-    [if]
-        [variable]
-            name=quests.overall
-            less_than=7
-        [/variable]
-        [then]
-            [event]
-                name=moveto
-                [filter]
-                    side=1
-                    x,y=1-5,1-6
-                [/filter]
-                [fire_event]
-                    name=allow return
-                [/fire_event]
-                [message]
-                    speaker=Konrad
-                    message=_"Welcome. I was told that you would come. Please, come here, to my room."
-                [/message]
-                [move_unit]
-                    side=1
-                    to_x=3
-                    to_y=4
-                    fire_event=no
-                [/move_unit]
-                [message]
-                    speaker=Konrad
-                    message=_"What do you want, Burke?"
-                [/message]
-                [message]
-                    speaker=Burke
-                    message=_"Let the White Mage speak, he can explain it better."
-                [/message]
-                [message]
-                    speaker=Konrad
-                    message=_"So, what do you want, Rimaru? Don't be scared, I was told your name by some of our lookouts and you are quite a famous person."
-                [/message]
-                [message]
-                    speaker=Rimaru
-                    message=_"If you see a man wielding unimaginable magical powers, what would you think about him? Powers that you have never seen any mage from Academy use, not even in demonstrations of their craft?"
-                [/message]
-                [message]
-                    speaker=Konrad
-                    message=_"I'd assume that he found some ancient artifacts of power. Or that he discovered some unusual powers, something that is forbidden in the Academy. Most likely something with black magic, they don't forbid spells that aren't evil in nature."
-                [/message]
-                [message]
-                    speaker=Rimaru
-                    message=_"Okay, so it's most likely somebody who dabbed into necromancy in a good way. I will tell you a story of a man. He wanted to be a mage, so he joined the Brothers of Light. The Academy was too far away from his home probably. Instead of healing others, he spent decades in library and on travels. After one particularly long journey, he returned home with great powers that amazed everyone. How would you classify this man?"
-                [/message]
-                [message]
-                    speaker=Konrad
-                    message=_"I think I know who are you talking about, but I will try to continue your game. In this case, I would think that he successfully investigated where some powerful relic is and used its power, pretending that it's his power. But because the Brothers of Light study various powers of darkness so that they could fight them effectively, I might also conclude that he found an ancient evil entity like Argan the Lich Lord and made a pact with him."
-                [/message]
-                [message]
-                    speaker=Rimaru
-                    message=_"As you guessed, I am speaking about Luke, the Bringer of Light. He returned with new powers and everybody reveres him and follows him now."
-                [/message]
-                [message]
-                    speaker=Konrad
-                    message=_"Yes. But there is a little problem in your analogy. The Child, Reezer by name. He wasn't crafted by an evil entity, I know that."
-                    [option]
-                    message=_"Do <i>you</i> have to start with that too? I thought you were a reasonable man."
-                    [command]
-                        [message]
-                            speaker=Konrad
-                            message=_"I know how it sounds, but please listen to me."
-                        [/message]
-                        [message]
-                            speaker=orc
-                            message=_"I have a feeling that all of you humans are insane."
-                        [/message]
-                        [message]
-                            speaker=she_brother
-                            message=_"I really wonder what will he say now."
-                        [/message]
-                    [/command]
-                    [/option]
-                    [option]
-                    message=_"If you were an evil entity of incredible power, why should you be unable to use black magic for some faint illumination and weak healing too?"
-                    [command]
-                        [message]
-                            speaker=Konrad
-                            message=_"I know that there is no logic in my words, but..."
-                        [/message]
-                        [message]
-                            speaker=faithful_lieutenant
-                            message=_"I must tell that I believe you."
-                        [/message]
-                        [message]
-                            speaker=bandit_merc
-                            message=_"How about simply killing him and impersonating him? He speaks like Luke's lackeys."
-                        [/message]
-                    [/command]
-                    [/option]
-                    [option]
-                    message=_"What was it, then?"
-                    [command]
-                    [/command]
-                    [/option]
-                [/message]
-                [message]
-                    speaker=Konrad
-                    message=_"It must have been a son of the gods. He looked so... otherwordly. Nothing in this world can have such grace. Believe me or not, but you will not persuade me about his nature. The rational part of myself tried to make sense of it, but I could not. It could not be caused by any narcotic substances in the air, because it was in an open area and the wind was blowing. It could not be magic, because I have seen what magic can do and what it cannot."
-                [/message]
-                [message]
-                    speaker=Rimaru
-                    message=_"So do you think that Luke snatched the child of gods somewhere so that we could misuse it as a demonstration of his supremacy?"
-                [/message]
-                [message]
-                    speaker=she_brother
-                    message=_"Excellent. So now you believe that there is actually something divine in this plot."
-                [/message]
-                [message]
-                    speaker=Konrad
-                    message=_"That is what I think, yes. I am afraid of them, so I would not tell it openly, but I am sure that I can trust you in this, Rimaru. Luke clearly could not give birth to little Reezer, because he is a man and he doesn't have a womb."
-                    [option]
-                    message=_"He must have stolen him somewhere. Do you think that the woman that brought him up chose to give him away?"
-                    [command]
-                        [message]
-                            speaker=Rimaru
-                            message=_"I doubt that. Mothers don't leave their children to strangers unless they're born from rape. He either stole him or forced the poor woman to let him take her child."
-                        [/message]
-                        [message]
-                            speaker=Burke
-                            message=_"I think that rumours of such a magnificent child would spread quickly. How did he get to him first?"
-                        [/message]
-                    [/command]
-                    [/option]
-                    [option]
-                    message=_"What if he stole them from the gods somehow?"
-                    [command]
-                        [message]
-                            speaker=Rimaru
-                            message=_"I think that he isn't powerful enough to penetrate into the mythical old world, steal the child from the gods, return to our world and stay unpunished when our gods are almost omnipotent if they reach this world. They can destroy or build empires in a fraction of second, and even Luke can't resist somebody as powerful. So I assume that Reezer came here somehow independently of Luke's will."
-                        [/message]
-                        [message]
-                            speaker=Burke
-                            message=_"Yes, but why did he appear right in Luke's grasp, when the world is so big there are too many others who would take care of him too?"
-                        [/message]
-                    [/command]
-                    [/option]
-                    [option]
-                    message=_"That is wrong, by the way, men actually have wombs, but they are too small to be for any use."
-                    [command]
-                        [message]
-                            speaker=Konrad
-                            message=_"That does not matter, a man can't give birth. He surely found him somewhere and took him. The question is, how did he know his location?"
-                        [/message]
-                        [message]
-                            speaker=Burke
-                            message=_"Rumours about subjects so peculiar like this one spread fast. But why did he get to him before the other Brothers of Light?"
-                        [/message]
-                    [/command]
-                    [/option]
-                [/message]
-                [message]
-                    speaker=Konrad
-                    message=_"What if it was just a coincidence? There are thousands of thousands of people who could have found him, thousands of people who would take him and take care of him. But Luke is one of them and..."
-                [/message]
-                [message]
-                    speaker=Rimaru
-                    message=_"As you said, it's unlikely but possible. We should find a more probable explanation."
-                    [option]
-                    message=_"What if he learned about some of our gods' weaknesses in that library and misused them? Maybe he can track divine powers or snatch their children."
-                    [command]
-                        [message]
-                            speaker=Rimaru
-                            message=_"The gods would remove that weakness right after the first misuse or destroy all evidence including Luke himself. Neither of that happened, Luke is still as powerful as he was before. And I am damn sure that the gods are watching their child. If it's truly their child."
-                        [/message]
-                        [message]
-                            speaker=Burke
-                            message=_"But we have no other explanations..."
-                        [/message]
-                    [/command]
-                    [/option]
-                    [option]
-                    message=_"What if he managed to replicate some of the mythical ancient experiments our gods performed to become gods?"
-                    [command]
-                        [message]
-                            speaker=Rimaru
-                            message=_"Ah, yes, the old story, our gods were once mortals and found a way to become gods, so they aren't going to prevent any mortal from finding a way to become one like them. Unlikely, but possible. Then, it would be acceptable if Reezer was his son."
-                        [/message]
-                        [message]
-                            speaker=Konrad
-                            message=_"But Reezer looks so glorious and you have not noticed anything like that in Luke. I doubt that the divine radiance weakens with age. This does not fit."
-                        [/message]
-                    [/command]
-                    [/option]
-                    [option]
-                    message=_"What if he was truly chosen and all of this is all a plan of our gods? Their motivations are not understandable to mortals."
-                    [command]
-                        [message]
-                            speaker=Rimaru
-                            message=_"If that's true, they aren't my gods. But that isn't true for sure, that denies all that we fight for! You... you were joking, right?"
-                        [/message]
-                        [message]
-                            speaker=player
-                            message=_"It was a half-joke, but it's still an explanation..."
-                        [/message]
-                    [/command]
-                    [/option]
-                    [option]
-                    message=_"I have no idea."
-                    [command]
-                    [/command]
-                    [/option]
-                [/message]
-                [message]
-                    speaker=Rimaru
-                    message=_"To sum it up, we have no idea why Reezer is here and how Luke got to him. So there can be another explanation we haven't found or Reezer isn't really a child of gods."
-                [/message]
-                [message]
-                    speaker=Konrad
-                    message=_"Either way, you made me consider the possibility of rebellion against Luke the Stealer of Children. You helped my a lot when you destroyed the bandit's alliance. But there is a problem."
-                [/message]
-                [message]
-                    speaker=Rimaru
-                    message=_"What problem?"
-                [/message]
-                [message]
-                    speaker=Konrad
-                    message=_"Lord Uver, residing south from here. He kidnapped my son. It was my mistake, I should not have sent him there, but I needed to know on which side Uver is and I could not have sent an unimportant person there, that might insult him. Uver gets offended even if you sit next to him, bite into a piece of meat and spray some of its juice on him. I learned too late that he was fanatically loyal to Brothers of Light."
-                [/message]
-                [message]
-                    speaker=Konrad
-                    message=_"I need somebody who would free him from Uver's prisons. And because you are demanding a huge favour from me, it will be you."
-                    [option]
-                    message=_"Gladly. I don't want them to torture your son for our actions."
-                    [command]
-                        [message]
-                            speaker=Rimaru
-                            message=_"That's awful! Such misuse!"
-                        [/message]
-                        [message]
-                            speaker=Konrad
-                            message=_"I know. But I need him freed and you are capable of doing so."
-                        [/message]
-                    [/command]
-                    [/option]
-                    [option]
-                    message=_"Can you ask somebody else to do that? We have our own duties."
-                    [command]
-                        [message]
-                            speaker=Konrad
-                            message=_"I know. But it's <i>you</i> who demands a favour here and offer nothing in return. Cheap words will not buy my help."
-                        [/message]
-                    [/command]
-                    [/option]
-                    [option]
-                    message=_"Such insolence! You were looking for somebody who needs help from you so that you could demand this in return!"
-                    [command]
-                        [message]
-                            speaker=Konrad
-                            message=_"Yes. But I have no other options."
-                        [/message]
-                    [/command]
-                    [/option]
-                [/message]
-                [message]
-                    speaker=Rimaru
-                    message=_"I think that we have no other options. Come on, time to free lord Konrad II. Any idea where he is?"
-                [/message]
-                [message]
-                    speaker=Konrad
-                    message=_"He met Uver on the way into Uver's town, Faithdome, that is south from here. He can't have him imprisoned legally, so I suppose that my son wasn't moved to his stupid town. I'd expect him to be somewhere south from here, before Faithdome, but where is that damned dungeon where he's held, I don't know. Maybe some of his men will know, but they will need some encouragement to tell you about it."
-                [/message]
-                [message]
-                    speaker=bandit_merc
-                    message=_"Encouragement to talk. I like that."
-                [/message]
-                [message]
-                    speaker=Rimaru
-                    message=_"I hate to say that, but we'll bring him here. You have my word."
-                [/message]
-                {VARIABLE quests.overall 7}
-                [fire_event]
-                    name=open fertile lands
-                [/fire_event]
-            [/event]
-        [/then]
-    [/if]
+        [if]
+            [variable]
+                name=quests.overall
+                equals=8
+            [/variable]
+            [not]
+                [variable]
+                    name=quests.luke_told_rimaru_about_sister
+                    equals=yes
+                [/variable]
+            [/not]
+            [then]
+                [event]
+                    name=moveto
+                    [filter]
+                        side=1
+                        y=16-22
+                    [/filter]
+                    [store_unit]
+                        [filter]
+                            id=Rimaru
+                        [/filter]
+                        variable=rimaru_coords
+                        kill=no
+                    [/store_unit]
+                    [unit]
+                        x,y=34,1
+                        side=3
+                        gender=male
+                        type=Bringer of Light
+                        id=Luke
+                        name=_"Luke, The Bringer of Light"
+                        canrecruit=yes
+                    [/unit]
+                    [move_unit]
+                        id=Luke
+                        to_x=$rimaru_coords.x
+                        to_y=$rimaru_coords.y
+                        fire_event=no
+                    [/move_unit]
+                    {CLEAR_VARIABLE rimaru_coords}
+                    [message]
+                        speaker=Luke
+                        message=_"Rimaru, there is one thing I decided to let you know."
+                    [/message]
+                    [message]
+                        speaker=Rimaru
+                        message=_"What? I already know that you're a necromancer."
+                    [/message]
+                    [message]
+                        speaker=Luke
+                        message=_"No, it's about your sister."
+                    [/message]
+                    [message]
+                        speaker=Rimaru
+                        message=_"You resurrected her body with your necromantic abilities and made her your mistress?"
+                    [/message]
+                    [message]
+                        speaker=Luke
+                        message=_"No, nothing like that. Our refusal to help her that made you eventually leave our order wasn't done because of laziness. It was done on purpose. A great talent was seen within you, so it was decided to use your relative's sickness to force you to work as hard as you could and improve your skill with an amazing leap. They were sure that you could do that, but you spent too much effort conspiring, trying to get somebody to help her instead of finding a cure yourself."
+                    [/message]
+                    [message]
+                        speaker=Rimaru
+                        message=_"Now I hear from your own mouth how futile is it to rely on any Brother of Larceny."
+                    [/message]
+                    [message]
+                        speaker=Luke
+                        message=_"You should have relied on one particular Brother of Light. Yourself. But you had no faith in yourself, you didn't try hard enough. There was no doubt that you could do it, but you didn't put enough effort into it. You decided to pick another strategy and it was too late when your superiors realised that you were conspiring how to get any of us to save her instead of saving her yourself."
+                    [/message]
+                    [message]
+                        speaker=Rimaru
+                        message=_"So she died because I didn't have enough faith in myself? I think that the amount of enough faith in myself I have is just fine, you are the one who has way too much faith in himself and the justness of his deeds. You put a person into great danger only to make me learn faster, to achieve some level of skill in a few days instead of a year it would take me normally."
+                    [/message]
+                    [message]
+                        speaker=Luke
+                        message=_"Don't blame me, it was your failure. You were capable of saving her, and you failed. As you will fail now, when my army meets you in a bloody clash."
+                    [/message]
+                    {TBC_SPAWN_UNITS_NO_LEADER 3 0.7 "Spearman,Heavy Infantryman,Fencer,Bowman" 11 31}
+                    {TBC_SPAWN_UNITS_NO_LEADER 3 0.4 "Swordsman,Pikeman,Javelineer,Duelist,Longbowman" 24 30}
+                    {TBC_SPAWN_UNITS_NO_LEADER 3 0.4 "Swordsman,Pikeman,Javelineer,Duelist,Longbowman" 3 27}
+                    {TBC_SPAWN_UNITS_NO_LEADER 3 0.3 "Royal Guard,Halberdier,Pilum Master,Master Bowman" 10 13}
+                    {TBC_SPAWN_UNITS_NO_LEADER 3 0.4 "Swordsman,Pikeman,Javelineer,Duelist,Longbowman" 25 18}
+                    [unit]
+                        # Make sure that nobody will sneak into the castle and finish the scenario too early.
+                        side=3
+                        x,y=8,7
+                        type=Iron Mauler
+                        generate_name=yes
+                        [modifications]
+                            [advance]
+                                [effect]
+                                    apply_to=movement
+                                    set=0
+                                [/effect]
+                            [/advance]
+                        [/modifications]
+                    [/unit]
+                    [message]
+                        speaker=Rimaru
+                        message=_"Do you think that your gibberish can make me feel guilty, Luke the Impostor of Light? No, it can't. Now, I'll kill you. With my friends, we can face you."
+                    [/message]
+                    [message]
+                        speaker=Luke
+                        message=_"Yes, we might fight, but I don't want to debase myself with that. I might get a bruise and that can be quite annoying. My army will take care of you. Goodbye."
+                    [/message]
+                    [move_unit]
+                        id=Luke
+                        to_x=34
+                        to_y=1
+                        fire_event=no
+                    [/move_unit]
+                    [kill]
+                        id=Luke
+                        fire_event=no
+                        animate=no
+                    [/kill]
+                    [message]
+                        speaker=Rimaru
+                        message=_"Coward! Come back!"
+                    [/message]
+                    [message]
+                        speaker=bandit_merc
+                        message=_"This dude must really hate bruises, I can tell."
+                    [/message]
+                    {VARIABLE quests.luke_told_rimaru_about_sister yes}
+                [/event]
+            [/then]
+        [/if]
 
-    [if]
-        [variable]
-            name=quests.overall
-            equals=8
-        [/variable]
-        [then]
-            [event]
-                name=moveto
-                [filter]
-                    side=1
-                    x,y=1-13,1-13
-                [/filter]
-                [message]
-                    speaker=Konrad_II
-                    message=_"Take back the gear you lent me to help me survive, I will not need it after meeting my father."
-                [/message]
-            [/event]
-            [event]
-                name=moveto
-                [filter]
-                    side=1
-                    x,y=1-5,1-6
-                [/filter]
-                [message]
-                    speaker=Konrad_II
-                    message=_"Father, I am back! You made these brave warriors rescue me!"
-                [/message]
-                [message]
-                    speaker=Konrad
-                    message=_"Come here, everyone."
-                [/message]
-                [move_unit]
-                    side=1
-                    to_x=3
-                    to_y=4
-                    fire_event=no
-                [/move_unit]
-                [message]
-                    speaker=Konrad
-                    message=_"A big thanks for saving my son. Later, I will ask all the questions I'd like to ask him as a father, now it's time to discuss important matters with you."
-                [/message]
-                [message]
-                    speaker=Burke
-                    message=_"This lord Uver is dangerous. His soldiers are perfectly trained and numerous. Defeating him will not be an easy feat."
-                [/message]
-                [message]
-                    speaker=Konrad
-                    message=_"It will not be an easy feat, but we have some aces in our sleeves. You can employ many hired bandits, and he doesn't expect those. Both our and his soldiers will profit from the light of day, but bandits will surprise them in the dead of night. Furthermore, we know that he's quite dumb. His father was far more intelligent and built a good army with good officers and trainers and he can only keep them."
-                [/message]
-                [message]
-                    speaker=Konrad
-                    message=_"Any larger damage we do to them will be irreversible. A longer campaign would be more suitable for us, because he would replace dead officers by wrong people. I assume that he'll initially underestimate us and leave most of his troops in the war with Sand Empire. Splitting the enemy army to smaller parts is the key to defeating larger armies."
-                [/message]
-                [message]
-                    speaker=Rimaru
-                    message=_"How much time do you think we have? The Brothers of Larceny will notice us prevailing and rally other lords to send their troops as well, surrounding us with enemies so numerous that... ehm,... very very numerous."
-                [/message]
-                [message]
-                    speaker=Konrad
-                    message=_"That can be a serious problem. We need to defeat that man quickly and he's a kind of enemy that should be defeated slowly."
-                [/message]
-                [if]
-                    [have_unit]
-                        id=faithful_lieutenant
-                    [/have_unit]
-                    [then]
-                        [message]
-                            speaker=faithful_lieutenant
-                            message=_"I think that he'll send an army at us as a revenge for freeing our friend. Well, at least those he didn't send against the Sand Empire, heeding the Brothers' demands. We can't avoid that, so how about defeating those guys and invading his town right after it? He'll suffer heavy losses and he won't be ready for us. If we kill Uver before he musters all of his army, we can achieve an easy victory."
-                        [/message]
-                    [/then]
-                    [else]
-                        [message]
-                            speaker=Burke
-                            message=_"I know one thing for sure. Our last deed will not be unavenged. We have trespassed into his land, killed may of his soldiers, freed an important hostage and shamed him. They'll strike at this town, and we can't avoid fighting them. After defeating those, his army will be disorganised, mostly far away fighting the Sand Empire and that might allow us to strike at his town and force him to do whatever we want, possibly taking control of most of his army."
-                        [/message]
-                    [/else]
-                [/if]
-                [message]
-                    speaker=Konrad_II
-                    message=_"Interesting! That might be the thing we need."
-                [/message]
-                [message]
-                    speaker=Konrad
-                    message=_"A direct confrontation is risky, but it seems to be the only possibility for us. We'll need to prepare well."
-                [/message]
-                [store_gold]
-                    side=1
-                    variable=gold
-                [/store_gold]
-                [while]
-                    [not]
-                        [variable]
-                            name=done
-                            equals=yes
-                        [/variable]
-                    [/not]
-                    [do]
-                        [message]
-                            speaker=Rimaru
-                            message=_"Any other ideas?"
-                            [option]
-                            message=_"How about pretending that we fled and avoiding the confrontation with the majority of his army completely?"
+        [if]
+            [variable]
+                name=quests.overall
+                less_than=7
+            [/variable]
+            [then]
+                [event]
+                    name=moveto
+                    [filter]
+                        side=1
+                        x,y=1-5,1-6
+                    [/filter]
+                    [fire_event]
+                        name=allow return
+                    [/fire_event]
+                    [message]
+                        speaker=Konrad
+                        message=_"Welcome. I was told that you would come. Please, come here, to my room."
+                    [/message]
+                    [move_unit]
+                        side=1
+                        to_x=3
+                        to_y=4
+                        fire_event=no
+                    [/move_unit]
+                    [message]
+                        speaker=Konrad
+                        message=_"What do you want, Burke?"
+                    [/message]
+                    [message]
+                        speaker=Burke
+                        message=_"Let the White Mage speak, he can explain it better."
+                    [/message]
+                    [message]
+                        speaker=Konrad
+                        message=_"So, what do you want, Rimaru? Don't be scared, I was told your name by some of our lookouts and you are quite a famous person."
+                    [/message]
+                    [message]
+                        speaker=Rimaru
+                        message=_"If you see a man wielding unimaginable magical powers, what would you think about him? Powers that you have never seen any mage from Academy use, not even in demonstrations of their craft?"
+                    [/message]
+                    [message]
+                        speaker=Konrad
+                        message=_"I'd assume that he found some ancient artifacts of power. Or that he discovered some unusual powers, something that is forbidden in the Academy. Most likely something with black magic, they don't forbid spells that aren't evil in nature."
+                    [/message]
+                    [message]
+                        speaker=Rimaru
+                        message=_"Okay, so it's most likely somebody who dabbed into necromancy in a good way. I will tell you a story of a man. He wanted to be a mage, so he joined the Brothers of Light. The Academy was too far away from his home probably. Instead of healing others, he spent decades in library and on travels. After one particularly long journey, he returned home with great powers that amazed everyone. How would you classify this man?"
+                    [/message]
+                    [message]
+                        speaker=Konrad
+                        message=_"I think I know who are you talking about, but I will try to continue your game. In this case, I would think that he successfully investigated where some powerful relic is and used its power, pretending that it's his power. But because the Brothers of Light study various powers of darkness so that they could fight them effectively, I might also conclude that he found an ancient evil entity like Argan the Lich Lord and made a pact with him."
+                    [/message]
+                    [message]
+                        speaker=Rimaru
+                        message=_"As you guessed, I am speaking about Luke, the Bringer of Light. He returned with new powers and everybody reveres him and follows him now."
+                    [/message]
+                    [message]
+                        speaker=Konrad
+                        message=_"Yes. But there is a little problem in your analogy. The Child, Reezer by name. He wasn't crafted by an evil entity, I know that."
+                        [option]
+                            message=_"Do <i>you</i> have to start with that too? I thought you were a reasonable man."
                             [command]
-                                [if]
-                                    [have_unit]
-                                        id=faithful_lieutenant
-                                    [/have_unit]
-                                    [then]
-                                        [message]
-                                            speaker=faithful_lieutenant
-                                            message=_"Deceiving him like this would be nice, but we would be forced to conquer his town no matter what. That would be a great risk, but allowing a great gain."
-                                        [/message]
-                                        [message]
-                                            speaker=hired_swordsman
-                                            message=_"That would be a nice challenge..."
-                                        [/message]
-                                    [/then]
-                                [/if]
                                 [message]
                                     speaker=Konrad
-                                    message=_"Remember that he's allied with the Brothers of Light. Uver's soldiers would plunder the town, kill people, rape anybody they choose. Brothers of Light would call some people that would not suit them heretics and imprison them for some dark experiments or just sadistic pleasure from torture. I will not have my citizens suffer them."
+                                    message=_"I know how it sounds, but please listen to me."
+                                [/message]
+                                [message]
+                                    speaker=orc
+                                    message=_"I have a feeling that all of you humans are insane."
                                 [/message]
                                 [message]
                                     speaker=she_brother
-                                    message=_"They might also imprison the rape victims for causing the invaders to rape them using their personal charm. They did it a few times already. Sometimes they declare guilty of rape the person who was raped, not the rapist, because they can bend logic as it suits them."
+                                    message=_"I really wonder what will he say now."
                                 [/message]
                             [/command]
-                            [/option]
-                            [option]
-                            message=_"We have a skilled bandit ambusher here, so how about simply sneaking up to his town and starting the attack inside his castle?"
-                            [show_if]
-                                [have_unit]
-                                    id=bandit_merc
-                                [/have_unit]
-                            [/show_if]
+                        [/option]
+                        [option]
+                            message=_"If you were an evil entity of incredible power, why should you be unable to use black magic for some faint illumination and weak healing too?"
                             [command]
-                                [message]
-                                    speaker=bandit_merc
-                                    message=_"I don't think that it's possible. A few assassins might be able to sneak there and possibly also kill him, but we aren't professional assassins and we need to carry heavy weaponry."
-                                [/message]
                                 [message]
                                     speaker=Konrad
-                                    message=_"Also, they might not accept defeat from assassins who avoid fair fights. Ruses of war to lure the enemies away are acceptable, but assassinating the leaders will only strengthen their will to oppose us."
-                                [/message]
-                                [message]
-                                    speaker=elf_merc
-                                    message=_"It's so bad that they like fair fights so much. When I get to a fistfight, I always aim for the opponent's crotch."
-                                [/message]
-                            [/command]
-                            [/option]
-                            [option]
-                            message=_"How about having <i>somebody</i> shoot an arrow into his knee and make him fall from a balcony during a pretended siege?"
-                            [show_if]
-                                [have_unit]
-                                    id=elf_merc
-                                [/have_unit]
-                            [/show_if]
-                            [command]
-                                [message]
-                                    speaker=elf_merc
-                                    message=_"Who do you want to shoot that arrow?"
-                                [/message]
-                                [message]
-                                    speaker=Rimaru
-                                    message=_"You, obviously."
-                                [/message]
-                                [message]
-                                    speaker=elf_merc
-                                    message=_"I have never been there, but I don't think that he'll stand on a balcony that is close enough to the outer fortification. And he'll most likely wear an armour and arrows can penetrate armour only from short distances."
+                                    message=_"I know that there is no logic in my words, but..."
                                 [/message]
                                 [message]
                                     speaker=faithful_lieutenant
-                                    message=_"I wish it was possible to shoot him down and have it all done."
+                                    message=_"I must tell that I believe you."
                                 [/message]
-                                [message]
-                                    id=hired_halberdier
-                                    side=1
-                                    message=_"I was almost afraid that I'll have nobody to hack to pieces."
-                                [/message]
-                            [/command]
-                            [/option]
-                            [option]
-                            message=_"I think that we can spare some money to hire the bandits to support us in the battle."
-                            [show_if]
-                                [variable]
-                                    name=gold
-                                    greater_than_equal_to=400
-                                [/variable]
-                            [/show_if]
-                            [command]
                                 [message]
                                     speaker=bandit_merc
-                                    message=_"Yeah, that's how enemies should be dealt with!"
+                                    message=_"How about simply killing him and impersonating him? He speaks like Luke's lackeys."
                                 [/message]
-                                [message]
-                                    speaker=halberdier_merc
-                                    message=_"Darn, less kills to me."
-                                [/message]
+                            [/command]
+                        [/option]
+                        [option]
+                            message=_"What was it, then?"
+                            [command]
+                            [/command]
+                        [/option]
+                    [/message]
+                    [message]
+                        speaker=Konrad
+                        message=_"It must have been a son of the gods. He looked so... otherwordly. Nothing in this world can have such grace. Believe me or not, but you will not persuade me about his nature. The rational part of myself tried to make sense of it, but I could not. It could not be caused by any narcotic substances in the air, because it was in an open area and the wind was blowing. It could not be magic, because I have seen what magic can do and what it cannot."
+                    [/message]
+                    [message]
+                        speaker=Rimaru
+                        message=_"So do you think that Luke snatched the child of gods somewhere so that we could misuse it as a demonstration of his supremacy?"
+                    [/message]
+                    [message]
+                        speaker=she_brother
+                        message=_"Excellent. So now you believe that there is actually something divine in this plot."
+                    [/message]
+                    [message]
+                        speaker=Konrad
+                        message=_"That is what I think, yes. I am afraid of them, so I would not tell it openly, but I am sure that I can trust you in this, Rimaru. Luke clearly could not give birth to little Reezer, because he is a man and he doesn't have a womb."
+                        [option]
+                            message=_"He must have stolen him somewhere. Do you think that the woman that brought him up chose to give him away?"
+                            [command]
                                 [message]
                                     speaker=Rimaru
-                                    message=_"I was considering this possibility. We'll need 400 gold for that."
-                                    [option]
-                                    message=_"400 gold is okay, that should be worth their help."
-                                    [command]
-                                        {VARIABLE quests.marching_into_war_hired yes}
-                                        [gold]
-                                            side=1
-                                            amount=-400
-                                        [/gold]
-                                        [message]
-                                            speaker=Konrad
-                                            message=_"Okay, sending a messenger there."
-                                        [/message]
-                                    [/command]
-                                    [/option]
-                                    [option]
-                                    message=_"We can't afford that, we need gold for other stuff."
-                                    [command]
-                                        [message]
-                                            speaker=Konrad
-                                            message=_"Shame..."
-                                        [/message]
-                                    [/command]
-                                    [/option]
+                                    message=_"I doubt that. Mothers don't leave their children to strangers unless they're born from rape. He either stole him or forced the poor woman to let him take her child."
+                                [/message]
+                                [message]
+                                    speaker=Burke
+                                    message=_"I think that rumours of such a magnificent child would spread quickly. How did he get to him first?"
                                 [/message]
                             [/command]
-                            [/option]
-                            [option]
-                            message=_"That's all I can think of."
+                        [/option]
+                        [option]
+                            message=_"What if he stole them from the gods somehow?"
                             [command]
-                                {VARIABLE done yes}
+                                [message]
+                                    speaker=Rimaru
+                                    message=_"I think that he isn't powerful enough to penetrate into the mythical old world, steal the child from the gods, return to our world and stay unpunished when our gods are almost omnipotent if they reach this world. They can destroy or build empires in a fraction of second, and even Luke can't resist somebody as powerful. So I assume that Reezer came here somehow independently of Luke's will."
+                                [/message]
+                                [message]
+                                    speaker=Burke
+                                    message=_"Yes, but why did he appear right in Luke's grasp, when the world is so big there are too many others who would take care of him too?"
+                                [/message]
                             [/command]
-                            [/option]
-                        [/message]
-                    [/do]
-                [/while]
-                {CLEAR_VARIABLE done,gold}
-                [message]
-                    speaker=Konrad_II
-                    message=_"So, I think it's time for the confrontation with them. Preparations must start immediately."
-                [/message]
-                [message]
-                    speaker=Konrad
-                    message=_"<i>I</i> am the one who gives commands. All you said will be done anyway because I wanted to do the same thing."
-                [/message]
-                [unit]
-                    side=3
-                    type=Manhunter
-                    name=_"???"
-                    x,y=1,25
-                    id=Manhunter
-                [/unit]
-                [if]
-                    [variable]
-                        name=party_members.length
-                        greater_than=6
-                    [/variable]
-                    [then]
-                        [object]
-                            [filter]
-                                id=Manhunter
-                            [/filter]
-                            silent=yes
-                            [effect]
-                                apply_to=hitpoints
-                                increase_total=50%
-                                heal_full=yes
-                            [/effect]
-                        [/object]
-                    [/then]
-                [/if]
-                [if]
-                    [variable]
-                        name=party_members.length
-                        greater_than=8
-                    [/variable]
-                    [then]
-                        [object]
-                            [filter]
-                                id=Manhunter
-                            [/filter]
-                            silent=yes
-                            [effect]
-                                apply_to=hitpoints
-                                increase_total=50%
-                                heal_full=yes
-                            [/effect]
-                        [/object]
-                    [/then]
-                [/if]
-                [move_unit]
-                    id=Manhunter
-                    to_x=8
-                    to_y=2
-                    fire_event=no
-                [/move_unit]
-                {EARTHQUAKE (
-                    [terrain]
-                        x,y=8,7
-                        terrain=Xu
-                    [/terrain]
-                    [redraw]
-                    [/redraw]
-                )}
-                [message]
-                    speaker=Rimaru
-                    message=_"Not again. It seems that you had time to lick your wounds and bother us again?"
-                [/message]
-                [message]
-                    speaker=Manhunter
-                    message=_"This time, I am stronger... I will watch you die with pleasure..."
-                [/message]
-                [message]
-                    speaker=Rimaru
-                    message=_"Who are you?"
-                [/message]
-                [message]
-                    speaker=Manhunter
-                    message=_"You don't know? Ha ha ha..."
-                [/message]
-                [if]
-                    [variable]
-                        name=party_members.length
-                        greater_than=4
-                    [/variable]
-                    [then]
-                        [event]
-                            name=spellcast
-                            first_time_only=no
-                            [store_unit]
-                                [filter]
-                                    type=Magic Missile
-                                    [or]
-                                        type=Soulless
-                                    [/or]
-                                    [not]
-                                        [filter_wml]
-                                            [variables]
-                                                improved=yes
-                                            [/variables]
-                                        [/filter_wml]
-                                    [/not]
-                                [/filter]
-                                variable=summons
-                                kill=no
-                            [/store_unit]
-                            {FOREACH summons i}
-                                {VARIABLE summons[$i].variables.improved yes}
-                                [if]
-                                    [variable]
-                                        name=party_members.length
-                                        greater_than=5
-                                    [/variable]
-                                    [then]
-                                        [object]
-                                            [filter]
-                                                id=$summons[$i].id
-                                            [/filter]
-                                            silent=yes
-                                            [effect]
-                                                apply_to=attack
-                                                increase_damage=2
-                                            [/effect]
-                                        [/object]
-                                    [/then]
-                                [/if]
-                                [if]
-                                    [variable]
-                                        name=party_members.length
-                                        greater_than=7
-                                    [/variable]
-                                    [then]
-                                        [object]
-                                            [filter]
-                                                id=$summons[$i].id
-                                            [/filter]
-                                            silent=yes
-                                            [effect]
-                                                apply_to=attack
-                                                increase_damage=20%
-                                            [/effect]
-                                        [/object]
-                                    [/then]
-                                [/if]
-                                [if]
-                                    [variable]
-                                        name=party_members.length
-                                        greater_than=9
-                                    [/variable]
-                                    [then]
-                                        [object]
-                                            [filter]
-                                                id=$summons[$i].id
-                                            [/filter]
-                                            silent=yes
-                                            [effect]
-                                                apply_to=attack
-                                                increase_damage=2
-                                            [/effect]
-                                        [/object]
-                                    [/then]
-                                [/if]
-                            {NEXT i}
-                            {CLEAR_VARIABLE summons}
-                        [/event]
-                    [/then]
-                [/if]
-                {VARIABLE quests.overall 9}
+                        [/option]
+                        [option]
+                            message=_"That is wrong, by the way, men actually have wombs, but they are too small to be for any use."
+                            [command]
+                                [message]
+                                    speaker=Konrad
+                                    message=_"That does not matter, a man can't give birth. He surely found him somewhere and took him. The question is, how did he know his location?"
+                                [/message]
+                                [message]
+                                    speaker=Burke
+                                    message=_"Rumours about subjects so peculiar like this one spread fast. But why did he get to him before the other Brothers of Light?"
+                                [/message]
+                            [/command]
+                        [/option]
+                    [/message]
+                    [message]
+                        speaker=Konrad
+                        message=_"What if it was just a coincidence? There are thousands of thousands of people who could have found him, thousands of people who would take him and take care of him. But Luke is one of them and..."
+                    [/message]
+                    [message]
+                        speaker=Rimaru
+                        message=_"As you said, it's unlikely but possible. We should find a more probable explanation."
+                        [option]
+                            message=_"What if he learned about some of our gods' weaknesses in that library and misused them? Maybe he can track divine powers or snatch their children."
+                            [command]
+                                [message]
+                                    speaker=Rimaru
+                                    message=_"The gods would remove that weakness right after the first misuse or destroy all evidence including Luke himself. Neither of that happened, Luke is still as powerful as he was before. And I am damn sure that the gods are watching their child. If it's truly their child."
+                                [/message]
+                                [message]
+                                    speaker=Burke
+                                    message=_"But we have no other explanations..."
+                                [/message]
+                            [/command]
+                        [/option]
+                        [option]
+                            message=_"What if he managed to replicate some of the mythical ancient experiments our gods performed to become gods?"
+                            [command]
+                                [message]
+                                    speaker=Rimaru
+                                    message=_"Ah, yes, the old story, our gods were once mortals and found a way to become gods, so they aren't going to prevent any mortal from finding a way to become one like them. Unlikely, but possible. Then, it would be acceptable if Reezer was his son."
+                                [/message]
+                                [message]
+                                    speaker=Konrad
+                                    message=_"But Reezer looks so glorious and you have not noticed anything like that in Luke. I doubt that the divine radiance weakens with age. This does not fit."
+                                [/message]
+                            [/command]
+                        [/option]
+                        [option]
+                            message=_"What if he was truly chosen and all of this is all a plan of our gods? Their motivations are not understandable to mortals."
+                            [command]
+                                [message]
+                                    speaker=Rimaru
+                                    message=_"If that's true, they aren't my gods. But that isn't true for sure, that denies all that we fight for! You... you were joking, right?"
+                                [/message]
+                                [message]
+                                    speaker=player
+                                    message=_"It was a half-joke, but it's still an explanation..."
+                                [/message]
+                            [/command]
+                        [/option]
+                        [option]
+                            message=_"I have no idea."
+                            [command]
+                            [/command]
+                        [/option]
+                    [/message]
+                    [message]
+                        speaker=Rimaru
+                        message=_"To sum it up, we have no idea why Reezer is here and how Luke got to him. So there can be another explanation we haven't found or Reezer isn't really a child of gods."
+                    [/message]
+                    [message]
+                        speaker=Konrad
+                        message=_"Either way, you made me consider the possibility of rebellion against Luke the Stealer of Children. You helped my a lot when you destroyed the bandit's alliance. But there is a problem."
+                    [/message]
+                    [message]
+                        speaker=Rimaru
+                        message=_"What problem?"
+                    [/message]
+                    [message]
+                        speaker=Konrad
+                        message=_"Lord Uver, residing south from here. He kidnapped my son. It was my mistake, I should not have sent him there, but I needed to know on which side Uver is and I could not have sent an unimportant person there, that might insult him. Uver gets offended even if you sit next to him, bite into a piece of meat and spray some of its juice on him. I learned too late that he was fanatically loyal to Brothers of Light."
+                    [/message]
+                    [message]
+                        speaker=Konrad
+                        message=_"I need somebody who would free him from Uver's prisons. And because you are demanding a huge favour from me, it will be you."
+                        [option]
+                            message=_"Gladly. I don't want them to torture your son for our actions."
+                            [command]
+                                [message]
+                                    speaker=Rimaru
+                                    message=_"That's awful! Such misuse!"
+                                [/message]
+                                [message]
+                                    speaker=Konrad
+                                    message=_"I know. But I need him freed and you are capable of doing so."
+                                [/message]
+                            [/command]
+                        [/option]
+                        [option]
+                            message=_"Can you ask somebody else to do that? We have our own duties."
+                            [command]
+                                [message]
+                                    speaker=Konrad
+                                    message=_"I know. But it's <i>you</i> who demands a favour here and offer nothing in return. Cheap words will not buy my help."
+                                [/message]
+                            [/command]
+                        [/option]
+                        [option]
+                            message=_"Such insolence! You were looking for somebody who needs help from you so that you could demand this in return!"
+                            [command]
+                                [message]
+                                    speaker=Konrad
+                                    message=_"Yes. But I have no other options."
+                                [/message]
+                            [/command]
+                        [/option]
+                    [/message]
+                    [message]
+                        speaker=Rimaru
+                        message=_"I think that we have no other options. Come on, time to free lord Konrad II. Any idea where he is?"
+                    [/message]
+                    [message]
+                        speaker=Konrad
+                        message=_"He met Uver on the way into Uver's town, Faithdome, that is south from here. He can't have him imprisoned legally, so I suppose that my son wasn't moved to his stupid town. I'd expect him to be somewhere south from here, before Faithdome, but where is that damned dungeon where he's held, I don't know. Maybe some of his men will know, but they will need some encouragement to tell you about it."
+                    [/message]
+                    [message]
+                        speaker=bandit_merc
+                        message=_"Encouragement to talk. I like that."
+                    [/message]
+                    [message]
+                        speaker=Rimaru
+                        message=_"I hate to say that, but we'll bring him here. You have my word."
+                    [/message]
+                    {VARIABLE quests.overall 7}
+                    [fire_event]
+                        name=open fertile lands
+                    [/fire_event]
+                [/event]
+            [/then]
+        [/if]
+
+        [if]
+            [variable]
+                name=quests.overall
+                equals=8
+            [/variable]
+            [then]
                 [event]
-                    name=last breath
+                    name=moveto
                     [filter]
-                        id=Manhunter
+                        side=1
+                        x,y=1-13,1-13
                     [/filter]
-                    {VARIABLE quests.overall 10}
+                    [message]
+                        speaker=Konrad_II
+                        message=_"Take back the gear you lent me to help me survive, I will not need it after meeting my father."
+                    [/message]
+                [/event]
+                [event]
+                    name=moveto
+                    [filter]
+                        side=1
+                        x,y=1-5,1-6
+                    [/filter]
+                    [message]
+                        speaker=Konrad_II
+                        message=_"Father, I am back! You made these brave warriors rescue me!"
+                    [/message]
+                    [message]
+                        speaker=Konrad
+                        message=_"Come here, everyone."
+                    [/message]
+                    [move_unit]
+                        side=1
+                        to_x=3
+                        to_y=4
+                        fire_event=no
+                    [/move_unit]
+                    [message]
+                        speaker=Konrad
+                        message=_"A big thanks for saving my son. Later, I will ask all the questions I'd like to ask him as a father, now it's time to discuss important matters with you."
+                    [/message]
+                    [message]
+                        speaker=Burke
+                        message=_"This lord Uver is dangerous. His soldiers are perfectly trained and numerous. Defeating him will not be an easy feat."
+                    [/message]
+                    [message]
+                        speaker=Konrad
+                        message=_"It will not be an easy feat, but we have some aces in our sleeves. You can employ many hired bandits, and he doesn't expect those. Both our and his soldiers will profit from the light of day, but bandits will surprise them in the dead of night. Furthermore, we know that he's quite dumb. His father was far more intelligent and built a good army with good officers and trainers and he can only keep them."
+                    [/message]
+                    [message]
+                        speaker=Konrad
+                        message=_"Any larger damage we do to them will be irreversible. A longer campaign would be more suitable for us, because he would replace dead officers by wrong people. I assume that he'll initially underestimate us and leave most of his troops in the war with Sand Empire. Splitting the enemy army to smaller parts is the key to defeating larger armies."
+                    [/message]
+                    [message]
+                        speaker=Rimaru
+                        message=_"How much time do you think we have? The Brothers of Larceny will notice us prevailing and rally other lords to send their troops as well, surrounding us with enemies so numerous that... ehm,... very very numerous."
+                    [/message]
+                    [message]
+                        speaker=Konrad
+                        message=_"That can be a serious problem. We need to defeat that man quickly and he's a kind of enemy that should be defeated slowly."
+                    [/message]
+                    [if]
+                        [have_unit]
+                            id=faithful_lieutenant
+                        [/have_unit]
+                        [then]
+                            [message]
+                                speaker=faithful_lieutenant
+                                message=_"I think that he'll send an army at us as a revenge for freeing our friend. Well, at least those he didn't send against the Sand Empire, heeding the Brothers' demands. We can't avoid that, so how about defeating those guys and invading his town right after it? He'll suffer heavy losses and he won't be ready for us. If we kill Uver before he musters all of his army, we can achieve an easy victory."
+                            [/message]
+                        [/then]
+                        [else]
+                            [message]
+                                speaker=Burke
+                                message=_"I know one thing for sure. Our last deed will not be unavenged. We have trespassed into his land, killed may of his soldiers, freed an important hostage and shamed him. They'll strike at this town, and we can't avoid fighting them. After defeating those, his army will be disorganised, mostly far away fighting the Sand Empire and that might allow us to strike at his town and force him to do whatever we want, possibly taking control of most of his army."
+                            [/message]
+                        [/else]
+                    [/if]
+                    [message]
+                        speaker=Konrad_II
+                        message=_"Interesting! That might be the thing we need."
+                    [/message]
+                    [message]
+                        speaker=Konrad
+                        message=_"A direct confrontation is risky, but it seems to be the only possibility for us. We'll need to prepare well."
+                    [/message]
+                    [store_gold]
+                        side=1
+                        variable=gold
+                    [/store_gold]
+                    [while]
+                        [not]
+                            [variable]
+                                name=done
+                                equals=yes
+                            [/variable]
+                        [/not]
+                        [do]
+                            [message]
+                                speaker=Rimaru
+                                message=_"Any other ideas?"
+                                [option]
+                                    message=_"How about pretending that we fled and avoiding the confrontation with the majority of his army completely?"
+                                    [command]
+                                        [if]
+                                            [have_unit]
+                                                id=faithful_lieutenant
+                                            [/have_unit]
+                                            [then]
+                                                [message]
+                                                    speaker=faithful_lieutenant
+                                                    message=_"Deceiving him like this would be nice, but we would be forced to conquer his town no matter what. That would be a great risk, but allowing a great gain."
+                                                [/message]
+                                                [message]
+                                                    speaker=hired_swordsman
+                                                    message=_"That would be a nice challenge..."
+                                                [/message]
+                                            [/then]
+                                        [/if]
+                                        [message]
+                                            speaker=Konrad
+                                            message=_"Remember that he's allied with the Brothers of Light. Uver's soldiers would plunder the town, kill people, rape anybody they choose. Brothers of Light would call some people that would not suit them heretics and imprison them for some dark experiments or just sadistic pleasure from torture. I will not have my citizens suffer them."
+                                        [/message]
+                                        [message]
+                                            speaker=she_brother
+                                            message=_"They might also imprison the rape victims for causing the invaders to rape them using their personal charm. They did it a few times already. Sometimes they declare guilty of rape the person who was raped, not the rapist, because they can bend logic as it suits them."
+                                        [/message]
+                                    [/command]
+                                [/option]
+                                [option]
+                                    message=_"We have a skilled bandit ambusher here, so how about simply sneaking up to his town and starting the attack inside his castle?"
+                                    [show_if]
+                                        [have_unit]
+                                            id=bandit_merc
+                                        [/have_unit]
+                                    [/show_if]
+                                    [command]
+                                        [message]
+                                            speaker=bandit_merc
+                                            message=_"I don't think that it's possible. A few assassins might be able to sneak there and possibly also kill him, but we aren't professional assassins and we need to carry heavy weaponry."
+                                        [/message]
+                                        [message]
+                                            speaker=Konrad
+                                            message=_"Also, they might not accept defeat from assassins who avoid fair fights. Ruses of war to lure the enemies away are acceptable, but assassinating the leaders will only strengthen their will to oppose us."
+                                        [/message]
+                                        [message]
+                                            speaker=elf_merc
+                                            message=_"It's so bad that they like fair fights so much. When I get to a fistfight, I always aim for the opponent's crotch."
+                                        [/message]
+                                    [/command]
+                                [/option]
+                                [option]
+                                    message=_"How about having <i>somebody</i> shoot an arrow into his knee and make him fall from a balcony during a pretended siege?"
+                                    [show_if]
+                                        [have_unit]
+                                            id=elf_merc
+                                        [/have_unit]
+                                    [/show_if]
+                                    [command]
+                                        [message]
+                                            speaker=elf_merc
+                                            message=_"Who do you want to shoot that arrow?"
+                                        [/message]
+                                        [message]
+                                            speaker=Rimaru
+                                            message=_"You, obviously."
+                                        [/message]
+                                        [message]
+                                            speaker=elf_merc
+                                            message=_"I have never been there, but I don't think that he'll stand on a balcony that is close enough to the outer fortification. And he'll most likely wear an armour and arrows can penetrate armour only from short distances."
+                                        [/message]
+                                        [message]
+                                            speaker=faithful_lieutenant
+                                            message=_"I wish it was possible to shoot him down and have it all done."
+                                        [/message]
+                                        [message]
+                                            id=hired_halberdier
+                                            side=1
+                                            message=_"I was almost afraid that I'll have nobody to hack to pieces."
+                                        [/message]
+                                    [/command]
+                                [/option]
+                                [option]
+                                    message=_"I think that we can spare some money to hire the bandits to support us in the battle."
+                                    [show_if]
+                                        [variable]
+                                            name=gold
+                                            greater_than_equal_to=400
+                                        [/variable]
+                                    [/show_if]
+                                    [command]
+                                        [message]
+                                            speaker=bandit_merc
+                                            message=_"Yeah, that's how enemies should be dealt with!"
+                                        [/message]
+                                        [message]
+                                            speaker=halberdier_merc
+                                            message=_"Darn, less kills to me."
+                                        [/message]
+                                        [message]
+                                            speaker=Rimaru
+                                            message=_"I was considering this possibility. We'll need 400 gold for that."
+                                            [option]
+                                                message=_"400 gold is okay, that should be worth their help."
+                                                [command]
+                                                    {VARIABLE quests.marching_into_war_hired yes}
+                                                    [gold]
+                                                        side=1
+                                                        amount=-400
+                                                    [/gold]
+                                                    [message]
+                                                        speaker=Konrad
+                                                        message=_"Okay, sending a messenger there."
+                                                    [/message]
+                                                [/command]
+                                            [/option]
+                                            [option]
+                                                message=_"We can't afford that, we need gold for other stuff."
+                                                [command]
+                                                    [message]
+                                                        speaker=Konrad
+                                                        message=_"Shame..."
+                                                    [/message]
+                                                [/command]
+                                            [/option]
+                                        [/message]
+                                    [/command]
+                                [/option]
+                                [option]
+                                    message=_"That's all I can think of."
+                                    [command]
+                                        {VARIABLE done yes}
+                                    [/command]
+                                [/option]
+                            [/message]
+                        [/do]
+                    [/while]
+                    {CLEAR_VARIABLE done,gold}
+                    [message]
+                        speaker=Konrad_II
+                        message=_"So, I think it's time for the confrontation with them. Preparations must start immediately."
+                    [/message]
+                    [message]
+                        speaker=Konrad
+                        message=_"<i>I</i> am the one who gives commands. All you said will be done anyway because I wanted to do the same thing."
+                    [/message]
+                    [unit]
+                        side=3
+                        type=Manhunter
+                        name=_"???"
+                        x,y=1,25
+                        id=Manhunter
+                    [/unit]
+                    [if]
+                        [variable]
+                            name=party_members.length
+                            greater_than=6
+                        [/variable]
+                        [then]
+                            [object]
+                                [filter]
+                                    id=Manhunter
+                                [/filter]
+                                silent=yes
+                                [effect]
+                                    apply_to=hitpoints
+                                    increase_total=50%
+                                    heal_full=yes
+                                [/effect]
+                            [/object]
+                        [/then]
+                    [/if]
+                    [if]
+                        [variable]
+                            name=party_members.length
+                            greater_than=8
+                        [/variable]
+                        [then]
+                            [object]
+                                [filter]
+                                    id=Manhunter
+                                [/filter]
+                                silent=yes
+                                [effect]
+                                    apply_to=hitpoints
+                                    increase_total=50%
+                                    heal_full=yes
+                                [/effect]
+                            [/object]
+                        [/then]
+                    [/if]
+                    [move_unit]
+                        id=Manhunter
+                        to_x=8
+                        to_y=2
+                        fire_event=no
+                    [/move_unit]
                     {EARTHQUAKE (
                         [terrain]
                             x,y=8,7
-                            terrain=Iwr
+                            terrain=Xu
                         [/terrain]
                         [redraw]
                         [/redraw]
                     )}
                     [message]
+                        speaker=Rimaru
+                        message=_"Not again. It seems that you had time to lick your wounds and bother us again?"
+                    [/message]
+                    [message]
                         speaker=Manhunter
-                        message=_"You are growing stronger... but not as much as me."
+                        message=_"This time, I am stronger... I will watch you die with pleasure..."
                     [/message]
                     [message]
                         speaker=Rimaru
-                        message=_"I have a feeling that under your disguise, you are a person I know. Who the hell are you, assassin?"
+                        message=_"Who are you?"
                     [/message]
                     [message]
                         speaker=Manhunter
-                        message=_"My name is not Luke."
+                        message=_"You don't know? Ha ha ha..."
                     [/message]
-                    [move_unit]
-                        id=Manhunter
-                        to_x=1
-                        to_y=17
-                        fire_event=no
-                    [/move_unit]
-                    [kill]
-                        id=Manhunter
-                        fire_event=no
-                        animate=no
-                    [/kill]
-                    [message]
-                        speaker=Burke
-                        message=_"His voice was somewhat boyish, clearly different from Luke's deep voice that sounds wise until you hear a few sentences."
-                        [option]
-                        message=_"Maybe he was just trying to speak a different voice than his natural voice, so that we would not recognise him."
-                        [command]
-                            [message]
-                                speaker=Rimaru
-                                message=_"Well, it clearly isn't Luke but it can be anybody we've seen. Maybe even somebody we think we have killed, like the Bloody Rainmaker."
-                            [/message]
-                            [message]
-                                speaker=Burke
-                                message=_"Doesn't sound like his voice."
-                            [/message]
-                            [message]
-                                speaker=Rimaru
-                                message=_"We have heard only a few sentences. And he was shouting commands, not speaking normally. That wasn't much like his real voice."
-                            [/message]
-                        [/command]
-                        [/option]
-                        [option]
-                        message=_"What if it's the Child?"
-                        [command]
-                            [message]
-                                speaker=Konrad
-                                message=_"The Child was younger. I doubt he grew up so quickly."
-                            [/message]
-                            [message]
-                                speaker=Rimaru
-                                message=_"Also, I would never send out somebody so precious to a mission like this."
-                            [/message]
-                            [message]
-                                speaker=player
-                                message=_"Maybe he grew up very fast and he's so powerful that wounds like the ones we've just inflicted are no threat to him and he chickened when the first signs of danger appeared."
-                            [/message]
-                            [message]
-                                speaker=Rimaru
-                                message=_"That's unlikely."
-                            [/message]
-                        [/command]
-                        [/option]
-                        [option]
-                        message=_"What if it was not a man, but a woman?"
-                        [command]
-                            [message]
-                                speaker=Rimaru
-                                message=_"I doubt a woman can become so powerful."
-                            [/message]
-                            [message]
-                                speaker=she_brother
-                                message=_"You sexist freak!"
-                            [/message]
-                            [message]
-                                speaker=elf_merc
-                                message=_"My arrow will teach you how it really is if you won't stop."
-                            [/message]
-                            [message]
-                                speaker=Konrad_II
-                                message=_"Yeah, that guy's too badass to be a woman."
-                            [/message]
-                            [message]
-                                speaker=Burke
-                                message=_"If that person is really a human, it doesn't matter if it's a man or a woman or a child. No humans can be so powerful unless something wicked is happening."
-                            [/message]
-                        [/command]
-                        [/option]
-                    [/message]
-                    [message]
-                        speaker=Konrad
-                        message=_"Okay, now it's time to prepare for the ongoing battle. But there is one more thing to consider. I need to inform the king about this. His castle might not be overrun with Brothers of Light's corruption and if there's a chance to settle this all without a war, I will try my best."
-                    [/message]
-                    [message]
-                        speaker=Burke
-                        message=_"But... what shall we do without you?"
-                    [/message]
-                    [message]
-                        speaker=Konrad
-                        message=_"My son will take care about the town. And you will take care of the war."
-                    [/message]
-                    [message]
-                        speaker=Konrad_II
-                        message=_"I will not let you down, father. I will try hard."
-                    [/message]
-                    [message]
-                        speaker=Burke
-                        message=_"Thank you for the trust you're putting into our hands, my lord."
-                    [/message]
-                    [modify_unit]
+                    [if]
+                        [variable]
+                            name=party_members.length
+                            greater_than=4
+                        [/variable]
+                        [then]
+                            [event]
+                                name=spellcast
+                                first_time_only=no
+                                [store_unit]
+                                    [filter]
+                                        type=Magic Missile
+                                        [or]
+                                            type=Soulless
+                                        [/or]
+                                        [not]
+                                            [filter_wml]
+                                                [variables]
+                                                    improved=yes
+                                                [/variables]
+                                            [/filter_wml]
+                                        [/not]
+                                    [/filter]
+                                    variable=summons
+                                    kill=no
+                                [/store_unit]
+                                [for]
+                                    array=summons
+                                    [do]
+                                        {VARIABLE summons[$i].variables.improved yes}
+                                        [if]
+                                            [variable]
+                                                name=party_members.length
+                                                greater_than=5
+                                            [/variable]
+                                            [then]
+                                                [object]
+                                                    [filter]
+                                                        id=$summons[$i].id
+                                                    [/filter]
+                                                    silent=yes
+                                                    [effect]
+                                                        apply_to=attack
+                                                        increase_damage=2
+                                                    [/effect]
+                                                [/object]
+                                            [/then]
+                                        [/if]
+                                        [if]
+                                            [variable]
+                                                name=party_members.length
+                                                greater_than=7
+                                            [/variable]
+                                            [then]
+                                                [object]
+                                                    [filter]
+                                                        id=$summons[$i].id
+                                                    [/filter]
+                                                    silent=yes
+                                                    [effect]
+                                                        apply_to=attack
+                                                        increase_damage=20%
+                                                    [/effect]
+                                                [/object]
+                                            [/then]
+                                        [/if]
+                                        [if]
+                                            [variable]
+                                                name=party_members.length
+                                                greater_than=9
+                                            [/variable]
+                                            [then]
+                                                [object]
+                                                    [filter]
+                                                        id=$summons[$i].id
+                                                    [/filter]
+                                                    silent=yes
+                                                    [effect]
+                                                        apply_to=attack
+                                                        increase_damage=2
+                                                    [/effect]
+                                                [/object]
+                                            [/then]
+                                        [/if]
+                                    [/do]
+                                [/for]
+                                {CLEAR_VARIABLE summons}
+                            [/event]
+                        [/then]
+                    [/if]
+                    {VARIABLE quests.overall 9}
+                    [event]
+                        name=last breath
                         [filter]
-                            id=Konrad_II
+                            id=Manhunter
                         [/filter]
-                        side=2
-                    [/modify_unit]
-                    {FOREACH party_members i}
-                        [if]
-                            [variable]
-                                name=party_members[$i].id
-                                equals=Konrad_II
-                            [/variable]
-                            [then]
-                                {CLEAR_VARIABLE party_members[$i]}
-                            [/then]
-                        [/if]
-                    {NEXT i}
-                    [endlevel]
-                        result=victory
-                        bonus=no
-                        next_scenario=04_Marching_into_War
-                        {NEW_GOLD_CARRYOVER 100}
-                    [/endlevel]
+                        {VARIABLE quests.overall 10}
+                        {EARTHQUAKE (
+                            [terrain]
+                                x,y=8,7
+                                terrain=Iwr
+                            [/terrain]
+                            [redraw]
+                            [/redraw]
+                        )}
+                        [message]
+                            speaker=Manhunter
+                            message=_"You are growing stronger... but not as much as me."
+                        [/message]
+                        [message]
+                            speaker=Rimaru
+                            message=_"I have a feeling that under your disguise, you are a person I know. Who the hell are you, assassin?"
+                        [/message]
+                        [message]
+                            speaker=Manhunter
+                            message=_"My name is not Luke."
+                        [/message]
+                        [move_unit]
+                            id=Manhunter
+                            to_x=1
+                            to_y=17
+                            fire_event=no
+                        [/move_unit]
+                        [kill]
+                            id=Manhunter
+                            fire_event=no
+                            animate=no
+                        [/kill]
+                        [message]
+                            speaker=Burke
+                            message=_"His voice was somewhat boyish, clearly different from Luke's deep voice that sounds wise until you hear a few sentences."
+                            [option]
+                                message=_"Maybe he was just trying to speak a different voice than his natural voice, so that we would not recognise him."
+                                [command]
+                                    [message]
+                                        speaker=Rimaru
+                                        message=_"Well, it clearly isn't Luke but it can be anybody we've seen. Maybe even somebody we think we have killed, like the Bloody Rainmaker."
+                                    [/message]
+                                    [message]
+                                        speaker=Burke
+                                        message=_"Doesn't sound like his voice."
+                                    [/message]
+                                    [message]
+                                        speaker=Rimaru
+                                        message=_"We have heard only a few sentences. And he was shouting commands, not speaking normally. That wasn't much like his real voice."
+                                    [/message]
+                                [/command]
+                            [/option]
+                            [option]
+                                message=_"What if it's the Child?"
+                                [command]
+                                    [message]
+                                        speaker=Konrad
+                                        message=_"The Child was younger. I doubt he grew up so quickly."
+                                    [/message]
+                                    [message]
+                                        speaker=Rimaru
+                                        message=_"Also, I would never send out somebody so precious to a mission like this."
+                                    [/message]
+                                    [message]
+                                        speaker=player
+                                        message=_"Maybe he grew up very fast and he's so powerful that wounds like the ones we've just inflicted are no threat to him and he chickened when the first signs of danger appeared."
+                                    [/message]
+                                    [message]
+                                        speaker=Rimaru
+                                        message=_"That's unlikely."
+                                    [/message]
+                                [/command]
+                            [/option]
+                            [option]
+                                message=_"What if it was not a man, but a woman?"
+                                [command]
+                                    [message]
+                                        speaker=Rimaru
+                                        message=_"I doubt a woman can become so powerful."
+                                    [/message]
+                                    [message]
+                                        speaker=she_brother
+                                        message=_"You sexist freak!"
+                                    [/message]
+                                    [message]
+                                        speaker=elf_merc
+                                        message=_"My arrow will teach you how it really is if you won't stop."
+                                    [/message]
+                                    [message]
+                                        speaker=Konrad_II
+                                        message=_"Yeah, that guy's too badass to be a woman."
+                                    [/message]
+                                    [message]
+                                        speaker=Burke
+                                        message=_"If that person is really a human, it doesn't matter if it's a man or a woman or a child. No humans can be so powerful unless something wicked is happening."
+                                    [/message]
+                                [/command]
+                            [/option]
+                        [/message]
+                        [message]
+                            speaker=Konrad
+                            message=_"Okay, now it's time to prepare for the ongoing battle. But there is one more thing to consider. I need to inform the king about this. His castle might not be overrun with Brothers of Light's corruption and if there's a chance to settle this all without a war, I will try my best."
+                        [/message]
+                        [message]
+                            speaker=Burke
+                            message=_"But... what shall we do without you?"
+                        [/message]
+                        [message]
+                            speaker=Konrad
+                            message=_"My son will take care about the town. And you will take care of the war."
+                        [/message]
+                        [message]
+                            speaker=Konrad_II
+                            message=_"I will not let you down, father. I will try hard."
+                        [/message]
+                        [message]
+                            speaker=Burke
+                            message=_"Thank you for the trust you're putting into our hands, my lord."
+                        [/message]
+                        [modify_unit]
+                            [filter]
+                                id=Konrad_II
+                            [/filter]
+                            side=2
+                        [/modify_unit]
+                        [for]
+                            array=party_members
+                            [do]
+                                [if]
+                                    [variable]
+                                        name=party_members[$i].id
+                                        equals=Konrad_II
+                                    [/variable]
+                                    [then]
+                                        {CLEAR_VARIABLE party_members[$i]}
+                                    [/then]
+                                [/if]
+                            [/do]
+                        [/for]
+                        [endlevel]
+                            result=victory
+                            bonus=no
+                            next_scenario=04_Marching_into_War
+                            {NEW_GOLD_CARRYOVER 100}
+                        [/endlevel]
+                    [/event]
                 [/event]
-            [/event]
-        [/then]
-    [/if]
+            [/then]
+        [/if]
 
-    {TBC_GOLD_CHEST 13 1 thunderhold_chest}
+        {TBC_GOLD_CHEST 13 1 thunderhold_chest}
 
-    [if]
-        [variable]
-            name=quests.overall
-            greater_than=13
-        [/variable]
-        [then]
-            [if]
-                [variable]
-                    name=quests.thunderhold_later_ambush_1
-                    equals=yes
-                [/variable]
-                [else]
-                    [event]
-                        name=moveto
-                        [filter]
-                            x,y=25-38,5-14
-                            side=1
-                        [/filter]
-                        {TBC_SPAWN_UNITS_NO_LEADER 3 1.1 "Highwayman,Assassin,Fugitive,Royal Guard,Halberdier,White Mage" 30 10}
-                        {VARIABLE quests.thunderhold_later_ambush_1 yes}
-                    [/event]
-                [/else]
-            [/if]
-            [if]
-                [variable]
-                    name=quests.thunderhold_later_ambush_2
-                    equals=yes
-                [/variable]
-                [else]
-                    [event]
-                        name=moveto
-                        [filter]
-                            x,y=19-34,24-33
-                            side=1
-                        [/filter]
-                        {TBC_SPAWN_UNITS_NO_LEADER 3 1.1 "Highwayman,Assassin,Fugitive,Royal Guard,Halberdier,White Mage" 26 27}
-                        {VARIABLE quests.thunderhold_later_ambush_2 yes}
-                    [/event]
-                [/else]
-            [/if]
-            [if]
-                [variable]
-                    name=quests.thunderhold_later_ambush_3
-                    equals=yes
-                [/variable]
-                [else]
-                    [event]
-                        name=moveto
-                        [filter]
-                            x,y=1-10,26-33
-                            side=1
-                        [/filter]
-                        {TBC_SPAWN_UNITS_NO_LEADER 3 1.1 "Highwayman,Assassin,Fugitive,Royal Guard,Halberdier,White Mage" 6 30}
-                        {VARIABLE quests.thunderhold_later_ambush_3 yes}
-                    [/event]
-                [/else]
-            [/if]
-        [/then]
-    [/if]
-
+        [if]
+            [variable]
+                name=quests.overall
+                greater_than=13
+            [/variable]
+            [then]
+                [if]
+                    [variable]
+                        name=quests.thunderhold_later_ambush_1
+                        equals=yes
+                    [/variable]
+                    [else]
+                        [event]
+                            name=moveto
+                            [filter]
+                                x,y=25-38,5-14
+                                side=1
+                            [/filter]
+                            {TBC_SPAWN_UNITS_NO_LEADER 3 1.1 "Highwayman,Assassin,Fugitive,Royal Guard,Halberdier,White Mage" 30 10}
+                            {VARIABLE quests.thunderhold_later_ambush_1 yes}
+                        [/event]
+                    [/else]
+                [/if]
+                [if]
+                    [variable]
+                        name=quests.thunderhold_later_ambush_2
+                        equals=yes
+                    [/variable]
+                    [else]
+                        [event]
+                            name=moveto
+                            [filter]
+                                x,y=19-34,24-33
+                                side=1
+                            [/filter]
+                            {TBC_SPAWN_UNITS_NO_LEADER 3 1.1 "Highwayman,Assassin,Fugitive,Royal Guard,Halberdier,White Mage" 26 27}
+                            {VARIABLE quests.thunderhold_later_ambush_2 yes}
+                        [/event]
+                    [/else]
+                [/if]
+                [if]
+                    [variable]
+                        name=quests.thunderhold_later_ambush_3
+                        equals=yes
+                    [/variable]
+                    [else]
+                        [event]
+                            name=moveto
+                            [filter]
+                                x,y=1-10,26-33
+                                side=1
+                            [/filter]
+                            {TBC_SPAWN_UNITS_NO_LEADER 3 1.1 "Highwayman,Assassin,Fugitive,Royal Guard,Halberdier,White Mage" 6 30}
+                            {VARIABLE quests.thunderhold_later_ambush_3 yes}
+                        [/event]
+                    [/else]
+                [/if]
+            [/then]
+        [/if]
     [/event]
 
-
     [event]
-    id=forbid_progress
-    name=moveto
-    [filter]
-        side=1
-        x,y=1-41,32-33
-    [/filter]
-    [message]
-        speaker=Rimaru
-        message=_"We shouldn't go there. That land belongs to lord Uver, a faithful servant of Brothers of Larceny. We would meet armed resistance there."
-    [/message]
+        id=forbid_progress
+        name=moveto
+        [filter]
+            side=1
+            x,y=1-41,32-33
+        [/filter]
+        [message]
+            speaker=Rimaru
+            message=_"We shouldn't go there. That land belongs to lord Uver, a faithful servant of Brothers of Larceny. We would meet armed resistance there."
+        [/message]
     [/event]
 
     [event]
@@ -1744,34 +1748,34 @@
     [/event]
 
 #define BUY_GEM VAR COST
-[show_if]
-    [variable]
-        name=gold
-        greater_than_equal_to={COST}
-    [/variable]
-[/show_if]
-[command]
-    {VARIABLE_OP {VAR} add 1}
-    [gold]
-        side=1
-        amount=-{COST}
-    [/gold]
-[/command]
+    [show_if]
+        [variable]
+            name=gold
+            greater_than_equal_to={COST}
+        [/variable]
+    [/show_if]
+    [command]
+        {VARIABLE_OP {VAR} add 1}
+        [gold]
+            side=1
+            amount=-{COST}
+        [/gold]
+    [/command]
 #enddef
 #define SELL_GEM VAR COST
-[show_if]
-    [variable]
-        name={VAR}
-        greater_than_equal_to=1
-    [/variable]
-[/show_if]
-[command]
-    {VARIABLE_OP {VAR} sub 1}
-    [gold]
-        side=1
-        amount={COST}
-    [/gold]
-[/command]
+    [show_if]
+        [variable]
+            name={VAR}
+            greater_than_equal_to=1
+        [/variable]
+    [/show_if]
+    [command]
+        {VARIABLE_OP {VAR} sub 1}
+        [gold]
+            side=1
+            amount={COST}
+        [/gold]
+    [/command]
 #enddef
 
     [event]
@@ -1787,166 +1791,166 @@
             side=1
             variable=gold
         [/store_gold]
-    [if]
-        [variable]
-            name=quests.thunderhold_told_scam
-            equals=yes
-        [/variable]
-        [then]
-            [message]
-                speaker=Rimaru
-                message=_"Be careful here, my friend. This man can sell you wonders, but they can be extremely overpriced. Trade with him only if you really need to and check the prices at least twice before buying anything."
-            [/message]
-            [message]
-                speaker=bandit_merc
-                message=_"If didn't look him so strong, we might get reasonable prices by force, but this one does not look like somebody who can be messed with like that."
-            [/message]
-            {VARIABLE quests.thunderhold_told_scam yes}
-        [/then]
-    [/if]
+        [if]
+            [variable]
+                name=quests.thunderhold_told_scam
+                equals=yes
+            [/variable]
+            [then]
+                [message]
+                    speaker=Rimaru
+                    message=_"Be careful here, my friend. This man can sell you wonders, but they can be extremely overpriced. Trade with him only if you really need to and check the prices at least twice before buying anything."
+                [/message]
+                [message]
+                    speaker=bandit_merc
+                    message=_"If didn't look him so strong, we might get reasonable prices by force, but this one does not look like somebody who can be messed with like that."
+                [/message]
+                {VARIABLE quests.thunderhold_told_scam yes}
+            [/then]
+        [/if]
         [message]
             speaker=trader4
             message= _ "Hello, I am a trader. I buy and sell magical gems. Would you like to buy some or sell some?"
             [option]
                 message=_"Buy."
                 [command]
-            [while]
-                [not]
-                    [variable]
-                        name=done
-                        equals=yes
-                    [/variable]
-                [/not]
-                [do]
-                    [store_gold]
-                        side=1
-                        variable=gold
-                    [/store_gold]
-                    [message]
-                        speaker=trader4
-                        message= _ "Best prices in this kingdom! Well, best because I am the only seller."
-                        [option]
-                        message=_"Buy an obsidian for 5 gold (currently having $obsidians of them)"
-                        {BUY_GEM obsidians 5}
-                        [/option]
-                        [option]
-                        message=_"Buy a topaz for 9 gold (currently having $topazes of them)"
-                        {BUY_GEM topazes 9}
-                        [/option]
-                        [option]
-                        message=_"Buy an opal for 16 gold (currently having $opals of them)"
-                        {BUY_GEM opals 16}
-                        [/option]
-                        [option]
-                        message=_"Buy a pearl for 30 gold (currently having $pearls of them)"
-                        {BUY_GEM pearls 30}
-                        [/option]
-                        [option]
-                        message=_"Buy a diamond for 55 gold (currently having $diamonds of them)"
-                        {BUY_GEM diamonds 55}
-                        [/option]
-                        [option]
-                        message=_"Buy a ruby for 100 gold (currently having $rubies of them)"
-                        {BUY_GEM rubies 100}
-                        [/option]
-                        [option]
-                        message=_"Buy an emerald for 200 gold (currently having $emeralds of them)"
-                        {BUY_GEM emeralds 200}
-                        [/option]
-                        [option]
-                        message=_"Buy an amethyst for 500 gold (currently having $amethysts of them)"
-                        {BUY_GEM amethysts 500}
-                        [/option]
-                        [option]
-                        message=_"Buy a sapphire for 1000 gold (currently having $sapphires of them)"
-                        {BUY_GEM sapphires 1000}
-                        [/option]
-                        [option]
-                        message=_"Buy a black pearl for 2000 gold (currently having $black_pearls of them)"
-                        {BUY_GEM black_pearls 2000}
-                        [/option]
-                        [option]
-                        message=_"I have bought all I needed."
-                        [command]
-                            {VARIABLE done yes}
-                        [/command]
-                        [/option]
-                    [/message]
-                    {CLEAR_VARIABLE gold}
-                [/do]
-            [/while]
-            {CLEAR_VARIABLE done}
+                    [while]
+                        [not]
+                            [variable]
+                                name=done
+                                equals=yes
+                            [/variable]
+                        [/not]
+                        [do]
+                            [store_gold]
+                                side=1
+                                variable=gold
+                            [/store_gold]
+                            [message]
+                                speaker=trader4
+                                message= _ "Best prices in this kingdom! Well, best because I am the only seller."
+                                [option]
+                                    message=_"Buy an obsidian for 5 gold (currently having $obsidians of them)"
+                                    {BUY_GEM obsidians 5}
+                                [/option]
+                                [option]
+                                    message=_"Buy a topaz for 9 gold (currently having $topazes of them)"
+                                    {BUY_GEM topazes 9}
+                                [/option]
+                                [option]
+                                    message=_"Buy an opal for 16 gold (currently having $opals of them)"
+                                    {BUY_GEM opals 16}
+                                [/option]
+                                [option]
+                                    message=_"Buy a pearl for 30 gold (currently having $pearls of them)"
+                                    {BUY_GEM pearls 30}
+                                [/option]
+                                [option]
+                                    message=_"Buy a diamond for 55 gold (currently having $diamonds of them)"
+                                    {BUY_GEM diamonds 55}
+                                [/option]
+                                [option]
+                                    message=_"Buy a ruby for 100 gold (currently having $rubies of them)"
+                                    {BUY_GEM rubies 100}
+                                [/option]
+                                [option]
+                                    message=_"Buy an emerald for 200 gold (currently having $emeralds of them)"
+                                    {BUY_GEM emeralds 200}
+                                [/option]
+                                [option]
+                                    message=_"Buy an amethyst for 500 gold (currently having $amethysts of them)"
+                                    {BUY_GEM amethysts 500}
+                                [/option]
+                                [option]
+                                    message=_"Buy a sapphire for 1000 gold (currently having $sapphires of them)"
+                                    {BUY_GEM sapphires 1000}
+                                [/option]
+                                [option]
+                                    message=_"Buy a black pearl for 2000 gold (currently having $black_pearls of them)"
+                                    {BUY_GEM black_pearls 2000}
+                                [/option]
+                                [option]
+                                    message=_"I have bought all I needed."
+                                    [command]
+                                        {VARIABLE done yes}
+                                    [/command]
+                                [/option]
+                            [/message]
+                            {CLEAR_VARIABLE gold}
+                        [/do]
+                    [/while]
+                    {CLEAR_VARIABLE done}
                 [/command]
             [/option]
             [option]
                 message=_"Sell."
                 [command]
-            [while]
-                [not]
-                    [variable]
-                        name=done
-                        equals=yes
-                    [/variable]
-                [/not]
-                [do]
-                    [store_gold]
-                        side=1
-                        variable=gold
-                    [/store_gold]
-                    [message]
-                        speaker=trader4
-                        message= _ "I will pay you more than anyone in this kingdom! Well, I don't think anyone else is buying them..."
-                        [option]
-                        message=_"Sell an obsidian for 3 gold (currently having $obsidians of them)"
-                        {SELL_GEM obsidians 3}
-                        [/option]
-                        [option]
-                        message=_"Sell a topaz for 5 gold (currently having $topazes of them)"
-                        {SELL_GEM topazes 5}
-                        [/option]
-                        [option]
-                        message=_"Sell an opal for 8 gold (currently having $opals of them)"
-                        {SELL_GEM opals 8}
-                        [/option]
-                        [option]
-                        message=_"Sell a pearl for 12 gold (currently having $pearls of them)"
-                        {SELL_GEM pearls 12}
-                        [/option]
-                        [option]
-                        message=_"Sell a diamond for 18 gold (currently having $diamonds of them)"
-                        {SELL_GEM diamonds 18}
-                        [/option]
-                        [option]
-                        message=_"Sell a ruby for 25 gold (currently having $rubies of them)"
-                        {SELL_GEM rubies 25}
-                        [/option]
-                        [option]
-                        message=_"Sell an emerald for 40 gold (currently having $emeralds of them)"
-                        {SELL_GEM emeralds 40}
-                        [/option]
-                        [option]
-                        message=_"Sell an amethyst for 60 gold (currently having $amethysts of them)"
-                        {SELL_GEM amethysts 60}
-                        [/option]
-                        [option]
-                        message=_"Sell a sapphire for 90 gold (currently having $sapphires of them)"
-                        {SELL_GEM sapphires 90}
-                        [/option]
-                        [option]
-                        message=_"Sell a black pearl for 150 gold (currently having $black_pearls of them)"
-                        {SELL_GEM black_pearls 150}
-                        [/option]
-                        [option]
-                        message=_"I have sold all I could."
-                        [command]
-                            {VARIABLE done yes}
-                        [/command]
-                        [/option]
-                    [/message]
-                    {CLEAR_VARIABLE gold}
-                [/do]
-            [/while]
-            {CLEAR_VARIABLE done}
+                    [while]
+                        [not]
+                            [variable]
+                                name=done
+                                equals=yes
+                            [/variable]
+                        [/not]
+                        [do]
+                            [store_gold]
+                                side=1
+                                variable=gold
+                            [/store_gold]
+                            [message]
+                                speaker=trader4
+                                message= _ "I will pay you more than anyone in this kingdom! Well, I don't think anyone else is buying them..."
+                                [option]
+                                    message=_"Sell an obsidian for 3 gold (currently having $obsidians of them)"
+                                    {SELL_GEM obsidians 3}
+                                [/option]
+                                [option]
+                                    message=_"Sell a topaz for 5 gold (currently having $topazes of them)"
+                                    {SELL_GEM topazes 5}
+                                [/option]
+                                [option]
+                                    message=_"Sell an opal for 8 gold (currently having $opals of them)"
+                                    {SELL_GEM opals 8}
+                                [/option]
+                                [option]
+                                    message=_"Sell a pearl for 12 gold (currently having $pearls of them)"
+                                    {SELL_GEM pearls 12}
+                                [/option]
+                                [option]
+                                    message=_"Sell a diamond for 18 gold (currently having $diamonds of them)"
+                                    {SELL_GEM diamonds 18}
+                                [/option]
+                                [option]
+                                    message=_"Sell a ruby for 25 gold (currently having $rubies of them)"
+                                    {SELL_GEM rubies 25}
+                                [/option]
+                                [option]
+                                    message=_"Sell an emerald for 40 gold (currently having $emeralds of them)"
+                                    {SELL_GEM emeralds 40}
+                                [/option]
+                                [option]
+                                    message=_"Sell an amethyst for 60 gold (currently having $amethysts of them)"
+                                    {SELL_GEM amethysts 60}
+                                [/option]
+                                [option]
+                                    message=_"Sell a sapphire for 90 gold (currently having $sapphires of them)"
+                                    {SELL_GEM sapphires 90}
+                                [/option]
+                                [option]
+                                    message=_"Sell a black pearl for 150 gold (currently having $black_pearls of them)"
+                                    {SELL_GEM black_pearls 150}
+                                [/option]
+                                [option]
+                                    message=_"I have sold all I could."
+                                    [command]
+                                        {VARIABLE done yes}
+                                    [/command]
+                                [/option]
+                            [/message]
+                            {CLEAR_VARIABLE gold}
+                        [/do]
+                    [/while]
+                    {CLEAR_VARIABLE done}
                 [/command]
             [/option]
             [option]

--- a/spinoffs/The_Beautiful_Child/scenarios/Valley_Passage.cfg
+++ b/spinoffs/The_Beautiful_Child/scenarios/Valley_Passage.cfg
@@ -29,7 +29,7 @@
         side=2
         team_name=good,twisted_good
         user_team_name=_"Non-Combatants"
-    ai_algorithm=idle_ai
+        ai_algorithm=idle_ai
     [/side]
     [side]
         no_leader=yes
@@ -42,910 +42,921 @@
         side=4
         team_name=twisted_good
         user_team_name=_"Twisted Good"
-    [ai]
-        aggression=1
-    [/ai]
+        [ai]
+            aggression=1
+        [/ai]
     [/side]
 
     {TBC_PLACE_WAYPOINT 19 26}
 
     [event]
-    name=prestart
-    {CLEAR_RECALLS}
-    {VARIABLE current_scenario valley_passage}
-    {TBC_ORIGIN faithdome 50 5}
-    {TBC_ORIGIN ziggurat_town 45 33}
-    {TBC_TRANSITION 51-52 1-12 Faithdome _"Faithdome" 51 5}
-    [if]
-        [variable]
-            name=quests.overall
-            greater_than=14
-        [/variable]
-        [then]
-            {TBC_TRANSITION 41-52 33-34 Ziggurat_Town _"Ziggurat Town" 45 33}
-        [/then]
-        [else]
-            [unit]
-                side=2
-                x,y=49,33
-                type=Master at Arms
-                id=Konrad_II
-                name= _"Konrad II"
-                canrecruit=yes
-                [modifications]
-                    [advance]
-                        id=portrait
-                        [effect]
-                            apply_to=profile
-                            portrait="portraits/humans/transparent/fencer.png"
-                        [/effect]
-                    [/advance]
-                [/modifications]
-            [/unit]
-        [/else]
-    [/if]
-    [/event]
-
-    [event]
-    name=start
-    {TBC_GOLD_CHEST 47 24 valley_passage_cave_chest}
-    [if]
-        [variable]
-            name=quests.entered_valley_passage
-            equals=yes
-        [/variable]
-        [else] 
-            [message]
-                speaker=Rimaru
-                message=_"So, we are here, but where exactly is it and does it really exist?"
-            [/message]
-            [message]
-                speaker=wise_warrior
-                message=_"Never been there, but many people talked about it like if it was real. I know it's no evidence, but still..."
-            [/message]
-            [message]
-                speaker=Burke
-                message=_"I think that we should be afraid from enemies who penetrated through the enemy lines. This place isn't completely secure, there might be some fighting still."
-            [/message]
-            {VARIABLE quests.entered_valley_passage yes}
-        [/else]
-    [/if]
-    [event]
-        name=moveto
-        first_time_only=no
-        [filter]
-            side=1
-            x,y=40-51,31-34
-        [/filter]
+        name=prestart
+        {CLEAR_RECALLS}
+        {VARIABLE current_scenario valley_passage}
+        {TBC_ORIGIN faithdome 50 5}
+        {TBC_ORIGIN ziggurat_town 45 33}
+        {TBC_TRANSITION 51-52 1-12 Faithdome _"Faithdome" 51 5}
         [if]
             [variable]
                 name=quests.overall
-                less_than=13
+                greater_than=14
             [/variable]
             [then]
-                [message]
-                    speaker=Konrad_II
-                    message=_"You have a mission to do if I recall correctly."
-                [/message]
-                [message]
-                    speaker=unit
-                    message=_"Yes, I know, but I need to ask you once again where the Hidden Valley is."
-                [/message]
-                [message]
-                    speaker=Konrad_II
-                    message=_"You should have written it down. It should be a cave passage that starts somewhere where the two rivers meet. If it doesn't exist, Luke will probably be near its entrance."
-                [/message]
-                [message]
-                    speaker=unit
-                    message=_"Thanks."
-                [/message]
-                [move_unit]
-                    id=$unit.id
-                    to_x=$x2
-                    to_y=$y2
-                    fire_event=no
-                [/move_unit]
+                {TBC_TRANSITION 41-52 33-34 Ziggurat_Town _"Ziggurat Town" 45 33}
             [/then]
             [else]
-                [if]
-                    [have_unit]
-                        id=Konrad_II
-                    [/have_unit]
-                    [then]
-                        [message]
-                            speaker=unit
-                            message=_"Luke is dead."
-                        [/message]
-                        [message]
-                            speaker=Konrad_II
-                            message=_"Great! Now, their fractions will start fighting each other and they'll be much weaker. Let's exploit this leadership gap to invade Ziggurat."
-                        [/message]
-                        [message]
-                            speaker=unit
-                            message=_"Please send some diggers, the path to Hidden Valley was blocked by a cave-in that Luke used to prevent us from fleeing, unintentionally preventing himself from fleeing."
-                        [/message]
-                        [message]
-                            speaker=Konrad_II
-                            message=_"Interesting. Please tell me how did the fight go?"
-                        [/message]
-                        [endlevel]
-                            result=victory
-                            bonus=yes
-                            {NEW_GOLD_CARRYOVER 100}
-                        [/endlevel]
-                    [/then]
-                [/if]
+                [unit]
+                    side=2
+                    x,y=49,33
+                    type=Master at Arms
+                    id=Konrad_II
+                    name= _"Konrad II"
+                    canrecruit=yes
+                    [modifications]
+                        [advance]
+                            id=portrait
+                            [effect]
+                                apply_to=profile
+                                portrait="portraits/humans/transparent/fencer.png"
+                            [/effect]
+                        [/advance]
+                    [/modifications]
+                [/unit]
             [/else]
         [/if]
     [/event]
-    [if]
-        [variable]
-            name=quests.overall
-            less_than=14
-        [/variable]
-        [then]
-            {TBC_SPAWN_UNITS_NO_LEADER 2 2 "Swordsman,Javelineer,Longbowman,Duelist,Spearman,Bowman,Fencer,Heavy Infantryman,Shock Trooper,Sword Mage,Cavalryman,Dragoon" 46 32}
-            [event]
-                name=moveto
-                [filter]
-                    side=1
-                    x,y=9-22,1-17
-                [/filter]
-                [message]
-                    speaker=unit
-                    message=_"This is the Hidden Valley! Eureka!"
-                [/message]
+
+    [event]
+        name=start
+        {TBC_GOLD_CHEST 47 24 valley_passage_cave_chest}
+        [if]
+            [variable]
+                name=quests.entered_valley_passage
+                equals=yes
+            [/variable]
+            [else]
                 [message]
                     speaker=Rimaru
-                    message=_"Let's see if the bait worked."
+                    message=_"So, we are here, but where exactly is it and does it really exist?"
                 [/message]
-                [unit]
-                    type=Bringer of Light
-                    id=Luke
-                    name=_"Luke, The Bringer of Light"
-                    canrecruit=yes
-                    gender=male
-                    side=4
-                    x,y=18,7
-                [/unit]
-                {GENERIC_UNIT 4 "Mage of Light" 12 10}
+                [message]
+                    speaker=wise_warrior
+                    message=_"Never been there, but many people talked about it like if it was real. I know it's no evidence, but still..."
+                [/message]
+                [message]
+                    speaker=Burke
+                    message=_"I think that we should be afraid from enemies who penetrated through the enemy lines. This place isn't completely secure, there might be some fighting still."
+                [/message]
+                {VARIABLE quests.entered_valley_passage yes}
+            [/else]
+        [/if]
+        [event]
+            name=moveto
+            first_time_only=no
+            [filter]
+                side=1
+                x,y=40-51,31-34
+            [/filter]
+            [if]
+                [variable]
+                    name=quests.overall
+                    less_than=13
+                [/variable]
+                [then]
+                    [message]
+                        speaker=Konrad_II
+                        message=_"You have a mission to do if I recall correctly."
+                    [/message]
+                    [message]
+                        speaker=unit
+                        message=_"Yes, I know, but I need to ask you once again where the Hidden Valley is."
+                    [/message]
+                    [message]
+                        speaker=Konrad_II
+                        message=_"You should have written it down. It should be a cave passage that starts somewhere where the two rivers meet. If it doesn't exist, Luke will probably be near its entrance."
+                    [/message]
+                    [message]
+                        speaker=unit
+                        message=_"Thanks."
+                    [/message]
+                    [move_unit]
+                        id=$unit.id
+                        to_x=$x2
+                        to_y=$y2
+                        fire_event=no
+                    [/move_unit]
+                [/then]
+                [else]
+                    [if]
+                        [have_unit]
+                            id=Konrad_II
+                        [/have_unit]
+                        [then]
+                            [message]
+                                speaker=unit
+                                message=_"Luke is dead."
+                            [/message]
+                            [message]
+                                speaker=Konrad_II
+                                message=_"Great! Now, their fractions will start fighting each other and they'll be much weaker. Let's exploit this leadership gap to invade Ziggurat."
+                            [/message]
+                            [message]
+                                speaker=unit
+                                message=_"Please send some diggers, the path to Hidden Valley was blocked by a cave-in that Luke used to prevent us from fleeing, unintentionally preventing himself from fleeing."
+                            [/message]
+                            [message]
+                                speaker=Konrad_II
+                                message=_"Interesting. Please tell me how did the fight go?"
+                            [/message]
+                            [endlevel]
+                                result=victory
+                                bonus=yes
+                                {NEW_GOLD_CARRYOVER 100}
+                            [/endlevel]
+                        [/then]
+                    [/if]
+                [/else]
+            [/if]
+        [/event]
+        [if]
+            [variable]
+                name=quests.overall
+                less_than=14
+            [/variable]
+            [then]
+                {TBC_SPAWN_UNITS_NO_LEADER 2 2 "Swordsman,Javelineer,Longbowman,Duelist,Spearman,Bowman,Fencer,Heavy Infantryman,Shock Trooper,Sword Mage,Cavalryman,Dragoon" 46 32}
+                [event]
+                    name=moveto
+                    [filter]
+                        side=1
+                        x,y=9-22,1-17
+                    [/filter]
+                    [message]
+                        speaker=unit
+                        message=_"This is the Hidden Valley! Eureka!"
+                    [/message]
+                    [message]
+                        speaker=Rimaru
+                        message=_"Let's see if the bait worked."
+                    [/message]
+                    [unit]
+                        type=Bringer of Light
+                        id=Luke
+                        name=_"Luke, The Bringer of Light"
+                        canrecruit=yes
+                        gender=male
+                        side=4
+                        x,y=18,7
+                    [/unit]
+                    {GENERIC_UNIT 4 "Mage of Light" 12 10}
 #ifdef HARD
-                {GENERIC_UNIT 4 "Mage of Light" 19 11}
+                    {GENERIC_UNIT 4 "Mage of Light" 19 11}
 #endif
 #ifndef EASY
-                {GENERIC_UNIT 4 "Mage of Light" 10 6}
+                    {GENERIC_UNIT 4 "Mage of Light" 10 6}
 #endif
-                {GENERIC_UNIT 4 "Mage of Light" 16 5}
-                [+unit]
-                    id=mage_speaker
-                [/unit]
-                [store_unit]
-                    [filter]
-                        type=Mage of Light
-                        side=4
-                    [/filter]
-                    variable=mages
-                    kill=no
-                [/store_unit]
-                {FOREACH mages i}
-                    [object]
-                        silent=yes
+                    {GENERIC_UNIT 4 "Mage of Light" 16 5}
+                    [+unit]
+                        id=mage_speaker
+                    [/unit]
+                    [store_unit]
                         [filter]
-                            id=$mages[$i].id
+                            type=Mage of Light
+                            side=4
                         [/filter]
-                        [effect]
-                            apply_to=attack
-                            [set_specials]
-                                [chance_to_hit]
-                                    id=dazzle_counter
-                                    value=30
-                                    apply_to=opponent
-                                    [filter_base_value]
-                                        greater_than=30
-                                    [/filter_base_value]
-                                    [filter_opponent]
-                                        [filter_wml]
-                                            [variables]
-                                                dazzled=yes
-                                            [/variables]
-                                        [/filter_wml]
-                                    [/filter_opponent]
-                                [/chance_to_hit]
-                            [/set_specials]
-                        [/effect]
-                    [/object]
-                {NEXT i}
-                {CLEAR_VARIABLE mages}
-                {VARIABLE i 24}
-                [while]
-                    [variable]
-                        name=i
-                        greater_than=0
-                    [/variable]
-                    [do]
-                        {GENERIC_UNIT 2 Peasant 20 8}
-                        {VARIABLE_OP i sub 1}
-                    [/do]
-                [/while]
-                {GENERIC_UNIT 2 "Peasant" 19 10}
-                [+unit]
-                    id=peasant_speaker_1
-                [/unit]
-                {GENERIC_UNIT 2 "Peasant" 17 7}
-                [+unit]
-                    id=peasant_speaker_2
-                [/unit]
-                [remove_shroud]
-                    x,y=15,9
-                    radius=7
-                    side=1
-                [/remove_shroud]
-                [move_unit]
-                    side=1
-                    to_x=17
-                    to_y=12
-                    fire_event=no
-                [/move_unit]
-                [message]
-                    speaker=Luke
-                    message=_"Work, dig in the ground, the ancient vault must be somewhere around here. If I was Niflheim the Horror from the Northern Wastelands, I would hide it somewhere around here."
-                [/message]
-                [message]
-                    speaker=Burke
-                    message=_"Hello, Luke. We came here to see you."
-                [/message]
-                [message]
-                    speaker=hired_swordsman
-                    message=_"Kill him!"
-                [/message]
-                [message]
-                    speaker=Luke
-                    message=_"So you came here. I should have known your intentions, you're trying to steal the phoenix ash for yourself! If you find it, you'll pose a great threat to our order and to the entire kingdom!"
-                [/message]
-                [message]
-                    speaker=Sicaria
-                    message=_"There is no phoenix ash, we made that rumour in order to get you in a distant place where escape is uneasy. Now, we are going to kill you."
-                [/message]
-                [message]
-                    speaker=Luke
-                    message=_"Fools! You will not deceive me with such cheap tricks. It is here and it is MINE. You will not have it because I will kill you now. Wait... aren't you Sicaria Homicide, by the way?"
-                [/message]
-                [message]
-                    speaker=Sicaria
-                    message=_"Yes, I am. I realised that the ring you gave me that is supposed to empower me when I kill the unrighteous just empowers me whenever I kill something. It seems that it steals souls. Just like you were, when you found me dying in that morgue. You're a soul stealer, of the worst kind. You disobeyed every single rule of your order..."
-                [/message]
-                [message]
-                    speaker=Luke
-                    message=_"Shut up, nobody is interested in random stories you make up, girl. Write a book about that, maybe you'll turn out to be a good novel writer."
-                    [option]
-                    message=_"Luke, accept that we have found, trapped you and you have nothing to explain anymore, we all know about your wrongdoings."
-                    [command]
-                        [message]
-                            speaker=Rimaru
-                            message=_"Now, you've lost."
-                        [/message]
-                    [/command]
-                    [/option]
-                    [option]
-                    message=_"Look at you. You have only a few allies here and we're in full force. There is no way to escape. You will die."
-                    [command]
-                        [message]
-                            speaker=Burke
-                            message=_"I am not an expert on war strategy, but I can easily tell whose forces are superior here."
-                        [/message]
-                    [/command]
-                    [/option]
-                    [option]
-                    message=_"Tell me how to steal souls or I will torture you until you tell me that."
-                    [command]
-                        [message]
-                            speaker=Rimaru
-                            message=_"No, we will not torture and you will not learn the dark art of stealing souls."
-                        [/message]
-                        [message]
-                            speaker=Luke
-                            message=_"Ha ha ha... Join me. Be my apprentice!"
-                        [/message]
-                        [message]
-                            speaker=player
-                            message=_"I don't serve people like you!"
-                        [/message]
-                        [message]
-                            speaker=Luke
-                            message=_"So you won't learn anything."
-                        [/message]
-                        [message]
-                            speaker=Rimaru
-                            message=_"So be it. What matters is that you must die."
-                        [/message]
-                    [/command]
-                    [/option]
-                [/message]
-                [message]
-                    speaker=Luke
-                    message=_"Peasants. I will need you to understand the conception of divine sacrifice."
-                [/message]
-                [message]
-                    speaker=peasant_speaker_1
-                    message=_"I don't know what it is, but it sounds pretty grim."
-                [/message]
-                [message]
-                    speaker=she_brother
-                    message=_"I have a feeling that this will be really grim."
-                [/message]
-                [message]
-                    speaker=mage_speaker
-                    message=_"You plan to sacrifice yourself and let us die here?"
-                [/message]
-                [message]
-                    speaker=Luke
-                    message=_"The idea is that you kill something you need in order to gain higher favours of gods. Human sacrifice is the greatest of sacrifices and it brings the greatest gifts from gods, because you show that you love your gods so much that you are willing to give human life."
-                [/message]
-                [message]
-                    speaker=peasant_speaker_2
-                    message=_"That sounds very grim."
-                [/message]
-                [message]
-                    speaker=she_brother
-                    message=_"Where did you learn <i>that</i>? Our gods never spoke about that!"
-                [/message]
-                [message]
-                    speaker=mage_speaker
-                    message=_"That is what pagans do, Brothers of Light don't have to sacrifice objects and beings to gods because everything we have was given to us by gods and we should not refuse the gifts!"
-                [/message]
-                [message]
-                    speaker=Luke
-                    message=_"A peasant cares about the crops, fertilises the ground, poisons the weeds. Our food is from peasants, not from gods. A smith makes weapons, a carpenter makes wooden structures. Our tools and buildings are made by humans, not gods. Humans are made by other humans, not by gods. All we possess aren't gifts from gods. Wild animals, trees and mountains might be gifts from them, but we don't sacrifice them as you told."
-                [/message]
-                [message]
-                    speaker=Rimaru
-                    message=_"I second that idea that gods aren't behind everything, because most things we have were made by humans, but I would never ever use it to justify murder! And not a murder out of hatred or vengeance, but a selfish murder for minor personal gains!"
-                [/message]
-                [message]
-                    speaker=Luke
-                    message=_"Enough, Rimaru, let me finish my idea. Gods didn't tell us much what we should do and so we should learn from the pagans. They sacrifice and they gain favours. If we sacrificed, we would gain more favours than we're getting now. We need sacrifice to feed the Child with the most precious thing we have, our lives."
-                [/message]
-                [message]
-                    speaker=mage_speaker
-                    message=_"Do you mean that you're already killing humans before the Child? That's horrible!"
-                [/message]
-                [message]
-                    speaker=Luke
-                    message=_"It accelerates his growth, makes his powers stronger and brings happiness to his face. He thrives when sacrifices are done."
-                [/message]
-                [message]
-                    speaker=mage_speaker
-                    message=_"That is incredible!"
-                [/message]
-                [message]
-                    speaker=Rimaru
-                    message=_"I wonder how would bloody murders give strength to the Divine Child."
-                    [option]
-                    message=_"Maybe it isn't a Divine Child, but a child of a demon."
-                    [command]
-                        [message]
-                            speaker=Burke
-                            message=_"A demon in disguise. Interesting, but what else would need human sacrifices?"
-                        [/message]
-                        [message]
-                            speaker=faithful_lieutenant
-                            message=_"A child of pagan gods?"
-                        [/message]
-                        [message]
-                            speaker=Rimaru
-                            message=_"Luke, he steals souls, remember?"
-                        [/message]
-                    [/command]
-                    [/option]
-                    [option]
-                    message=_"What if our gods are more bloodthirsty than we think?"
-                    [command]
-                        [message]
-                            speaker=Rimaru
-                            message=_"If that is true, I will convert to atheism and force atheism to anybody in this kingdom. Nobody would worship vampire gods."
-                        [/message]
-                        [message]
-                            speaker=Burke
-                            message=_"We would still need to rip apart the Brothers of Light's order."
-                        [/message]
-                        [message]
-                            speaker=hired_halberdier
-                            message=_"Yeah, let's do that!"
-                        [/message]
-                        [message]
-                            speaker=Sicaria
-                            message=_"Guys, think about the fact that Luke steals souls. What is the best way to cover multiple murders? Tell that you're doing it in the name of gods, like any other crimes."
-                        [/message]
-                    [/command]
-                    [/option]
-                    [option]
-                    message=_"What if Luke is stealing the souls also there and adding all the sacrifice stuff just to legalise it?"
-                    [command]
-                        [message]
-                            speaker=Rimaru
-                            message=_"That sounds reasonable..."
-                        [/message]
-                    [/command]
-                    [/option]
-                [/message]
-                [message]
-                    speaker=Burke
-                    message=_"Luke, it's amazing how you have corrupted your order. How excellently you can make up anything to justify any crimes. A person like you is very dangerous and should be sent into the world of the dead."
-                [/message]
-                [message]
-                    speaker=mage_speaker
-                    message=_"The child is growing stronger from sacrifice! We must practise sacrifice! Thank Luke for his discovery!"
-                [/message]
-                [message]
-                    speaker=orc
-                    message=_"Idiots. Orcs can be stupid, but humans possess the ability of wilful ignorance that is beyond orcish stupidity."
-                [/message]
-                [message]
-                    speaker=Luke
-                    message=_"I think that we'll need a sacrifice right now, right here."
-                [/message]
-                [message]
-                    speaker=peasant_speaker_1
-                    message=_"I have a really grim feeling about this!"
-                [/message]
-                [store_unit]
-                    [filter]
-                        type=Peasant
-                        side=2
-                    [/filter]
-                    variable=peasants
-                    kill=no
-                [/store_unit]
-                {VARIABLE j 100}
-                [while]
-                    [variable]
-                        name=j
-                        greater_than=0
-                    [/variable]
-                    [do]
-                        {VARIABLE_OP j sub 5}
-                        [delay]
-                            time=200
-                        [/delay]
-                        [if]
-                            [variable]
-                                name=j
-                                equals=60
-                            [/variable]
-                            [then]
-                                [message]
-                                    speaker=peasant_speaker_2
-                                    message=_"Argh! Stop that! That is horrible! How can a Brother of Light like you do something like this!"
-                                [/message]
-                                [message]
-                                    speaker=Luke
-                                    message=_"I am sorry, but it's necessary for my survival and my survival is the only thing that saves you from the darkness these heretics bring."
-                                [/message]
-                            [/then]
-                        [/if]
-                        [if]
-                            [variable]
-                                name=j
-                                equals=40
-                            [/variable]
-                            [then]
-                                [message]
-                                    speaker=Sicaria
-                                    message=_"Luke, stop eating their souls!"
-                                [/message]
-                                [message]
-                                    speaker=Luke
-                                    message=_"You enjoyed that, right?"
-                                [/message]
-                                [message]
-                                    speaker=Sicaria
-                                    message=_"I didn't know that I was eating souls! You told me that I am rewarded by gods for killing unrighteous people! And now you've proven me that I was right that you are a soul stealer and no saviour."
-                                [/message]
-                                [message]
-                                    speaker=Luke
-                                    message=_"You betrayed me, so I am done with you. I have no need of traitors."
-                                [/message]
-                            [/then]
-                        [/if]
-                        [if]
-                            [variable]
-                                name=j
-                                equals=20
-                            [/variable]
-                            [then]
-                                [message]
-                                    speaker=Rimaru
-                                    message=_"Luke, stop that! The thing you are doing is the worst evil I have ever seen."
-                                [/message]
-                                [message]
-                                    speaker=peasant_speaker_1
-                                    message=_"Please, do as he asks!"
-                                [/message]
-                                [message]
-                                    speaker=Luke
-                                    message=_"I have done things you would see far worse than this. But it's only because you misunderstand the conception of sacrifice."
-                                [/message]
-                                [message]
-                                    speaker=mage_speaker
-                                    message=_"I will really need to study how this can be righteous when I return."
-                                [/message]
-                                [message]
-                                    speaker=Luke
-                                    message=_"Believe me, it is needed for the greater good."
-                                [/message]
-                            [/then]
-                        [/if]
-                        {FOREACH peasants i}
+                        variable=mages
+                        kill=no
+                    [/store_unit]
+                    [for]
+                        array=mages
+                        [do]
                             [object]
                                 silent=yes
                                 [filter]
-                                    id=$peasants[$i].id
+                                    id=$mages[$i].id
                                 [/filter]
                                 [effect]
-                                    apply_to=image_mod
-                                    replace="O($j%)"
+                                    apply_to=attack
+                                    [set_specials]
+                                        [chance_to_hit]
+                                            id=dazzle_counter
+                                            value=30
+                                            apply_to=opponent
+                                            [filter_base_value]
+                                                greater_than=30
+                                            [/filter_base_value]
+                                            [filter_opponent]
+                                                [filter_wml]
+                                                    [variables]
+                                                        dazzled=yes
+                                                    [/variables]
+                                                [/filter_wml]
+                                            [/filter_opponent]
+                                        [/chance_to_hit]
+                                    [/set_specials]
                                 [/effect]
                             [/object]
-                        {NEXT i}
-                    [/do]
-                [/while]
-                {CLEAR_VARIABLE peasants}
-                [kill]
-                    type=Peasant
-                    side=2
-                    animate=no
-                    fire_event=no
-                [/kill]
-                [if]
-                    [variable]
-                        name=party_members.length
-                        less_than=9
-                    [/variable]
-                    [then]
-                        [object]
-                            [filter]
-                                id=Luke
-                            [/filter]
-                            silent=yes
-                            [effect]
-                                apply_to=hitpoints
-                                increase_total=-30%
-                                heal_full=yes
-                            [/effect]
-                        [/object]
-                    [/then]
-                [/if]
-                [if]
-                    [variable]
-                        name=party_members.length
-                        less_than=4
-                    [/variable]
-                    [then]
-                        [object]
-                            [filter]
-                                id=Luke
-                            [/filter]
-                            silent=yes
-                            [effect]
-                                apply_to=hitpoints
-                                increase_total=-30%
-                                heal_full=yes
-                            [/effect]
-                        [/object]
-                    [/then]
-                [/if]
-                [message]
-                    speaker=Luke
-                    message=_"Now, our gods bestowed upon me the power to destroy you!"
-                [/message]
-                [if]
-                    [variable]
-                        name=party_members.length
-                        less_than=6
-                    [/variable]
-                    [then]
-                        [object]
-                            [filter]
-                                id=Luke
-                            [/filter]
-                            silent=yes
-                            [effect]
-                                apply_to=attack
-                                increase_damage=-30%
-                            [/effect]
-                        [/object]
-                    [/then]
-                [/if]
-#define BLOOD_RAIN X Y
-                [set_variables]
-                    mode=replace
-                    name=blood_rain[$blood_rain.length]
-                    [value]
-                        x,y={X},{Y}
-                        side=4
-                    [/value]
-                [/set_variables]
-                [item]
-                    halo=bloodrain/bloodrain-1.png:40,bloodrain/bloodrain-2.png:40,bloodrain/bloodrain-3.png:40,bloodrain/bloodrain-4.png:40,bloodrain/bloodrain-5.png:40,bloodrain/bloodrain-6.png:40,bloodrain/bloodrain-7.png:40,bloodrain/bloodrain-8.png:40,bloodrain/bloodrain-9.png:40,bloodrain/bloodrain-10.png:40
-                    x,y={X},{Y}
-                [/item]
-#enddef
-                {BLOOD_RAIN 17 7}
-                {BLOOD_RAIN 15 6}
-                {BLOOD_RAIN 21 5}
-                {BLOOD_RAIN 19 9}
-                {BLOOD_RAIN 18 10}
-                {BLOOD_RAIN 21 11}
-                {BLOOD_RAIN 16 12}
-                {BLOOD_RAIN 20 3}
-                {BLOOD_RAIN 14 6}
-                {BLOOD_RAIN 11 4}
-                {BLOOD_RAIN 13 7}
-                {BLOOD_RAIN 8 5}
-                {BLOOD_RAIN 12 3}
-                {BLOOD_RAIN 5 7}
-                {BLOOD_RAIN 5 10}
-                {BLOOD_RAIN 6 11}
-                {BLOOD_RAIN 10 11}
-                {BLOOD_RAIN 13 14}
-                {BLOOD_RAIN 17 16}
-                {BLOOD_RAIN 19 12}
-                {BLOOD_RAIN 19 15}
-                {BLOOD_RAIN 10 7}
-                {BLOOD_RAIN 13 10}
-                {BLOOD_RAIN 11 6}
-                {BLOOD_RAIN 15 9}
-                {BLOOD_RAIN 9 3}
-                {BLOOD_RAIN 17 3}
-                {BLOOD_RAIN 15 4}
-                {BLOOD_RAIN 23 3}
-                {BLOOD_RAIN 24 6}
-                {BLOOD_RAIN 24 9}
-                {BLOOD_RAIN 22 13}
-                {BLOOD_RAIN 17 12}
-#undef BLOOD_RAIN
-                [event]
-                    name=victory
-                    id=remove_blood_rain_notes
-                    {CLEAR_VARIABLE blood_rain}
-                [/event]
-                [event]
-                    name=turn refresh
-                    first_time_only=no
-                    [fire_event]
-                        name=blood_rain
-                    [/fire_event]
-                [/event]
-                [event]
-                    name=blood_rain
-                    first_time_only=no
-                    [store_side]
-                        side=$side_number
-                        variable=this_side
-                    [/store_side]
-                    {FOREACH blood_rain i}
-                        [store_side]
-                            side=$blood_rain[$i].side
-                            variable=rain_side
-                        [/store_side]
-                        [if]
-                            [variable]
-                                name=this_side.team_name
-                                equals=$rain_side.team_name
-                            [/variable]
-                            [then]
-                                [heal_unit]
-                                    [filter]
-                                    [filter_location]
-                                        x,y=$blood_rain[$i].x,$blood_rain[$i].y
-                                        radius=1
-                                    [/filter_location]
-                                    side=$side_number
-                                    [/filter]
-                                    amount=8
-                                    animate=yes
-                                    restore_statuses=yes
-                                [/heal_unit]
-                            [/then]
-                            [else]
-                                [harm_unit]
-                                    [filter]
-                                    [filter_location]
-                                        x,y=$blood_rain[$i].x,$blood_rain[$i].y
-                                        radius=1
-                                    [/filter_location]
-                                    side=$side_number
-                                    [/filter]
-                                    amount=8
-                                    slowed=yes
-                                    kill=no
-                                [/harm_unit]
-                            [/else]
-                        [/if]
-                        {CLEAR_VARIABLE rain_side}
-                    {NEXT i}
-                    {CLEAR_VARIABLE this_side}
-                [/event]
-                [message]
-                    speaker=she_brother
-                    message=_"A rain of blood? It think that it's too obvious that it's something evil!"
-                [/message]
-                [message]
-                    speaker=Luke
-                    message=_"Besides this cleansing rain, I am also destroying the caves you came from to make sure that you won't flee."
-                [/message]
-                {EARTHQUAKE (
-                    [terrain]
-                        x,y=8,17
-                        terrain=Xu
-                    [/terrain]
-                    [terrain]
-                        x,y=9,17
-                        terrain=Ur^Dr
-                    [/terrain]
-                    [redraw]
-                    [/redraw]
-                )}
-                [message]
-                    speaker=Rimaru
-                    message=_"You will die for this. I will not flee."
-                [/message]
-                {VARIABLE quests.overall 13}
-                [message]
-                    speaker=Sicaria
-                    message=_"This stupid rain hurts. We'll need to find some spots where it isn't raining so heavily."
-                [/message]
-                [message]
-                    speaker=hired_halberdier
-                    message=_"I wonder why he didn't try to explain that our goddess is menstruating."
-                [/message]
-                [end_turn]
-                [/end_turn]
-                [event]
-                    name=turn refresh
-                    [filter]
-                        side=4
-                    [/filter]
-                    [modify_unit]
-                        [filter]
-                            id=Luke
-                        [/filter]
-                        moves=0
-                        attacks_left=0
-                    [/modify_unit]
-                [/event]
-                [event]
-                    name=last breath
-                    [filter]
-                        id=Luke
-                    [/filter]
+                        [/do]
+                    [/for]
+                    {CLEAR_VARIABLE mages}
+                    {VARIABLE i 24}
+                    [while]
+                        [variable]
+                            name=i
+                            greater_than=0
+                        [/variable]
+                        [do]
+                            {GENERIC_UNIT 2 Peasant 20 8}
+                            {VARIABLE_OP i sub 1}
+                        [/do]
+                    [/while]
+                    {GENERIC_UNIT 2 "Peasant" 19 10}
+                    [+unit]
+                        id=peasant_speaker_1
+                    [/unit]
+                    {GENERIC_UNIT 2 "Peasant" 17 7}
+                    [+unit]
+                        id=peasant_speaker_2
+                    [/unit]
+                    [remove_shroud]
+                        x,y=15,9
+                        radius=7
+                        side=1
+                    [/remove_shroud]
+                    [move_unit]
+                        side=1
+                        to_x=17
+                        to_y=12
+                        fire_event=no
+                    [/move_unit]
                     [message]
                         speaker=Luke
-                        message= _ "Save me, Sicaria, it's me, your old friend and saviour."
-                    [/message]
-                    [message]
-                        speaker=Sicaria
-                        message= _ "You saved me and pretended friendship to make me kill many people and do horrible things with their souls."
-                    [/message]
-                    [message]
-                        speaker=Luke
-                        message= _ "It isn't forbidden to steal and devour souls."
-                    [/message]
-                    [message]
-                        speaker=Sicaria
-                        message= _ "It isn't forbidden because nobody thought somebody would do it. Anyway, I think that it is a kind of desecration of human remains, so it is forbidden. Furthermore, I have just seen you committing a mass murder, which is forbidden. And condemnable. I will not save you, villain."
-                    [/message]
-                    [message]
-                        speaker=Luke
-                        message= _ "Save me, former Brother of Light, I will let you join the order again and I will also grant you the title of Master."
-                    [/message]
-                    [message]
-                        speaker=she_brother
-                        message= _ "I have left the order voluntarily and your actions only strengthened my belief that my choice was right."
-                    [/message]
-                    [message]
-                        speaker=Rimaru
-                        message= _ "I was thinking about leaving the order for long and I left when I was absolutely certain that it was what I wanted."
-                    [/message]
-                    [message]
-                        speaker=Luke
-                        message= _ "Your sister is alive."
-                    [/message]
-                    [message]
-                        speaker=Rimaru
-                        message= _ "I am aware of that. However, your horrible way of abducting her is even worse than just letting her die. You've persuaded me that I was wrong when I thought you were less bad than you really are."
-                    [/message]
-                    [message]
-                        speaker=Luke
-                        message= _ "And you..."
-                    [/message]
-                    [message]
-                        speaker=elf_merc
-                        message= _ "If somebody tries to help him, I will pierce his neck with an arrow. I long to take his trinkets."
+                        message=_"Work, dig in the ground, the ancient vault must be somewhere around here. If I was Niflheim the Horror from the Northern Wastelands, I would hide it somewhere around here."
                     [/message]
                     [message]
                         speaker=Burke
-                        message= _ "He's dead!"
+                        message=_"Hello, Luke. We came here to see you."
                     [/message]
-                    {VARIABLE quests.overall 14}
                     [message]
-                        speaker=Rimaru
-                        message= _ "Now, how do we get out of here? The cave's ceiling crumbled."
+                        speaker=hired_swordsman
+                        message=_"Kill him!"
                     [/message]
-                    [terrain]
-                        x,y=24,14
-                        terrain=Mm
-                    [/terrain]
-                    [redraw]
-                    [/redraw]
-                    [store_unit]
-                        [filter]
-                            side=1
-                            [filter_wml]
-                                [movement_costs]
-                                    mountains={UNREACHABLE}
-                                [/movement_costs]
-                            [/filter_wml]
-                        [/filter]
-                        variable=cant_pass
-                    [/store_unit]
-                    {FOREACH cant_pass i}
-                        [set_variables]
-                            name=cant_pass[$i].modifications.advance[$cant_pass[$i].modifications.advance.length]
-                            mode=replace
-                            [value]
-                                id=mountain_passing
-                                [effect]
-                                    apply_to=movement_costs
-                                    replace=true
-                                    [movement_costs]
-                                        mountains=3
-                                    [/movement_costs]
-                                [/effect]
-                            [/value]
-                        [/set_variables]
-                        {VARIABLE cant_pass[$i].movement_costs.mountains 3}
-                        [unstore_unit]
-                            variable=cant_pass[$i]
-                            find_vacant=no
-                        [/unstore_unit]
-                    {NEXT i}
-                    [if]
-                        [variable]
-                            name=cant_pass.length
-                            greater_than=0
-                        [/variable]
-                        [then]
-                            [message]
-                                speaker=Burke
-                                message= _ "I think that we'll need a heavy hike through the mountains, can all of us pass through mountains?"
-                            [/message]
-                            [message]
-                                id=$cant_pass.id
-                                message= _ "I hope I'll manage."
-                            [/message]
-                            [message]
-                                speaker=Burke
-                                message= _ "That might be too risky. We'll get you out of there. Just find shelter from the accursed rain!"
-                            [/message]
-                        [/then]
-                        [else]
-                            [message]
-                                speaker=Burke
-                                message= _ "When the cave is blocked, we'll need to pass through the mountains somehow. Fortunately, none of us has problems with mountains, so let's find a place where the mountains can be crossed. Otherwise, we'll just need to find some shelter from the accursed rain."
-                            [/message]
-                        [/else]
-                    [/if]
-                    {CLEAR_VARIABLE cant_pass}
+                    [message]
+                        speaker=Luke
+                        message=_"So you came here. I should have known your intentions, you're trying to steal the phoenix ash for yourself! If you find it, you'll pose a great threat to our order and to the entire kingdom!"
+                    [/message]
                     [message]
                         speaker=Sicaria
-                        message= _ "And we'll see Konrad then, right?"
+                        message=_"There is no phoenix ash, we made that rumour in order to get you in a distant place where escape is uneasy. Now, we are going to kill you."
                     [/message]
+                    [message]
+                        speaker=Luke
+                        message=_"Fools! You will not deceive me with such cheap tricks. It is here and it is MINE. You will not have it because I will kill you now. Wait... aren't you Sicaria Homicide, by the way?"
+                    [/message]
+                    [message]
+                        speaker=Sicaria
+                        message=_"Yes, I am. I realised that the ring you gave me that is supposed to empower me when I kill the unrighteous just empowers me whenever I kill something. It seems that it steals souls. Just like you were, when you found me dying in that morgue. You're a soul stealer, of the worst kind. You disobeyed every single rule of your order..."
+                    [/message]
+                    [message]
+                        speaker=Luke
+                        message=_"Shut up, nobody is interested in random stories you make up, girl. Write a book about that, maybe you'll turn out to be a good novel writer."
+                        [option]
+                            message=_"Luke, accept that we have found, trapped you and you have nothing to explain anymore, we all know about your wrongdoings."
+                            [command]
+                                [message]
+                                    speaker=Rimaru
+                                    message=_"Now, you've lost."
+                                [/message]
+                            [/command]
+                        [/option]
+                        [option]
+                            message=_"Look at you. You have only a few allies here and we're in full force. There is no way to escape. You will die."
+                            [command]
+                                [message]
+                                    speaker=Burke
+                                    message=_"I am not an expert on war strategy, but I can easily tell whose forces are superior here."
+                                [/message]
+                            [/command]
+                        [/option]
+                        [option]
+                            message=_"Tell me how to steal souls or I will torture you until you tell me that."
+                            [command]
+                                [message]
+                                    speaker=Rimaru
+                                    message=_"No, we will not torture and you will not learn the dark art of stealing souls."
+                                [/message]
+                                [message]
+                                    speaker=Luke
+                                    message=_"Ha ha ha... Join me. Be my apprentice!"
+                                [/message]
+                                [message]
+                                    speaker=player
+                                    message=_"I don't serve people like you!"
+                                [/message]
+                                [message]
+                                    speaker=Luke
+                                    message=_"So you won't learn anything."
+                                [/message]
+                                [message]
+                                    speaker=Rimaru
+                                    message=_"So be it. What matters is that you must die."
+                                [/message]
+                            [/command]
+                        [/option]
+                    [/message]
+                    [message]
+                        speaker=Luke
+                        message=_"Peasants. I will need you to understand the conception of divine sacrifice."
+                    [/message]
+                    [message]
+                        speaker=peasant_speaker_1
+                        message=_"I don't know what it is, but it sounds pretty grim."
+                    [/message]
+                    [message]
+                        speaker=she_brother
+                        message=_"I have a feeling that this will be really grim."
+                    [/message]
+                    [message]
+                        speaker=mage_speaker
+                        message=_"You plan to sacrifice yourself and let us die here?"
+                    [/message]
+                    [message]
+                        speaker=Luke
+                        message=_"The idea is that you kill something you need in order to gain higher favours of gods. Human sacrifice is the greatest of sacrifices and it brings the greatest gifts from gods, because you show that you love your gods so much that you are willing to give human life."
+                    [/message]
+                    [message]
+                        speaker=peasant_speaker_2
+                        message=_"That sounds very grim."
+                    [/message]
+                    [message]
+                        speaker=she_brother
+                        message=_"Where did you learn <i>that</i>? Our gods never spoke about that!"
+                    [/message]
+                    [message]
+                        speaker=mage_speaker
+                        message=_"That is what pagans do, Brothers of Light don't have to sacrifice objects and beings to gods because everything we have was given to us by gods and we should not refuse the gifts!"
+                    [/message]
+                    [message]
+                        speaker=Luke
+                        message=_"A peasant cares about the crops, fertilises the ground, poisons the weeds. Our food is from peasants, not from gods. A smith makes weapons, a carpenter makes wooden structures. Our tools and buildings are made by humans, not gods. Humans are made by other humans, not by gods. All we possess aren't gifts from gods. Wild animals, trees and mountains might be gifts from them, but we don't sacrifice them as you told."
+                    [/message]
+                    [message]
+                        speaker=Rimaru
+                        message=_"I second that idea that gods aren't behind everything, because most things we have were made by humans, but I would never ever use it to justify murder! And not a murder out of hatred or vengeance, but a selfish murder for minor personal gains!"
+                    [/message]
+                    [message]
+                        speaker=Luke
+                        message=_"Enough, Rimaru, let me finish my idea. Gods didn't tell us much what we should do and so we should learn from the pagans. They sacrifice and they gain favours. If we sacrificed, we would gain more favours than we're getting now. We need sacrifice to feed the Child with the most precious thing we have, our lives."
+                    [/message]
+                    [message]
+                        speaker=mage_speaker
+                        message=_"Do you mean that you're already killing humans before the Child? That's horrible!"
+                    [/message]
+                    [message]
+                        speaker=Luke
+                        message=_"It accelerates his growth, makes his powers stronger and brings happiness to his face. He thrives when sacrifices are done."
+                    [/message]
+                    [message]
+                        speaker=mage_speaker
+                        message=_"That is incredible!"
+                    [/message]
+                    [message]
+                        speaker=Rimaru
+                        message=_"I wonder how would bloody murders give strength to the Divine Child."
+                        [option]
+                            message=_"Maybe it isn't a Divine Child, but a child of a demon."
+                            [command]
+                                [message]
+                                    speaker=Burke
+                                    message=_"A demon in disguise. Interesting, but what else would need human sacrifices?"
+                                [/message]
+                                [message]
+                                    speaker=faithful_lieutenant
+                                    message=_"A child of pagan gods?"
+                                [/message]
+                                [message]
+                                    speaker=Rimaru
+                                    message=_"Luke, he steals souls, remember?"
+                                [/message]
+                            [/command]
+                        [/option]
+                        [option]
+                            message=_"What if our gods are more bloodthirsty than we think?"
+                            [command]
+                                [message]
+                                    speaker=Rimaru
+                                    message=_"If that is true, I will convert to atheism and force atheism to anybody in this kingdom. Nobody would worship vampire gods."
+                                [/message]
+                                [message]
+                                    speaker=Burke
+                                    message=_"We would still need to rip apart the Brothers of Light's order."
+                                [/message]
+                                [message]
+                                    speaker=hired_halberdier
+                                    message=_"Yeah, let's do that!"
+                                [/message]
+                                [message]
+                                    speaker=Sicaria
+                                    message=_"Guys, think about the fact that Luke steals souls. What is the best way to cover multiple murders? Tell that you're doing it in the name of gods, like any other crimes."
+                                [/message]
+                            [/command]
+                        [/option]
+                        [option]
+                            message=_"What if Luke is stealing the souls also there and adding all the sacrifice stuff just to legalise it?"
+                            [command]
+                                [message]
+                                    speaker=Rimaru
+                                    message=_"That sounds reasonable..."
+                                [/message]
+                            [/command]
+                        [/option]
+                    [/message]
+                    [message]
+                        speaker=Burke
+                        message=_"Luke, it's amazing how you have corrupted your order. How excellently you can make up anything to justify any crimes. A person like you is very dangerous and should be sent into the world of the dead."
+                    [/message]
+                    [message]
+                        speaker=mage_speaker
+                        message=_"The child is growing stronger from sacrifice! We must practise sacrifice! Thank Luke for his discovery!"
+                    [/message]
+                    [message]
+                        speaker=orc
+                        message=_"Idiots. Orcs can be stupid, but humans possess the ability of wilful ignorance that is beyond orcish stupidity."
+                    [/message]
+                    [message]
+                        speaker=Luke
+                        message=_"I think that we'll need a sacrifice right now, right here."
+                    [/message]
+                    [message]
+                        speaker=peasant_speaker_1
+                        message=_"I have a really grim feeling about this!"
+                    [/message]
+                    [store_unit]
+                        [filter]
+                            type=Peasant
+                            side=2
+                        [/filter]
+                        variable=peasants
+                        kill=no
+                    [/store_unit]
+                    {VARIABLE j 100}
+                    [while]
+                        [variable]
+                            name=j
+                            greater_than=0
+                        [/variable]
+                        [do]
+                            {VARIABLE_OP j sub 5}
+                            [delay]
+                                time=200
+                            [/delay]
+                            [if]
+                                [variable]
+                                    name=j
+                                    equals=60
+                                [/variable]
+                                [then]
+                                    [message]
+                                        speaker=peasant_speaker_2
+                                        message=_"Argh! Stop that! That is horrible! How can a Brother of Light like you do something like this!"
+                                    [/message]
+                                    [message]
+                                        speaker=Luke
+                                        message=_"I am sorry, but it's necessary for my survival and my survival is the only thing that saves you from the darkness these heretics bring."
+                                    [/message]
+                                [/then]
+                            [/if]
+                            [if]
+                                [variable]
+                                    name=j
+                                    equals=40
+                                [/variable]
+                                [then]
+                                    [message]
+                                        speaker=Sicaria
+                                        message=_"Luke, stop eating their souls!"
+                                    [/message]
+                                    [message]
+                                        speaker=Luke
+                                        message=_"You enjoyed that, right?"
+                                    [/message]
+                                    [message]
+                                        speaker=Sicaria
+                                        message=_"I didn't know that I was eating souls! You told me that I am rewarded by gods for killing unrighteous people! And now you've proven me that I was right that you are a soul stealer and no saviour."
+                                    [/message]
+                                    [message]
+                                        speaker=Luke
+                                        message=_"You betrayed me, so I am done with you. I have no need of traitors."
+                                    [/message]
+                                [/then]
+                            [/if]
+                            [if]
+                                [variable]
+                                    name=j
+                                    equals=20
+                                [/variable]
+                                [then]
+                                    [message]
+                                        speaker=Rimaru
+                                        message=_"Luke, stop that! The thing you are doing is the worst evil I have ever seen."
+                                    [/message]
+                                    [message]
+                                        speaker=peasant_speaker_1
+                                        message=_"Please, do as he asks!"
+                                    [/message]
+                                    [message]
+                                        speaker=Luke
+                                        message=_"I have done things you would see far worse than this. But it's only because you misunderstand the conception of sacrifice."
+                                    [/message]
+                                    [message]
+                                        speaker=mage_speaker
+                                        message=_"I will really need to study how this can be righteous when I return."
+                                    [/message]
+                                    [message]
+                                        speaker=Luke
+                                        message=_"Believe me, it is needed for the greater good."
+                                    [/message]
+                                [/then]
+                            [/if]
+                            [for]
+                                array=peasants
+                                [do]
+                                    [object]
+                                        silent=yes
+                                        [filter]
+                                            id=$peasants[$i].id
+                                        [/filter]
+                                        [effect]
+                                            apply_to=image_mod
+                                            replace="O($j%)"
+                                        [/effect]
+                                    [/object]
+                                [/do]
+                            [/for]
+                        [/do]
+                    [/while]
+                    {CLEAR_VARIABLE peasants}
+                    [kill]
+                        type=Peasant
+                        side=2
+                        animate=no
+                        fire_event=no
+                    [/kill]
+                    [if]
+                        [variable]
+                            name=party_members.length
+                            less_than=9
+                        [/variable]
+                        [then]
+                            [object]
+                                [filter]
+                                    id=Luke
+                                [/filter]
+                                silent=yes
+                                [effect]
+                                    apply_to=hitpoints
+                                    increase_total=-30%
+                                    heal_full=yes
+                                [/effect]
+                            [/object]
+                        [/then]
+                    [/if]
+                    [if]
+                        [variable]
+                            name=party_members.length
+                            less_than=4
+                        [/variable]
+                        [then]
+                            [object]
+                                [filter]
+                                    id=Luke
+                                [/filter]
+                                silent=yes
+                                [effect]
+                                    apply_to=hitpoints
+                                    increase_total=-30%
+                                    heal_full=yes
+                                [/effect]
+                            [/object]
+                        [/then]
+                    [/if]
+                    [message]
+                        speaker=Luke
+                        message=_"Now, our gods bestowed upon me the power to destroy you!"
+                    [/message]
+                    [if]
+                        [variable]
+                            name=party_members.length
+                            less_than=6
+                        [/variable]
+                        [then]
+                            [object]
+                                [filter]
+                                    id=Luke
+                                [/filter]
+                                silent=yes
+                                [effect]
+                                    apply_to=attack
+                                    increase_damage=-30%
+                                [/effect]
+                            [/object]
+                        [/then]
+                    [/if]
+#define BLOOD_RAIN X Y
+    [set_variables]
+        mode=replace
+        name=blood_rain[$blood_rain.length]
+        [value]
+            x,y={X},{Y}
+            side=4
+        [/value]
+    [/set_variables]
+    [item]
+        halo=bloodrain/bloodrain-1.png:40,bloodrain/bloodrain-2.png:40,bloodrain/bloodrain-3.png:40,bloodrain/bloodrain-4.png:40,bloodrain/bloodrain-5.png:40,bloodrain/bloodrain-6.png:40,bloodrain/bloodrain-7.png:40,bloodrain/bloodrain-8.png:40,bloodrain/bloodrain-9.png:40,bloodrain/bloodrain-10.png:40
+        x,y={X},{Y}
+    [/item]
+#enddef
+                    {BLOOD_RAIN 17 7}
+                    {BLOOD_RAIN 15 6}
+                    {BLOOD_RAIN 21 5}
+                    {BLOOD_RAIN 19 9}
+                    {BLOOD_RAIN 18 10}
+                    {BLOOD_RAIN 21 11}
+                    {BLOOD_RAIN 16 12}
+                    {BLOOD_RAIN 20 3}
+                    {BLOOD_RAIN 14 6}
+                    {BLOOD_RAIN 11 4}
+                    {BLOOD_RAIN 13 7}
+                    {BLOOD_RAIN 8 5}
+                    {BLOOD_RAIN 12 3}
+                    {BLOOD_RAIN 5 7}
+                    {BLOOD_RAIN 5 10}
+                    {BLOOD_RAIN 6 11}
+                    {BLOOD_RAIN 10 11}
+                    {BLOOD_RAIN 13 14}
+                    {BLOOD_RAIN 17 16}
+                    {BLOOD_RAIN 19 12}
+                    {BLOOD_RAIN 19 15}
+                    {BLOOD_RAIN 10 7}
+                    {BLOOD_RAIN 13 10}
+                    {BLOOD_RAIN 11 6}
+                    {BLOOD_RAIN 15 9}
+                    {BLOOD_RAIN 9 3}
+                    {BLOOD_RAIN 17 3}
+                    {BLOOD_RAIN 15 4}
+                    {BLOOD_RAIN 23 3}
+                    {BLOOD_RAIN 24 6}
+                    {BLOOD_RAIN 24 9}
+                    {BLOOD_RAIN 22 13}
+                    {BLOOD_RAIN 17 12}
+#undef BLOOD_RAIN
+                    [event]
+                        name=victory
+                        id=remove_blood_rain_notes
+                        {CLEAR_VARIABLE blood_rain}
+                    [/event]
+                    [event]
+                        name=turn refresh
+                        first_time_only=no
+                        [fire_event]
+                            name=blood_rain
+                        [/fire_event]
+                    [/event]
+                    [event]
+                        name=blood_rain
+                        first_time_only=no
+                        [store_side]
+                            side=$side_number
+                            variable=this_side
+                        [/store_side]
+                        [for]
+                            array=blood_rain
+                            [do]
+                                [store_side]
+                                    side=$blood_rain[$i].side
+                                    variable=rain_side
+                                [/store_side]
+                                [if]
+                                    [variable]
+                                        name=this_side.team_name
+                                        equals=$rain_side.team_name
+                                    [/variable]
+                                    [then]
+                                        [heal_unit]
+                                            [filter]
+                                                [filter_location]
+                                                    x,y=$blood_rain[$i].x,$blood_rain[$i].y
+                                                    radius=1
+                                                [/filter_location]
+                                                side=$side_number
+                                            [/filter]
+                                            amount=8
+                                            animate=yes
+                                            restore_statuses=yes
+                                        [/heal_unit]
+                                    [/then]
+                                    [else]
+                                        [harm_unit]
+                                            [filter]
+                                                [filter_location]
+                                                    x,y=$blood_rain[$i].x,$blood_rain[$i].y
+                                                    radius=1
+                                                [/filter_location]
+                                                side=$side_number
+                                            [/filter]
+                                            amount=8
+                                            slowed=yes
+                                            kill=no
+                                        [/harm_unit]
+                                    [/else]
+                                [/if]
+                                {CLEAR_VARIABLE rain_side}
+                            [/do]
+                        [/for]
+                        {CLEAR_VARIABLE this_side}
+                    [/event]
+                    [message]
+                        speaker=she_brother
+                        message=_"A rain of blood? It think that it's too obvious that it's something evil!"
+                    [/message]
+                    [message]
+                        speaker=Luke
+                        message=_"Besides this cleansing rain, I am also destroying the caves you came from to make sure that you won't flee."
+                    [/message]
+                    {EARTHQUAKE (
+                        [terrain]
+                            x,y=8,17
+                            terrain=Xu
+                        [/terrain]
+                        [terrain]
+                            x,y=9,17
+                            terrain=Ur^Dr
+                        [/terrain]
+                        [redraw]
+                        [/redraw]
+                    )}
+                    [message]
+                        speaker=Rimaru
+                        message=_"You will die for this. I will not flee."
+                    [/message]
+                    {VARIABLE quests.overall 13}
+                    [message]
+                        speaker=Sicaria
+                        message=_"This stupid rain hurts. We'll need to find some spots where it isn't raining so heavily."
+                    [/message]
+                    [message]
+                        speaker=hired_halberdier
+                        message=_"I wonder why he didn't try to explain that our goddess is menstruating."
+                    [/message]
+                    [end_turn]
+                    [/end_turn]
+                    [event]
+                        name=turn refresh
+                        [filter]
+                            side=4
+                        [/filter]
+                        [modify_unit]
+                            [filter]
+                                id=Luke
+                            [/filter]
+                            moves=0
+                            attacks_left=0
+                        [/modify_unit]
+                    [/event]
+                    [event]
+                        name=last breath
+                        [filter]
+                            id=Luke
+                        [/filter]
+                        [message]
+                            speaker=Luke
+                            message= _ "Save me, Sicaria, it's me, your old friend and saviour."
+                        [/message]
+                        [message]
+                            speaker=Sicaria
+                            message= _ "You saved me and pretended friendship to make me kill many people and do horrible things with their souls."
+                        [/message]
+                        [message]
+                            speaker=Luke
+                            message= _ "It isn't forbidden to steal and devour souls."
+                        [/message]
+                        [message]
+                            speaker=Sicaria
+                            message= _ "It isn't forbidden because nobody thought somebody would do it. Anyway, I think that it is a kind of desecration of human remains, so it is forbidden. Furthermore, I have just seen you committing a mass murder, which is forbidden. And condemnable. I will not save you, villain."
+                        [/message]
+                        [message]
+                            speaker=Luke
+                            message= _ "Save me, former Brother of Light, I will let you join the order again and I will also grant you the title of Master."
+                        [/message]
+                        [message]
+                            speaker=she_brother
+                            message= _ "I have left the order voluntarily and your actions only strengthened my belief that my choice was right."
+                        [/message]
+                        [message]
+                            speaker=Rimaru
+                            message= _ "I was thinking about leaving the order for long and I left when I was absolutely certain that it was what I wanted."
+                        [/message]
+                        [message]
+                            speaker=Luke
+                            message= _ "Your sister is alive."
+                        [/message]
+                        [message]
+                            speaker=Rimaru
+                            message= _ "I am aware of that. However, your horrible way of abducting her is even worse than just letting her die. You've persuaded me that I was wrong when I thought you were less bad than you really are."
+                        [/message]
+                        [message]
+                            speaker=Luke
+                            message= _ "And you..."
+                        [/message]
+                        [message]
+                            speaker=elf_merc
+                            message= _ "If somebody tries to help him, I will pierce his neck with an arrow. I long to take his trinkets."
+                        [/message]
+                        [message]
+                            speaker=Burke
+                            message= _ "He's dead!"
+                        [/message]
+                        {VARIABLE quests.overall 14}
+                        [message]
+                            speaker=Rimaru
+                            message= _ "Now, how do we get out of here? The cave's ceiling crumbled."
+                        [/message]
+                        [terrain]
+                            x,y=24,14
+                            terrain=Mm
+                        [/terrain]
+                        [redraw]
+                        [/redraw]
+                        [store_unit]
+                            [filter]
+                                side=1
+                                [filter_wml]
+                                    [movement_costs]
+                                        mountains={UNREACHABLE}
+                                    [/movement_costs]
+                                [/filter_wml]
+                            [/filter]
+                            variable=cant_pass
+                        [/store_unit]
+                        [for]
+                            array=cant_pass
+                            [do]
+                                [set_variables]
+                                    name=cant_pass[$i].modifications.advance[$cant_pass[$i].modifications.advance.length]
+                                    mode=replace
+                                    [value]
+                                        id=mountain_passing
+                                        [effect]
+                                            apply_to=movement_costs
+                                            replace=true
+                                            [movement_costs]
+                                                mountains=3
+                                            [/movement_costs]
+                                        [/effect]
+                                    [/value]
+                                [/set_variables]
+                                {VARIABLE cant_pass[$i].movement_costs.mountains 3}
+                                [unstore_unit]
+                                    variable=cant_pass[$i]
+                                    find_vacant=no
+                                [/unstore_unit]
+                            [/do]
+                        [/for]
+                        [if]
+                            [variable]
+                                name=cant_pass.length
+                                greater_than=0
+                            [/variable]
+                            [then]
+                                [message]
+                                    speaker=Burke
+                                    message= _ "I think that we'll need a heavy hike through the mountains, can all of us pass through mountains?"
+                                [/message]
+                                [message]
+                                    id=$cant_pass.id
+                                    message= _ "I hope I'll manage."
+                                [/message]
+                                [message]
+                                    speaker=Burke
+                                    message= _ "That might be too risky. We'll get you out of there. Just find shelter from the accursed rain!"
+                                [/message]
+                            [/then]
+                            [else]
+                                [message]
+                                    speaker=Burke
+                                    message= _ "When the cave is blocked, we'll need to pass through the mountains somehow. Fortunately, none of us has problems with mountains, so let's find a place where the mountains can be crossed. Otherwise, we'll just need to find some shelter from the accursed rain."
+                                [/message]
+                            [/else]
+                        [/if]
+                        {CLEAR_VARIABLE cant_pass}
+                        [message]
+                            speaker=Sicaria
+                            message= _ "And we'll see Konrad then, right?"
+                        [/message]
+                    [/event]
                 [/event]
-            [/event]
-        [/then]
-    [/if]
-
+            [/then]
+        [/if]
     [/event]
 
     [event]

--- a/spinoffs/The_Beautiful_Child/units/Bringer_of_Light.cfg
+++ b/spinoffs/The_Beautiful_Child/units/Bringer_of_Light.cfg
@@ -1,20 +1,20 @@
 #textdomain wesnoth-tbc
 #define DAZZLE_COUNTER
-[chance_to_hit]
-    id=dazzle_counter
-    value=30
-    apply_to=opponent
-    [filter_base_value]
-        greater_than=30
-    [/filter_base_value]
-    [filter_opponent]
-        [filter_wml]
-            [variables]
-                dazzled=yes
-            [/variables]
-        [/filter_wml]
-    [/filter_opponent]
-[/chance_to_hit]
+    [chance_to_hit]
+        id=dazzle_counter
+        value=30
+        apply_to=opponent
+        [filter_base_value]
+            greater_than=30
+        [/filter_base_value]
+        [filter_opponent]
+            [filter_wml]
+                [variables]
+                    dazzled=yes
+                [/variables]
+            [/filter_wml]
+        [/filter_opponent]
+    [/chance_to_hit]
 #enddef
 [unit_type]
     id=Bringer of Light
@@ -51,8 +51,8 @@
     [defense]
         deep_water=60
         shallow_water=60
-    swamp_water=60
-    reef=60
+        swamp_water=60
+        reef=60
     [/defense]
     description= _ "This man is the leader of the Brothers of Light. His bloodline originates from gods themselves and his knowledge of the divine is so good the gods personally speak to him and grant him a fraction of their powers... if his words are believable. His enemies claim that his power comes from necromantic rituals that are based on extracting souls of his victims by torture. Regardless of the truth behind it, he is a formidable opponent to face."
     die_sound={SOUND_LIST:HUMAN_OLD_DIE}
@@ -70,15 +70,15 @@
         image="portraits/humans/transparent/mage-light.png"
     [/portrait]
     [abilities]
-    [dummy]
-        id=spellcasting_light
-        name= _ "spell casting"
+        [dummy]
+            id=spellcasting_light
+            name= _ "spell casting"
 #ifver WESNOTH_VERSION >= 1.11.2
-        description= _ "At the beginning of this unit's turn, a spell is cast. It can be holy fire that ignites ground under him, it can be a call to arms that brings new soldiers to him or a burst of blinding light that limits the chance to hit of nearby enemies."
+            description= _ "At the beginning of this unit's turn, a spell is cast. It can be holy fire that ignites ground under him, it can be a call to arms that brings new soldiers to him or a burst of blinding light that limits the chance to hit of nearby enemies."
 #else
-        description= _ "Spell Casting: At the beginning of this unit's turn, a spell is cast. It can be holy fire that ignites ground under him, it can be a call to arms that brings new soldiers to him or a burst of blinding light that limits the chance to hit of nearby enemies."
+            description= _ "Spell Casting: At the beginning of this unit's turn, a spell is cast. It can be holy fire that ignites ground under him, it can be a call to arms that brings new soldiers to him or a burst of blinding light that limits the chance to hit of nearby enemies."
 #endif
-    [/dummy]
+        [/dummy]
         {ABILITY_ILLUMINATES}
         {ABILITY_CURES}
         {ABILITY_REGENERATES_OTHER 40}
@@ -180,19 +180,19 @@
         attack_weight=0
     [/attack]
     [attack]
-            name=firestorm
-            description=_"firestorm"
-            type=fire
-            [specials]
-                {WEAPON_SPECIAL_MAGICAL}
-                {WEAPON_SPECIAL_STORM}
-                {DAZZLE_COUNTER}
-            [/specials]
-            range=ranged
-            damage=25
-            number=2
-            icon=attacks/firestorm.png
-            defense_weight=0
+        name=firestorm
+        description=_"firestorm"
+        type=fire
+        [specials]
+            {WEAPON_SPECIAL_MAGICAL}
+            {WEAPON_SPECIAL_STORM}
+            {DAZZLE_COUNTER}
+        [/specials]
+        range=ranged
+        damage=25
+        number=2
+        icon=attacks/firestorm.png
+        defense_weight=0
     [/attack]
     [attack_anim]
         [filter_attack]
@@ -413,229 +413,244 @@
         [/frame]
     [/movement_anim]
     [event]
-    name=turn refresh
-    id=spellcasting_light
-    first_time_only=no
-    [store_unit]
-        [filter]
-            side=$side_number
-            ability=spellcasting_light
-        [/filter]
-        variable=casters
-        kill=no
-    [/store_unit]
-    {FOREACH casters i}
-        {VARIABLE_OP spell rand (holy_fire,call_to_arms,burst_of_light)}
-        [switch]
-            variable=spell
-            [case]
-                value=holy_fire
-                [floating_text]
-                    x,y=$casters[$i].x,$casters[$i].y
-                    text=_"Holy Fire!"
-                [/floating_text]
-                {VARIABLE already no}
-                {FOREACH burning_ground j}
-                    [if]
-                        [variable]
-                            name=burning_ground[$j].x
-                            equals=$casters[$i].x
-                        [/variable]
-                        [and]
-                            [variable]
-                                name=burning_ground[$j].x
-                                equals=$casters[$i].x
-                            [/variable]
-                        [/and]
-                        [and]
-                            [variable]
-                                name=burning_ground[$j].side
-                                equals=$casters[$i].side
-                            [/variable]
-                        [/and]
-                        [then]
-                            {VARIABLE already yes}
-                        [/then]
-                    [/if]
-                {NEXT j}
-                [if]
-                    [variable]
-                        name=already
-                        equals=no
-                    [/variable]
-                    [then]
-                        [set_variables]
-                            mode=replace
-                            name=burning_ground[$burning_ground.length]
-                            [value]
-                                x,y=$casters[$i].x,$casters[$i].y
-                                side=$casters[$i].side
-                            [/value]
-                        [/set_variables]
-                        [item]
-                            halo=burning_ground/burning-ground-1.png:80,burning_ground/burning-ground-2.png:80,burning_ground/burning-ground-3.png:80,burning_ground/burning-ground-4.png:80,burning_ground/burning-ground-5.png:80,burning_ground/burning-ground-6.png:80,burning_ground/burning-ground-7.png:80,burning_ground/burning-ground-8.png:80
+        name=turn refresh
+        id=spellcasting_light
+        first_time_only=no
+        [store_unit]
+            [filter]
+                side=$side_number
+                ability=spellcasting_light
+            [/filter]
+            variable=casters
+            kill=no
+        [/store_unit]
+        [for]
+            array=casters
+            variable=i
+            [do]
+                {VARIABLE_OP spell rand (holy_fire,call_to_arms,burst_of_light)}
+                [switch]
+                    variable=spell
+                    [case]
+                        value=holy_fire
+                        [floating_text]
                             x,y=$casters[$i].x,$casters[$i].y
-                            visible_in_fog=no
-                        [/item]
-                        [event]
-                            name=victory
-                            id=remove_burning_ground_notes
-                            {CLEAR_VARIABLE burning_ground}
-                        [/event]
-                    [/then]
-                [/if]
-            [/case]
-            [case]
-                value=call_to_arms
-                [floating_text]
-                    x,y=$casters[$i].x,$casters[$i].y
-                    text=_"Call to Arms!"
-                [/floating_text]
-                {VARIABLE count 0}
-                [while]
-                    [variable]
-                        name=count
-                        {QUANTITY less_than 4 5 6}
-                    [/variable]
-                    [do]
-                        {VARIABLE_OP type rand "Pikeman,Spearman,Swordsman,Bowman,Lieutenant,Heavy Infantryman"}
-                        {GENERIC_UNIT $side_number $type $casters[$i].x $casters[$i].y}
-                        [+unit]
-                            animate=yes
-                            moves=0
-                            attacks_left=0
-                            [modifications]
-                                [advance]
-                                    id=dazzle_effect
-                                    [effect]
-                                        apply_to=attack
-                                        [set_specials]
-                                                {DAZZLE_COUNTER}
-                                        [/set_specials]
-                                    [/effect]
-                                [/advance]
-                            [/modifications]
-                        [/unit]
-                        {VARIABLE_OP count add 1}
-                    [/do]
-                [/while]
-                {CLEAR_VARIABLE count,type}
-            [/case]
-            [case]
-                value=burst_of_light
-                [floating_text]
-                    x,y=$casters[$i].x,$casters[$i].y
-                    text=_"Light of Divinity!"
-                [/floating_text]
-                {COLOR_ADJUST 200 200 200}
-                [delay]
-                    time=300
-                [/delay]
-                {COLOR_ADJUST 0 0 0}
-                [store_unit]
-                    [filter]
-                        [filter_location]
+                            text=_"Holy Fire!"
+                        [/floating_text]
+                        {VARIABLE already no}
+                        [for]
+                            array=burning_ground
+                            variable=j
+                            [do]
+                                [if]
+                                    [variable]
+                                        name=burning_ground[$j].x
+                                        equals=$casters[$i].x
+                                    [/variable]
+                                    [and]
+                                        [variable]
+                                            name=burning_ground[$j].x
+                                            equals=$casters[$i].x
+                                        [/variable]
+                                    [/and]
+                                    [and]
+                                        [variable]
+                                            name=burning_ground[$j].side
+                                            equals=$casters[$i].side
+                                        [/variable]
+                                    [/and]
+                                    [then]
+                                        {VARIABLE already yes}
+                                    [/then]
+                                [/if]
+                            [/do]
+                        [/for]
+                        [if]
+                            [variable]
+                                name=already
+                                equals=no
+                            [/variable]
+                            [then]
+                                [set_variables]
+                                    mode=replace
+                                    name=burning_ground[$burning_ground.length]
+                                    [value]
+                                        x,y=$casters[$i].x,$casters[$i].y
+                                        side=$casters[$i].side
+                                    [/value]
+                                [/set_variables]
+                                [item]
+                                    halo=burning_ground/burning-ground-1.png:80,burning_ground/burning-ground-2.png:80,burning_ground/burning-ground-3.png:80,burning_ground/burning-ground-4.png:80,burning_ground/burning-ground-5.png:80,burning_ground/burning-ground-6.png:80,burning_ground/burning-ground-7.png:80,burning_ground/burning-ground-8.png:80
+                                    x,y=$casters[$i].x,$casters[$i].y
+                                    visible_in_fog=no
+                                [/item]
+                                [event]
+                                    name=victory
+                                    id=remove_burning_ground_notes
+                                    {CLEAR_VARIABLE burning_ground}
+                                [/event]
+                            [/then]
+                        [/if]
+                    [/case]
+                    [case]
+                        value=call_to_arms
+                        [floating_text]
                             x,y=$casters[$i].x,$casters[$i].y
-                            radius=6
-                        [/filter_location]
-                        [filter_side]
-                            [enemy_of]
-                                side=$side_number
-                            [/enemy_of]
-                        [/filter_side]
-                    [/filter]
-                    variable=targets
-                    kill=no
-                [/store_unit]
-                {FOREACH targets i}
-                    {VARIABLE targets[$i].variables.dazzled yes}
-                    [unstore_unit]
-                        variable=targets[$i]
-                        find_vacant=no
-                        text=_"blinded"
-                        {COLOR_HARM}
-                    [/unstore_unit]
-                    [event]
-                        delayed_variable_substitution=no
-                        name=turn refresh
-                        [filter_side]
-                            side=$side_number
-                        [/filter_side]
+                            text=_"Call to Arms!"
+                        [/floating_text]
+                        {VARIABLE count 0}
+                        [while]
+                            [variable]
+                                name=count
+                                {QUANTITY less_than 4 5 6}
+                            [/variable]
+                            [do]
+                                {VARIABLE_OP type rand "Pikeman,Spearman,Swordsman,Bowman,Lieutenant,Heavy Infantryman"}
+                                {GENERIC_UNIT $side_number $type $casters[$i].x $casters[$i].y}
+                                [+unit]
+                                    animate=yes
+                                    moves=0
+                                    attacks_left=0
+                                    [modifications]
+                                        [advance]
+                                            id=dazzle_effect
+                                            [effect]
+                                                apply_to=attack
+                                                [set_specials]
+                                                    {DAZZLE_COUNTER}
+                                                [/set_specials]
+                                            [/effect]
+                                        [/advance]
+                                    [/modifications]
+                                [/unit]
+                                {VARIABLE_OP count add 1}
+                            [/do]
+                        [/while]
+                        {CLEAR_VARIABLE count,type}
+                    [/case]
+                    [case]
+                        value=burst_of_light
+                        [floating_text]
+                            x,y=$casters[$i].x,$casters[$i].y
+                            text=_"Light of Divinity!"
+                        [/floating_text]
+                        {COLOR_ADJUST 200 200 200}
+                        [delay]
+                            time=300
+                        [/delay]
+                        {COLOR_ADJUST 0 0 0}
                         [store_unit]
                             [filter]
-                                id=$targets[$i].id
+                                [filter_location]
+                                    x,y=$casters[$i].x,$casters[$i].y
+                                    radius=6
+                                [/filter_location]
+                                [filter_side]
+                                    [enemy_of]
+                                        side=$side_number
+                                    [/enemy_of]
+                                [/filter_side]
                             [/filter]
-                            variable=undazzled
+                            variable=targets
+                            kill=no
                         [/store_unit]
-                        {CLEAR_VARIABLE undazzled.variables.dazzled}
-                        [unstore_unit]
-                            variable=undazzled
-                            find_vacant=no
-                        [/unstore_unit]
-                        {CLEAR_VARIABLE undazzled}
-                    [/event]
-                {NEXT i}
-                {CLEAR_VARIABLE targets}
-            [/case]
-        [/switch]
-        [fire_event]
-            name=spellcast
-            [primary_unit]
-                id=$casters[$i]
-            [/primary_unit]
-        [/fire_event]
-    {NEXT i}
-    {CLEAR_VARIABLE casters,spell}
+                        [for]
+                            array=targets
+                            variable=t
+                            [do]
+                                {VARIABLE targets[$t].variables.dazzled yes}
+                                [unstore_unit]
+                                    variable=targets[$t]
+                                    find_vacant=no
+                                    text=_"blinded"
+                                    {COLOR_HARM}
+                                [/unstore_unit]
+                                [event]
+                                    delayed_variable_substitution=no
+                                    name=turn refresh
+                                    [filter_side]
+                                        side=$side_number
+                                    [/filter_side]
+                                    [store_unit]
+                                        [filter]
+                                            id=$targets[$t].id
+                                        [/filter]
+                                        variable=undazzled
+                                    [/store_unit]
+                                    {CLEAR_VARIABLE undazzled.variables.dazzled}
+                                    [unstore_unit]
+                                        variable=undazzled
+                                        find_vacant=no
+                                    [/unstore_unit]
+                                    {CLEAR_VARIABLE undazzled}
+                                [/event]
+                            [/do]
+                        [/for]
+                        {CLEAR_VARIABLE targets}
+                    [/case]
+                [/switch]
+                [fire_event]
+                    name=spellcast
+                    [primary_unit]
+                        id=$casters[$i]
+                    [/primary_unit]
+                [/fire_event]
+            [/do]
+        [/for]
+        {CLEAR_VARIABLE casters,spell}
     [/event]
     [event]
-    name=turn refresh
-    id=burning_ground_damaging_event
-    first_time_only=no
-    [store_side]
-        side=$side_number
-        variable=this_side
-    [/store_side]
-    {FOREACH burning_ground i}
+        name=turn refresh
+        id=burning_ground_damaging_event
+        first_time_only=no
         [store_side]
-            side=$burning_ground[$i].side
-            variable=burning_ground_side
+            side=$side_number
+            variable=this_side
         [/store_side]
-        [if]
-            [variable]
-                name=this_side.team_name
-                equals=$burning_ground_side.team_name
-            [/variable]
-            [else]
+        [for]
+            array=burning_ground
+            [do]
+                [store_side]
+                    side=$burning_ground[$i].side
+                    variable=burning_ground_side
+                [/store_side]
                 [if]
-                    [have_unit]
-                        [filter_location]
-                            x,y=$burning_ground[$i].x,$burning_ground[$i].y
-                            radius=1
-                        [/filter_location]
-                        side=$side_number
-                    [/have_unit]
-                    [then]
-                        [fire_event]
-                            name=burning ground
-                        [/fire_event]
-                    [/then]
+                    [variable]
+                        name=this_side.team_name
+                        equals=$burning_ground_side.team_name
+                    [/variable]
+                    [else]
+                        [if]
+                            [have_unit]
+                                [filter_location]
+                                    x,y=$burning_ground[$i].x,$burning_ground[$i].y
+                                    radius=1
+                                [/filter_location]
+                                side=$side_number
+                            [/have_unit]
+                            [then]
+                                [fire_event]
+                                    name=burning ground
+                                [/fire_event]
+                            [/then]
+                        [/if]
+                        [harm_unit]
+                            [filter]
+                                [filter_location]
+                                    x,y=$burning_ground[$i].x,$burning_ground[$i].y
+                                    radius=1
+                                [/filter_location]
+                                side=$side_number
+                            [/filter]
+                            amount=24
+                            damage_type=fire
+                        [/harm_unit]
+                    [/else]
                 [/if]
-                [harm_unit]
-                    [filter]
-                    [filter_location]
-                        x,y=$burning_ground[$i].x,$burning_ground[$i].y
-                        radius=1
-                    [/filter_location]
-                    side=$side_number
-                    [/filter]
-                    amount=24
-                    damage_type=fire
-                [/harm_unit]
-            [/else]
-        [/if]
-        {CLEAR_VARIABLE burning_ground_side}
-    {NEXT i}
-    {CLEAR_VARIABLE this_side}
+                {CLEAR_VARIABLE burning_ground_side}
+            [/do]
+        [/for]
+        {CLEAR_VARIABLE this_side}
     [/event]
 [/unit_type]
 #undef DAZZLE_COUNTER

--- a/spinoffs/The_Beautiful_Child/units/Bringer_of_Light2.cfg
+++ b/spinoffs/The_Beautiful_Child/units/Bringer_of_Light2.cfg
@@ -1,5 +1,4 @@
-#textd
-main wesnoth-tbc
+#textdomain wesnoth-tbc
 #define DAZZLE_COUNTER
     [chance_to_hit]
         id=dazzle_counter

--- a/spinoffs/The_Beautiful_Child/units/Bringer_of_Light2.cfg
+++ b/spinoffs/The_Beautiful_Child/units/Bringer_of_Light2.cfg
@@ -1,20 +1,21 @@
-#textdomain wesnoth-tbc
+#textd
+main wesnoth-tbc
 #define DAZZLE_COUNTER
-[chance_to_hit]
-    id=dazzle_counter
-    value=30
-    apply_to=opponent
-    [filter_base_value]
-        greater_than=30
-    [/filter_base_value]
-    [filter_opponent]
-        [filter_wml]
-            [variables]
-                dazzled=yes
-            [/variables]
-        [/filter_wml]
-    [/filter_opponent]
-[/chance_to_hit]
+    [chance_to_hit]
+        id=dazzle_counter
+        value=30
+        apply_to=opponent
+        [filter_base_value]
+            greater_than=30
+        [/filter_base_value]
+        [filter_opponent]
+            [filter_wml]
+                [variables]
+                    dazzled=yes
+                [/variables]
+            [/filter_wml]
+        [/filter_opponent]
+    [/chance_to_hit]
 #enddef
 [unit_type]
     id=Bringer of Light2
@@ -47,14 +48,14 @@
         village=1
         castle=1
         frozen=1
-    unwalkable=1
+        unwalkable=1
     [/movement_costs]
     [defense]
         deep_water=60
         shallow_water=60
-    swamp_water=60
-    reef=60
-    unwalkable=50
+        swamp_water=60
+        reef=60
+        unwalkable=50
     [/defense]
     description= _ "This man is the leader of the Brothers of Light. His bloodline originates from gods themselves and his knowledge of the divine is so good the gods personally speak to him and grant him a fraction of their powers... if his words are believable. His enemies claim that his power comes from necromantic rituals that are based on extracting souls of his victims by torture. Regardless of the truth behind it, he is a formidable opponent to face."
     die_sound={SOUND_LIST:HUMAN_OLD_DIE}
@@ -72,15 +73,15 @@
         image="portraits/humans/transparent/mage-light.png"
     [/portrait]
     [abilities]
-    [dummy]
-        id=spellcasting_light_2
-        name= _ "spell casting"
+        [dummy]
+            id=spellcasting_light_2
+            name= _ "spell casting"
 #ifver WESNOTH_VERSION >= 1.11.2
-        description= _ "At the beginning of this unit's turn, a spell is cast. It can be teleportation that moves him somewhere nearby, it can be a call beyond death that causes fallen warriors to return to help him or a burst of blinding light that limits the chance to hit of nearby enemies."
+            description= _ "At the beginning of this unit's turn, a spell is cast. It can be teleportation that moves him somewhere nearby, it can be a call beyond death that causes fallen warriors to return to help him or a burst of blinding light that limits the chance to hit of nearby enemies."
 #else
-        description= _ "Spell Casting: At the beginning of this unit's turn, a spell is cast. It can be teleportation that moves him somewhere nearby, it can be a call beyond death that causes fallen warriors to return to help him or a burst of blinding light that limits the chance to hit of nearby enemies."
+            description= _ "Spell Casting: At the beginning of this unit's turn, a spell is cast. It can be teleportation that moves him somewhere nearby, it can be a call beyond death that causes fallen warriors to return to help him or a burst of blinding light that limits the chance to hit of nearby enemies."
 #endif
-    [/dummy]
+        [/dummy]
         {ABILITY_ILLUMINATES}
         {ABILITY_CURES}
         {ABILITY_REGENERATES_OTHER 32}
@@ -184,19 +185,19 @@
         attack_weight=0
     [/attack]
     [attack]
-            name=blizzard
-            description=_"blizzard"
-            type=cold
-            [specials]
-                {WEAPON_SPECIAL_MAGICAL}
-                {WEAPON_SPECIAL_STORM}
-                {WEAPON_SPECIAL_SLOW}
-            [/specials]
-            range=ranged
-            damage=16
-            number=2
-            icon=attacks/blizzard.png
-            defense_weight=0
+        name=blizzard
+        description=_"blizzard"
+        type=cold
+        [specials]
+            {WEAPON_SPECIAL_MAGICAL}
+            {WEAPON_SPECIAL_STORM}
+            {WEAPON_SPECIAL_SLOW}
+        [/specials]
+        range=ranged
+        damage=16
+        number=2
+        icon=attacks/blizzard.png
+        defense_weight=0
     [/attack]
     [attack_anim]
         [filter_attack]
@@ -417,144 +418,151 @@
         [/frame]
     [/movement_anim]
     [event]
-    name=turn refresh
-    id=spellcasting_light_2
-    first_time_only=no
-    [store_unit]
-        [filter]
-            side=$side_number
-            ability=spellcasting_light_2
-        [/filter]
-        variable=casters
-        kill=no
-    [/store_unit]
-    {FOREACH casters i}
-        {VARIABLE_OP spell rand (teleport,call_beyond_death,burst_of_light)}
-        [switch]
-            variable=spell
-            [case]
-                value=teleport
-                [floating_text]
-                    x,y=$casters[$i].x,$casters[$i].y
-                    text=_"Teleport!"
-                [/floating_text]
-                {VARIABLE_OP target_x rand 42..48}
-                {VARIABLE_OP target_y rand 5..11}
-                [if]
-                    [have_unit]
-                        x,y=$target_x,$target_y
-                    [/have_unit]
-                    [else]
-                        [teleport]
-                            [filter]
-                                id=$casters[$i].id
-                            [/filter]
-                            x,y=$target_x,$target_y
-                        [/teleport]
-                    [/else]
-                [/if]
-            [/case]
-            [case]
-                value=call_beyond_death
-                [floating_text]
-                    x,y=$casters[$i].x,$casters[$i].y
-                    text=_"Call Beyond Death!"
-                [/floating_text]
-                {VARIABLE count 0}
-                [while]
-                    [variable]
-                        name=count
-                        {QUANTITY less_than 4 5 6}
-                    [/variable]
-                    [do]
-                        {VARIABLE_OP type rand "Deathblade,Revenant,Bone Shooter,Wraith,Shadow"}
-                        {GENERIC_UNIT $side_number $type $casters[$i].x $casters[$i].y}
-                        [+unit]
-                            animate=yes
-                            moves=0
-                            attacks_left=0
-                            [modifications]
-                                [advance]
-                                    id=dazzle_effect
-                                    [effect]
-                                        apply_to=attack
-                                        [set_specials]
-                                                {DAZZLE_COUNTER}
-                                        [/set_specials]
-                                    [/effect]
-                                [/advance]
-                            [/modifications]
-                        [/unit]
-                        {VARIABLE_OP count add 1}
-                    [/do]
-                [/while]
-                {CLEAR_VARIABLE count,type}
-            [/case]
-            [case]
-                value=burst_of_light
-                [floating_text]
-                    x,y=$casters[$i].x,$casters[$i].y
-                    text=_"Light of Divinity!"
-                [/floating_text]
-                {COLOR_ADJUST 200 200 200}
-                [delay]
-                    time=300
-                [/delay]
-                {COLOR_ADJUST 0 0 0}
-                [store_unit]
-                    [filter]
-                        [filter_location]
+        name=turn refresh
+        id=spellcasting_light_2
+        first_time_only=no
+        [store_unit]
+            [filter]
+                side=$side_number
+                ability=spellcasting_light_2
+            [/filter]
+            variable=casters
+            kill=no
+        [/store_unit]
+        [for]
+            array=casters
+            [do]
+                {VARIABLE_OP spell rand (teleport,call_beyond_death,burst_of_light)}
+                [switch]
+                    variable=spell
+                    [case]
+                        value=teleport
+                        [floating_text]
                             x,y=$casters[$i].x,$casters[$i].y
-                            radius=4
-                        [/filter_location]
-                        [filter_side]
-                            [enemy_of]
-                                side=$side_number
-                            [/enemy_of]
-                        [/filter_side]
-                    [/filter]
-                    variable=targets
-                    kill=no
-                [/store_unit]
-                {FOREACH targets i}
-                    {VARIABLE targets[$i].variables.dazzled yes}
-                    [unstore_unit]
-                        variable=targets[$i]
-                        find_vacant=no
-                        text=_"blinded"
-                        {COLOR_HARM}
-                    [/unstore_unit]
-                    [event]
-                        delayed_variable_substitution=no
-                        name=turn refresh
-                        [filter_side]
-                            side=$side_number
-                        [/filter_side]
+                            text=_"Teleport!"
+                        [/floating_text]
+                        {VARIABLE_OP target_x rand 42..48}
+                        {VARIABLE_OP target_y rand 5..11}
+                        [if]
+                            [have_unit]
+                                x,y=$target_x,$target_y
+                            [/have_unit]
+                            [else]
+                                [teleport]
+                                    [filter]
+                                        id=$casters[$i].id
+                                    [/filter]
+                                    x,y=$target_x,$target_y
+                                [/teleport]
+                            [/else]
+                        [/if]
+                    [/case]
+                    [case]
+                        value=call_beyond_death
+                        [floating_text]
+                            x,y=$casters[$i].x,$casters[$i].y
+                            text=_"Call Beyond Death!"
+                        [/floating_text]
+                        {VARIABLE count 0}
+                        [while]
+                            [variable]
+                                name=count
+                                {QUANTITY less_than 4 5 6}
+                            [/variable]
+                            [do]
+                                {VARIABLE_OP type rand "Deathblade,Revenant,Bone Shooter,Wraith,Shadow"}
+                                {GENERIC_UNIT $side_number $type $casters[$i].x $casters[$i].y}
+                                [+unit]
+                                    animate=yes
+                                    moves=0
+                                    attacks_left=0
+                                    [modifications]
+                                        [advance]
+                                            id=dazzle_effect
+                                            [effect]
+                                                apply_to=attack
+                                                [set_specials]
+                                                    {DAZZLE_COUNTER}
+                                                [/set_specials]
+                                            [/effect]
+                                        [/advance]
+                                    [/modifications]
+                                [/unit]
+                                {VARIABLE_OP count add 1}
+                            [/do]
+                        [/while]
+                        {CLEAR_VARIABLE count,type}
+                    [/case]
+                    [case]
+                        value=burst_of_light
+                        [floating_text]
+                            x,y=$casters[$i].x,$casters[$i].y
+                            text=_"Light of Divinity!"
+                        [/floating_text]
+                        {COLOR_ADJUST 200 200 200}
+                        [delay]
+                            time=300
+                        [/delay]
+                        {COLOR_ADJUST 0 0 0}
                         [store_unit]
                             [filter]
-                                id=$targets[$i].id
+                                [filter_location]
+                                    x,y=$casters[$i].x,$casters[$i].y
+                                    radius=4
+                                [/filter_location]
+                                [filter_side]
+                                    [enemy_of]
+                                        side=$side_number
+                                    [/enemy_of]
+                                [/filter_side]
                             [/filter]
-                            variable=undazzled
+                            variable=targets
+                            kill=no
                         [/store_unit]
-                        {CLEAR_VARIABLE undazzled.variables.dazzled}
-                        [unstore_unit]
-                            variable=undazzled
-                            find_vacant=no
-                        [/unstore_unit]
-                        {CLEAR_VARIABLE undazzled}
-                    [/event]
-                {NEXT i}
-                {CLEAR_VARIABLE targets}
-            [/case]
-        [/switch]
-        [fire_event]
-            name=spellcast
-            [primary_unit]
-                id=$casters[$i]
-            [/primary_unit]
-        [/fire_event]
-    {NEXT i}
-    {CLEAR_VARIABLE casters,spell}
+                        [for]
+                            array=targets
+                            variable=t
+                            [do]
+                                {VARIABLE targets[$t].variables.dazzled yes}
+                                [unstore_unit]
+                                    variable=targets[$t]
+                                    find_vacant=no
+                                    text=_"blinded"
+                                    {COLOR_HARM}
+                                [/unstore_unit]
+                                [event]
+                                    delayed_variable_substitution=no
+                                    name=turn refresh
+                                    [filter_side]
+                                        side=$side_number
+                                    [/filter_side]
+                                    [store_unit]
+                                        [filter]
+                                            id=$targets[$t].id
+                                        [/filter]
+                                        variable=undazzled
+                                    [/store_unit]
+                                    {CLEAR_VARIABLE undazzled.variables.dazzled}
+                                    [unstore_unit]
+                                        variable=undazzled
+                                        find_vacant=no
+                                    [/unstore_unit]
+                                    {CLEAR_VARIABLE undazzled}
+                                [/event]
+                            [/do]
+                        [/for]
+                        {CLEAR_VARIABLE targets}
+                    [/case]
+                [/switch]
+                [fire_event]
+                    name=spellcast
+                    [primary_unit]
+                        id=$casters[$i]
+                    [/primary_unit]
+                [/fire_event]
+            [/do]
+        [/for]
+        {CLEAR_VARIABLE casters,spell}
     [/event]
 [/unit_type]
 #undef DAZZLE_COUNTER

--- a/spinoffs/The_Beautiful_Child/units/Bringer_of_Light3.cfg
+++ b/spinoffs/The_Beautiful_Child/units/Bringer_of_Light3.cfg
@@ -36,45 +36,45 @@
 #enddef
 
 #define MISSILE_FRAME_LIGHTNING_STORM
-{LIGHTNING_FRAME_INIT missile1 -650}
-{LIGHTNING_FRAME_INIT missile2 -550}
-{LIGHTNING_FRAME_INIT missile3 -450}
-{LIGHTNING_FRAME_INIT missile4 -250}
-{LIGHTNING_FRAME_INIT missile5 -150}
-{LIGHTNING_FRAME_INIT missile6 -50}
-{LIGHTNING_FRAME_INIT missile7 50}
-{LIGHTNING_FRAME_INIT missile8 150}
-{LIGHTNING_FRAME_INIT missile9 250}
-{LIGHTNING_FRAME_INIT missile10 350}
-{LIGHTNING_FRAME_INIT missile11 450}
-{LIGHTNING_FRAME missile1 1 35 -180}
-{LIGHTNING_FRAME missile2 2 -50 -100}
-{LIGHTNING_FRAME missile3 3 60 -150}
-{LIGHTNING_FRAME missile4 2 -70 -80}
-{LIGHTNING_FRAME missile5 3 35 -205}
-{LIGHTNING_FRAME missile6 1 40 -65}
-{LIGHTNING_FRAME missile7 1 70 -55}
-{LIGHTNING_FRAME missile8 3 25 -150}
-{LIGHTNING_FRAME missile9 2 -85 -175}
-{LIGHTNING_FRAME missile10 3 15 -70}
-{LIGHTNING_FRAME missile11 1 25 -25}
+    {LIGHTNING_FRAME_INIT missile1 -650}
+    {LIGHTNING_FRAME_INIT missile2 -550}
+    {LIGHTNING_FRAME_INIT missile3 -450}
+    {LIGHTNING_FRAME_INIT missile4 -250}
+    {LIGHTNING_FRAME_INIT missile5 -150}
+    {LIGHTNING_FRAME_INIT missile6 -50}
+    {LIGHTNING_FRAME_INIT missile7 50}
+    {LIGHTNING_FRAME_INIT missile8 150}
+    {LIGHTNING_FRAME_INIT missile9 250}
+    {LIGHTNING_FRAME_INIT missile10 350}
+    {LIGHTNING_FRAME_INIT missile11 450}
+    {LIGHTNING_FRAME missile1 1 35 -180}
+    {LIGHTNING_FRAME missile2 2 -50 -100}
+    {LIGHTNING_FRAME missile3 3 60 -150}
+    {LIGHTNING_FRAME missile4 2 -70 -80}
+    {LIGHTNING_FRAME missile5 3 35 -205}
+    {LIGHTNING_FRAME missile6 1 40 -65}
+    {LIGHTNING_FRAME missile7 1 70 -55}
+    {LIGHTNING_FRAME missile8 3 25 -150}
+    {LIGHTNING_FRAME missile9 2 -85 -175}
+    {LIGHTNING_FRAME missile10 3 15 -70}
+    {LIGHTNING_FRAME missile11 1 25 -25}
 #enddef
 #define DAZZLE_COUNTER
-[chance_to_hit]
-    id=dazzle_counter
-    value=30
-    apply_to=opponent
-    [filter_base_value]
-        greater_than=30
-    [/filter_base_value]
-    [filter_opponent]
-        [filter_wml]
-            [variables]
-                dazzled=yes
-            [/variables]
-        [/filter_wml]
-    [/filter_opponent]
-[/chance_to_hit]
+    [chance_to_hit]
+        id=dazzle_counter
+        value=30
+        apply_to=opponent
+        [filter_base_value]
+            greater_than=30
+        [/filter_base_value]
+        [filter_opponent]
+            [filter_wml]
+                [variables]
+                    dazzled=yes
+                [/variables]
+            [/filter_wml]
+        [/filter_opponent]
+    [/chance_to_hit]
 #enddef
 [unit_type]
     id=Bringer of Light3
@@ -107,14 +107,14 @@
         village=1
         castle=1
         frozen=1
-    unwalkable=1
+        unwalkable=1
     [/movement_costs]
     [defense]
         deep_water=60
         shallow_water=60
-    swamp_water=60
-    reef=60
-    unwalkable=50
+        swamp_water=60
+        reef=60
+        unwalkable=50
     [/defense]
     description= _ "This man is the leader of the Brothers of Light. His bloodline originates from gods themselves and his knowledge of the divine is so good the gods personally speak to him and grant him a fraction of their powers... if his words are believable. His enemies claim that his power comes from necromantic rituals that are based on extracting souls of his victims by torture. Regardless of the truth behind it, he is a formidable opponent to face."
     die_sound={SOUND_LIST:HUMAN_OLD_DIE}
@@ -132,15 +132,15 @@
         image="portraits/humans/transparent/mage-light.png"
     [/portrait]
     [abilities]
-    [dummy]
-        id=spellcasting_light_3
-        name= _ "spell casting"
+        [dummy]
+            id=spellcasting_light_3
+            name= _ "spell casting"
 #ifver WESNOTH_VERSION >= 1.11.2
-        description= _ "At the beginning of this unit's turn, a spell is cast. It can be an acid rain that creates areas that poison and damage all units inside, it can be a healing spell that allows him to recover a lot of hitpoints or burden of sin that causes nearby units to break through the floor and fall."
+            description= _ "At the beginning of this unit's turn, a spell is cast. It can be an acid rain that creates areas that poison and damage all units inside, it can be a healing spell that allows him to recover a lot of hitpoints or burden of sin that causes nearby units to break through the floor and fall."
 #else
-        description= _ "Spell Casting: At the beginning of this unit's turn, a spell is cast. It can be an acid rain that creates areas that poison and damage all units inside, it can be a healing spell that allows him to recover a lot of hitpoints or burden of sin that causes nearby units to break through the floor and fall."
+            description= _ "Spell Casting: At the beginning of this unit's turn, a spell is cast. It can be an acid rain that creates areas that poison and damage all units inside, it can be a healing spell that allows him to recover a lot of hitpoints or burden of sin that causes nearby units to break through the floor and fall."
 #endif
-    [/dummy]
+        [/dummy]
         {ABILITY_ILLUMINATES}
         {ABILITY_CURES}
         {ABILITY_REGENERATES_OTHER 32}
@@ -243,18 +243,18 @@
         attack_weight=0
     [/attack]
     [attack]
-            name=thunderstorm
-            description=_"thunderstorm"
-            type=lightning
-            [specials]
-                {WEAPON_SPECIAL_MAGICAL}
-                {WEAPON_SPECIAL_STORM}
-            [/specials]
-            range=ranged
-            damage=24
-            number=2
-            icon=attacks/lightning.png
-            defense_weight=0
+        name=thunderstorm
+        description=_"thunderstorm"
+        type=lightning
+        [specials]
+            {WEAPON_SPECIAL_MAGICAL}
+            {WEAPON_SPECIAL_STORM}
+        [/specials]
+        range=ranged
+        damage=24
+        number=2
+        icon=attacks/lightning.png
+        defense_weight=0
     [/attack]
     [attack_anim]
         [filter_attack]
@@ -475,210 +475,224 @@
         [/frame]
     [/movement_anim]
     [event]
-    name=turn refresh
-    id=spellcasting_light_3
-    first_time_only=no
-    [store_unit]
-        [filter]
-            side=$side_number
-            ability=spellcasting_light_3
-        [/filter]
-        variable=casters
-        kill=no
-    [/store_unit]
-    {FOREACH casters i}
-        {VARIABLE_OP spell rand (cleansing_rain,healing,burden_of_sin)}
-        [switch]
-            variable=spell
-            [case]
-                value=cleansing_rain
-                [floating_text]
-                    x,y=$casters[$i].x,$casters[$i].y
-                    text=_"Cleansing Rain!"
-                [/floating_text]
-                {VARIABLE already no}
-                {FOREACH cleansing_rain j}
-                    [if]
-                        [variable]
-                            name=cleansing_rain[$j].x
-                            equals=$casters[$i].x
-                        [/variable]
-                        [and]
+        name=turn refresh
+        id=spellcasting_light_3
+        first_time_only=no
+        [store_unit]
+            [filter]
+                side=$side_number
+                ability=spellcasting_light_3
+            [/filter]
+            variable=casters
+            kill=no
+        [/store_unit]
+        [for]
+            array=casters
+            variable=i
+            [do]
+                {VARIABLE_OP spell rand (cleansing_rain,healing,burden_of_sin)}
+                [switch]
+                    variable=spell
+                    [case]
+                        value=cleansing_rain
+                        [floating_text]
+                            x,y=$casters[$i].x,$casters[$i].y
+                            text=_"Cleansing Rain!"
+                        [/floating_text]
+                        {VARIABLE already no}
+                        [for]
+                            array=cleansing_rain
+                            variable=j
+                            [do]
+                                [if]
+                                    [variable]
+                                        name=cleansing_rain[$j].x
+                                        equals=$casters[$i].x
+                                    [/variable]
+                                    [and]
+                                        [variable]
+                                            name=cleansing_rain[$j].x
+                                            equals=$casters[$i].x
+                                        [/variable]
+                                    [/and]
+                                    [and]
+                                        [variable]
+                                            name=cleansing_rain[$j].side
+                                            equals=$casters[$i].side
+                                        [/variable]
+                                    [/and]
+                                    [then]
+                                        {VARIABLE already yes}
+                                    [/then]
+                                [/if]
+                            [/do]
+                        [/for]
+                        [if]
                             [variable]
-                                name=cleansing_rain[$j].x
-                                equals=$casters[$i].x
+                                name=already
+                                equals=yes
                             [/variable]
-                        [/and]
-                        [and]
-                            [variable]
-                                name=cleansing_rain[$j].side
-                                equals=$casters[$i].side
-                            [/variable]
-                        [/and]
-                        [then]
-                            {VARIABLE already yes}
-                        [/then]
-                    [/if]
-                {NEXT j}
+                            [else]
+                                [set_variables]
+                                    mode=replace
+                                    name=cleansing_rain[$cleansing_rain.length]
+                                    [value]
+                                        x,y=$casters[$i].x,$casters[$i].y
+                                        side=$casters[$i].side
+                                    [/value]
+                                [/set_variables]
+                                [item]
+                                    halo=bloodrain/bloodrain-1.png~CS(-100,250,100):40,bloodrain/bloodrain-2.png~CS(-100,250,100):40,bloodrain/bloodrain-3.png~CS(-100,250,100):40,bloodrain/bloodrain-4.png~CS(-100,250,100):40,bloodrain/bloodrain-5.png~CS(-100,250,100):40,bloodrain/bloodrain-6.png~CS(-100,250,100):40,bloodrain/bloodrain-7.png~CS(-100,250,100):40,bloodrain/bloodrain-8.png~CS(-100,250,100):40,bloodrain/bloodrain-9.png~CS(-100,250,100):40,bloodrain/bloodrain-10.png~CS(-100,250,100):40
+                                    x,y=$casters[$i].x,$casters[$i].y
+                                [/item]
+
+                                {VARIABLE target_x $casters[$i].x}
+                                {VARIABLE_OP target_x sub 18}
+                                [set_variables]
+                                    mode=replace
+                                    name=cleansing_rain[$cleansing_rain.length]
+                                    [value]
+                                        x,y=$target_x,$casters[$i].y
+                                        side=$casters[$i].side
+                                    [/value]
+                                [/set_variables]
+                                [item]
+                                    halo=bloodrain/bloodrain-1.png~CS(-100,250,100):40,bloodrain/bloodrain-2.png~CS(-100,250,100):40,bloodrain/bloodrain-3.png~CS(-100,250,100):40,bloodrain/bloodrain-4.png~CS(-100,250,100):40,bloodrain/bloodrain-5.png~CS(-100,250,100):40,bloodrain/bloodrain-6.png~CS(-100,250,100):40,bloodrain/bloodrain-7.png~CS(-100,250,100):40,bloodrain/bloodrain-8.png~CS(-100,250,100):40,bloodrain/bloodrain-9.png~CS(-100,250,100):40,bloodrain/bloodrain-10.png~CS(-100,250,100):40
+                                    x,y=$target_x,$casters[$i].y
+                                [/item]
+                                [event]
+                                    name=victory
+                                    id=remove_cleansing_rain_notes
+                                    {CLEAR_VARIABLE cleansing_rain}
+                                [/event]
+                            [/else]
+                        [/if]
+                        {CLEAR_VARIABLE already}
+                    [/case]
+                    [case]
+                        value=healing
+                        [floating_text]
+                            x,y=$casters[$i].x,$casters[$i].y
+                            text=_"Healing!"
+                        [/floating_text]
+                        {VARIABLE amount $casters[$i].max_hitpoints}
+                        {VARIABLE_OP amount divide 2}
+                        [heal_unit]
+                            [filter]
+                                id=$casters[$i].id
+                            [/filter]
+                            amount=$amount
+                            animate=yes
+                            restore_statuses=yes
+                        [/heal_unit]
+                        {CLEAR_VARIABLE amount}
+                    [/case]
+                    [case]
+                        value=burden_of_sin
+                        [floating_text]
+                            x,y=$casters[$i].x,$casters[$i].y
+                            text=_"Burden of Sin!"
+                        [/floating_text]
+                        [store_unit]
+                            [filter]
+                                [filter_adjacent]
+                                    x,y=$casters[$i].x,$casters[$i].y
+                                [/filter_adjacent]
+                                [filter_location]
+                                    terrain=Iwr
+                                [/filter_location]
+                                [filter_side]
+                                    [enemy_of]
+                                        side=$side_number
+                                    [/enemy_of]
+                                [/filter_side]
+                            [/filter]
+                            variable=targets
+                            kill=no
+                        [/store_unit]
+                        {FOREACH targets i}
+                            [for]
+                                array=targets
+                                variable=t
+                                [do]
+                                    {EARTHQUAKE (
+                                        [terrain]
+                                            x,y=$targets[$t].x,$targets[$t].y
+                                            terrain=Qxu
+                                        [/terrain]
+                                        {VARIABLE target_x $targets[$t].x}
+                                        {VARIABLE_OP target_x sub 18}
+                                        [teleport]
+                                            [filter]
+                                                id=$targets[$t].id
+                                            [/filter]
+                                            x,y=$target_x,$targets[$t].y
+                                        [/teleport]
+                                        [terrain]
+                                            x,y=$target_x,$targets[$t].y
+                                            terrain=Iwr^Dr
+                                        [/terrain]
+                                    )}
+                                    [harm_unit]
+                                        [filter]
+                                            x,y=$target_x,$targets[$t].y
+                                        [/filter]
+                                        amount=32
+                                        damage_type=impact
+                                        kill=yes
+                                        fire_event=yes
+                                    [/harm_unit]
+                                    {CLEAR_VARIABLE target_x}
+                                [/do]
+                            [/for]
+                            {CLEAR_VARIABLE targets}
+                        [/case]
+                    [/switch]
+                    [fire_event]
+                        name=spellcast
+                        [primary_unit]
+                            id=$casters[$i]
+                        [/primary_unit]
+                    [/fire_event]
+                [/do]
+            [/for]
+            {CLEAR_VARIABLE casters,spell}
+        [/event]
+        [event]
+            name=turn_refresh
+            first_time_only=no
+            [store_side]
+                side=$side_number
+                variable=this_side
+            [/store_side]
+            {FOREACH cleansing_rain i}
+                [store_side]
+                    side=$cleansing_rain[$i].side
+                    variable=rain_side
+                [/store_side]
                 [if]
                     [variable]
-                        name=already
-                        equals=yes
+                        name=this_side.team_name
+                        equals=$rain_side.team_name
                     [/variable]
                     [else]
-                        [set_variables]
-                            mode=replace
-                            name=cleansing_rain[$cleansing_rain.length]
-                            [value]
-                                x,y=$casters[$i].x,$casters[$i].y
-                                side=$casters[$i].side
-                            [/value]
-                        [/set_variables]
-                        [item]
-                            halo=bloodrain/bloodrain-1.png~CS(-100,250,100):40,bloodrain/bloodrain-2.png~CS(-100,250,100):40,bloodrain/bloodrain-3.png~CS(-100,250,100):40,bloodrain/bloodrain-4.png~CS(-100,250,100):40,bloodrain/bloodrain-5.png~CS(-100,250,100):40,bloodrain/bloodrain-6.png~CS(-100,250,100):40,bloodrain/bloodrain-7.png~CS(-100,250,100):40,bloodrain/bloodrain-8.png~CS(-100,250,100):40,bloodrain/bloodrain-9.png~CS(-100,250,100):40,bloodrain/bloodrain-10.png~CS(-100,250,100):40
-                            x,y=$casters[$i].x,$casters[$i].y
-                        [/item]
-
-                        {VARIABLE target_x $casters[$i].x}
-                        {VARIABLE_OP target_x sub 18}
-                        [set_variables]
-                            mode=replace
-                            name=cleansing_rain[$cleansing_rain.length]
-                            [value]
-                                x,y=$target_x,$casters[$i].y
-                                side=$casters[$i].side
-                            [/value]
-                        [/set_variables]
-                        [item]
-                            halo=bloodrain/bloodrain-1.png~CS(-100,250,100):40,bloodrain/bloodrain-2.png~CS(-100,250,100):40,bloodrain/bloodrain-3.png~CS(-100,250,100):40,bloodrain/bloodrain-4.png~CS(-100,250,100):40,bloodrain/bloodrain-5.png~CS(-100,250,100):40,bloodrain/bloodrain-6.png~CS(-100,250,100):40,bloodrain/bloodrain-7.png~CS(-100,250,100):40,bloodrain/bloodrain-8.png~CS(-100,250,100):40,bloodrain/bloodrain-9.png~CS(-100,250,100):40,bloodrain/bloodrain-10.png~CS(-100,250,100):40
-                            x,y=$target_x,$casters[$i].y
-                        [/item]
-                        [event]
-                            name=victory
-                            id=remove_cleansing_rain_notes
-                            {CLEAR_VARIABLE cleansing_rain}
-                        [/event]
+                        [harm_unit]
+                            [filter]
+                                [filter_location]
+                                    x,y=$cleansing_rain[$i].x,$cleansing_rain[$i].y
+                                    radius=1
+                                [/filter_location]
+                                side=$side_number
+                            [/filter]
+                            amount=4
+                            poisoned=yes
+                            kill=no
+                        [/harm_unit]
                     [/else]
                 [/if]
-                {CLEAR_VARIABLE already}
-            [/case]
-            [case]
-                value=healing
-                [floating_text]
-                    x,y=$casters[$i].x,$casters[$i].y
-                    text=_"Healing!"
-                [/floating_text]
-                {VARIABLE amount $casters[$i].max_hitpoints}
-                {VARIABLE_OP amount divide 2}
-                [heal_unit]
-                    [filter]
-                    id=$casters[$i].id
-                    [/filter]
-                    amount=$amount
-                    animate=yes
-                    restore_statuses=yes
-                [/heal_unit]
-                {CLEAR_VARIABLE amount}
-            [/case]
-            [case]
-                value=burden_of_sin
-                [floating_text]
-                    x,y=$casters[$i].x,$casters[$i].y
-                    text=_"Burden of Sin!"
-                [/floating_text]
-                [store_unit]
-                    [filter]
-                        [filter_adjacent]
-                            x,y=$casters[$i].x,$casters[$i].y
-                        [/filter_adjacent]
-                        [filter_location]
-                            terrain=Iwr
-                        [/filter_location]
-                        [filter_side]
-                            [enemy_of]
-                                side=$side_number
-                            [/enemy_of]
-                        [/filter_side]
-                    [/filter]
-                    variable=targets
-                    kill=no
-                [/store_unit]
-                {FOREACH targets i}
-                    {EARTHQUAKE (
-                        [terrain]
-                            x,y=$targets[$i].x,$targets[$i].y
-                            terrain=Qxu
-                        [/terrain]
-                        {VARIABLE target_x $targets[$i].x}
-                        {VARIABLE_OP target_x sub 18}
-                        [teleport]
-                            [filter]
-                                id=$targets[$i].id
-                            [/filter]
-                            x,y=$target_x,$targets[$i].y
-                        [/teleport]
-                        [terrain]
-                            x,y=$target_x,$targets[$i].y
-                            terrain=Iwr^Dr
-                        [/terrain]
-                    )}
-                    [harm_unit]
-                        [filter]
-                          x,y=$target_x,$targets[$i].y
-                        [/filter]
-                        amount=32
-                        damage_type=impact
-                        kill=yes
-                        fire_event=yes
-                    [/harm_unit]
-                    {CLEAR_VARIABLE target_x}
-                {NEXT i}
-                {CLEAR_VARIABLE targets}
-            [/case]
-        [/switch]
-        [fire_event]
-            name=spellcast
-            [primary_unit]
-                id=$casters[$i]
-            [/primary_unit]
-        [/fire_event]
-    {NEXT i}
-    {CLEAR_VARIABLE casters,spell}
-    [/event]
-    [event]
-        name=turn_refresh
-        first_time_only=no
-        [store_side]
-            side=$side_number
-            variable=this_side
-        [/store_side]
-        {FOREACH cleansing_rain i}
-            [store_side]
-                side=$cleansing_rain[$i].side
-                variable=rain_side
-            [/store_side]
-            [if]
-                [variable]
-                    name=this_side.team_name
-                    equals=$rain_side.team_name
-                [/variable]
-                [else]
-                    [harm_unit]
-                        [filter]
-                        [filter_location]
-                            x,y=$cleansing_rain[$i].x,$cleansing_rain[$i].y
-                            radius=1
-                        [/filter_location]
-                        side=$side_number
-                        [/filter]
-                        amount=4
-                        poisoned=yes
-                        kill=no
-                    [/harm_unit]
-                [/else]
-            [/if]
-            {CLEAR_VARIABLE rain_side}
-        {NEXT i}
+                {CLEAR_VARIABLE rain_side}
+            [/do]
+        [/for]
         {CLEAR_VARIABLE this_side}
     [/event]
 [/unit_type]

--- a/spinoffs/The_Beautiful_Child/units/Exalted_Blackguard.cfg
+++ b/spinoffs/The_Beautiful_Child/units/Exalted_Blackguard.cfg
@@ -21,23 +21,23 @@
     {DEFENSE_ANIM "units/humans/blackguard-defend-2.png" "units/humans/blackguard-defend-1.png" {SOUND_LIST:HUMAN_HIT} }
     [abilities]
         {ABILITY_DARKENS}
-    [dummy]
-        id=blood_rain
-        name= _ "blood rain"
+        [dummy]
+            id=blood_rain
+            name= _ "blood rain"
 #ifver WESNOTH_VERSION >= 1.11.2
-        description= _ "Wherever this unit steps, it begins to rain blood, dealing 8 damage per turn to enemies slowing them and healing 8 hitpoints per turn to allies."
+            description= _ "Wherever this unit steps, it begins to rain blood, dealing 8 damage per turn to enemies slowing them and healing 8 hitpoints per turn to allies."
 #else
-        description= _ "Blood Rain: Wherever this unit steps, it begins to rain blood, dealing 8 damage per turn to allies and healing 8 hitpoints per turn to allies."
+            description= _ "Blood Rain: Wherever this unit steps, it begins to rain blood, dealing 8 damage per turn to allies and healing 8 hitpoints per turn to allies."
 #endif
-    [/dummy]
+        [/dummy]
         {ABILITY_ABSORB_2}
     [/abilities]
     [resistance]
         blade=60
         pierce=60
-    fire=80
-    cold=80
-    impact=90
+        fire=80
+        cold=80
+        impact=90
     [/resistance]
     [portrait]
         size=400
@@ -53,10 +53,10 @@
         range=melee
         damage=12
         number=4
-    [specials]
-        {WEAPON_SPECIAL_DRAIN}
-        {WEAPON_SPECIAL_HIT_AND_RUN}
-    [/specials]
+        [specials]
+            {WEAPON_SPECIAL_DRAIN}
+            {WEAPON_SPECIAL_HIT_AND_RUN}
+        [/specials]
     [/attack]
     [attack_anim]
         [filter_attack]
@@ -92,133 +92,144 @@
         [/frame]
     [/attack_anim]
     [event]
-    name=turn refresh
-    id=blood_rain
-    first_time_only=no
-    [store_unit]
-        [filter]
-            side=$side_number
-            ability=blood_rain
-        [/filter]
-        variable=rainers
-        kill=no
-    [/store_unit]
-    {FOREACH rainers i}
-        {VARIABLE already no}
-        {FOREACH blood_rain j}
-            [if]
-                [variable]
-                    name=blood_rain[$j].x
-                    equals=$rainers[$i].x
-                [/variable]
-                [and]
-                    [variable]
-                        name=blood_rain[$j].x
-                        equals=$rainers[$i].x
-                    [/variable]
-                [/and]
-                [and]
-                    [variable]
-                        name=blood_rain[$j].side
-                        equals=$rainers[$i].side
-                    [/variable]
-                [/and]
-                [then]
-                    {VARIABLE already yes}
-                [/then]
-            [/if]
-        {NEXT j}
-        [if]
-            [variable]
-                name=already
-                equals=yes
-            [/variable]
-            [else]
-                [set_variables]
-                    mode=replace
-                    name=blood_rain[$blood_rain.length]
-                    [value]
-                        x,y=$rainers[$i].x,$rainers[$i].y
-                        side=$rainers[$i].side
-                    [/value]
-                [/set_variables]
-                [item]
-                    halo=bloodrain/bloodrain-1.png:40,bloodrain/bloodrain-2.png:40,bloodrain/bloodrain-3.png:40,bloodrain/bloodrain-4.png:40,bloodrain/bloodrain-5.png:40,bloodrain/bloodrain-6.png:40,bloodrain/bloodrain-7.png:40,bloodrain/bloodrain-8.png:40,bloodrain/bloodrain-9.png:40,bloodrain/bloodrain-10.png:40
-                    x,y=$rainers[$i].x,$rainers[$i].y
-                [/item]
-                [event]
-                    name=victory
-                    id=remove_blood_rain_notes
-                    {CLEAR_VARIABLE blood_rain}
-                [/event]
-            [/else]
-        [/if]
-        {CLEAR_VARIABLE already}
-    {NEXT i}
-    [store_side]
-        side=$side_number
-        variable=this_side
-    [/store_side]
-    {FOREACH blood_rain i}
-        [store_side]
-            side=$blood_rain[$i].side
-            variable=rain_side
-        [/store_side]
-        [if]
-            [variable]
-                name=this_side.team_name
-                equals=$rain_side.team_name
-            [/variable]
-            [then]
-                [heal_unit]
-                    [filter]
-                    [filter_location]
-                        x,y=$blood_rain[$i].x,$blood_rain[$i].y
-                        radius=1
-                    [/filter_location]
-                    side=$side_number
-                    [/filter]
-                    amount=8
-                    animate=yes
-                    restore_statuses=yes
-                [/heal_unit]
-            [/then]
-            [else]
-                [harm_unit]
-                    [filter]
-                    [filter_location]
-                        x,y=$blood_rain[$i].x,$blood_rain[$i].y
-                        radius=1
-                    [/filter_location]
-                    side=$side_number
-                    [/filter]
-                    amount=8
-                    slowed=yes
-                    kill=no
-                [/harm_unit]
+        name=turn refresh
+        id=blood_rain
+        first_time_only=no
+        [store_unit]
+            [filter]
+                side=$side_number
+                ability=blood_rain
+            [/filter]
+            variable=rainers
+            kill=no
+        [/store_unit]
+        [for]
+            array=rainers
+            variable=i
+            [do]
+                {VARIABLE already no}
+                [for]
+                    array=blood_rain
+                    variable=j
+                    [do]
+                        [if]
+                            [variable]
+                                name=blood_rain[$j].x
+                                equals=$rainers[$i].x
+                            [/variable]
+                            [and]
+                                [variable]
+                                    name=blood_rain[$j].x
+                                    equals=$rainers[$i].x
+                                [/variable]
+                            [/and]
+                            [and]
+                                [variable]
+                                    name=blood_rain[$j].side
+                                    equals=$rainers[$i].side
+                                [/variable]
+                            [/and]
+                            [then]
+                                {VARIABLE already yes}
+                            [/then]
+                        [/if]
+                    [/do]
+                [/for]
                 [if]
-                    [have_unit]
-                        [filter_location]
-                            x,y=$blood_rain[$i].x,$blood_rain[$i].y
-                            radius=1
-                        [/filter_location]
-                        side=$side_number
-                    [/have_unit]
-                    [then]
-                        [fire_event]
-                            name=raining blood
-                        [/fire_event]
-                    [/then]
+                    [variable]
+                        name=already
+                        equals=yes
+                    [/variable]
+                    [else]
+                        [set_variables]
+                            mode=replace
+                            name=blood_rain[$blood_rain.length]
+                            [value]
+                                x,y=$rainers[$i].x,$rainers[$i].y
+                                side=$rainers[$i].side
+                            [/value]
+                        [/set_variables]
+                        [item]
+                            halo=bloodrain/bloodrain-1.png:40,bloodrain/bloodrain-2.png:40,bloodrain/bloodrain-3.png:40,bloodrain/bloodrain-4.png:40,bloodrain/bloodrain-5.png:40,bloodrain/bloodrain-6.png:40,bloodrain/bloodrain-7.png:40,bloodrain/bloodrain-8.png:40,bloodrain/bloodrain-9.png:40,bloodrain/bloodrain-10.png:40
+                            x,y=$rainers[$i].x,$rainers[$i].y
+                        [/item]
+                        [event]
+                            name=victory
+                            id=remove_blood_rain_notes
+                            {CLEAR_VARIABLE blood_rain}
+                        [/event]
+                    [/else]
                 [/if]
-            [/else]
-        [/if]
-        {CLEAR_VARIABLE rain_side}
-    {NEXT i}
-    {CLEAR_VARIABLE rainers,this_side}
+                {CLEAR_VARIABLE already}
+            [/do]
+        [/for]
+        [store_side]
+            side=$side_number
+            variable=this_side
+        [/store_side]
+        [foreach]
+            array=blood_rain
+            [do]
+                [store_side]
+                    side=$this_item.side
+                    variable=rain_side
+                [/store_side]
+                [if]
+                    [variable]
+                        name=this_side.team_name
+                        equals=$rain_side.team_name
+                    [/variable]
+                    [then]
+                        [heal_unit]
+                            [filter]
+                                [filter_location]
+                                    x,y=$this_item.x,$this_item.y
+                                    radius=1
+                                [/filter_location]
+                                side=$side_number
+                            [/filter]
+                            amount=8
+                            animate=yes
+                            restore_statuses=yes
+                        [/heal_unit]
+                    [/then]
+                    [else]
+                        [harm_unit]
+                            [filter]
+                                [filter_location]
+                                    x,y=$this_item.x,$this_item.y
+                                    radius=1
+                                [/filter_location]
+                                side=$side_number
+                            [/filter]
+                            amount=8
+                            slowed=yes
+                            kill=no
+                        [/harm_unit]
+                        [if]
+                            [have_unit]
+                                [filter_location]
+                                    x,y=$this_item.x,$this_item.y
+                                    radius=1
+                                [/filter_location]
+                                side=$side_number
+                            [/have_unit]
+                            [then]
+                                [fire_event]
+                                    name=raining blood
+                                [/fire_event]
+                            [/then]
+                        [/if]
+                    [/else]
+                [/if]
+                {CLEAR_VARIABLE rain_side}
+            [/dp]
+        [/foreach]
+        {CLEAR_VARIABLE rainers,this_side}
     [/event]
     [event]
-    name=victory
-    id=blood_rain_end
-    {CLEAR_VARIABLE blood_rain}
+        name=victory
+        id=blood_rain_end
+        {CLEAR_VARIABLE blood_rain}
     [/event]
 [/unit_type]

--- a/spinoffs/The_Beautiful_Child/units/Manhunter.cfg
+++ b/spinoffs/The_Beautiful_Child/units/Manhunter.cfg
@@ -20,15 +20,15 @@
     {DEFENSE_ANIM "units/humans/exterminator+female-defend.png~O(30%)" "units/humans/exterminator+female.png~O(30%)" {SOUND_LIST:HUMAN_FEMALE_HIT} }
     [abilities]
         {ABILITY_SKIRMISHER}
-    [dummy]
-        id=spellcasting_shadow
-        name= _ "spell casting"
+        [dummy]
+            id=spellcasting_shadow
+            name= _ "spell casting"
 #ifver WESNOTH_VERSION >= 1.11.2
-        description= _ "At the beginning of this unit's turn, a spell is cast. It can be desecration that summons undead, magic storm that sends magical bolts at enemies or cave-in that deals damage and changes terrain."
+            description= _ "At the beginning of this unit's turn, a spell is cast. It can be desecration that summons undead, magic storm that sends magical bolts at enemies or cave-in that deals damage and changes terrain."
 #else
-        description= _ "Spell Casting: At the beginning of this unit's turn, a spell is cast. It can be desecration that summons undead, magic storm that sends magical bolts at enemies or cave-in that deals damage and changes terrain."
+            description= _ "Spell Casting: At the beginning of this unit's turn, a spell is cast. It can be desecration that summons undead, magic storm that sends magical bolts at enemies or cave-in that deals damage and changes terrain."
 #endif
-    [/dummy]
+        [/dummy]
     [/abilities]
     [attack]
         name=dagger
@@ -184,146 +184,149 @@
         [/frame]
     [/attack_anim]
     [event]
-    name=turn refresh
-    id=spellcasting_shadow
-    first_time_only=no
-    [store_unit]
-        [filter]
-            side=$side_number
-            ability=spellcasting_shadow
-        [/filter]
-        variable=casters
-        kill=no
-    [/store_unit]
-    {FOREACH casters i}
-        {VARIABLE_OP spell rand (desecrate,magic_storm,cave_in)}
-        [switch]
-            variable=spell
-            [case]
-                value=desecrate
-                [floating_text]
-                    x,y=$casters[$i].x,$casters[$i].y
-                    text=_"Desecate!"
-                [/floating_text]
-                {VARIABLE count 0}
-                [while]
-                    [variable]
-                        name=count
-                        {QUANTITY less_than 4 5 6}
-                    [/variable]
-                    [do]
-                        {GENERIC_UNIT $side_number Soulless $casters[$i].x $casters[$i].y}
-                        [+unit]
-                            attacks_left=0
-                            moves=0
-                        [/unit]
-                        {VARIABLE_OP count add 1}
-                    [/do]
-                [/while]
-                {CLEAR_VARIABLE count}
-            [/case]
-            [case]
-                value=magic_storm
-                [floating_text]
-                    x,y=$casters[$i].x,$casters[$i].y
-                    text=_"Magic Storm!"
-                [/floating_text]
-                {VARIABLE count 0}
-                [while]
-                    [variable]
-                        name=count
-                        {QUANTITY less_than 4 5 6}
-                    [/variable]
-                    [do]
-                        {GENERIC_UNIT $side_number "Magic Missile" $casters[$i].x $casters[$i].y}
-                        {VARIABLE_OP count add 1}
-                    [/do]
-                [/while]
-                {CLEAR_VARIABLE count}
-                [event]
-                    name=turn end
-                    [kill]
-                        type=Magic Missile
-                        animate=no
-                        fire_event=no
-                    [/kill]
-                [/event]
-                [event]
-                    name=attacker hits
-                    first_time_only=no
-                    id=suicide_attacker_hits
-                    [filter_attack]
-                        special_id=suicide
-                    [/filter_attack]
-                    [kill]
-                        id=$unit.id
-                        animate=no
-                        experience=no
-                        fire_event=no
-                    [/kill]
-                [/event]
-            [/case]
-            [case]
-                value=cave_in
-                [floating_text]
-                    x,y=$casters[$i].x,$casters[$i].y
-                    text=_"Cave In!"
-                [/floating_text]
-                [store_unit]
-                    [filter]
-                        [filter_side]
-                            [enemy_of]
-                                side=$side_number
-                            [/enemy_of]
-                        [/filter_side]
-                    [/filter]
-                    variable=targets
-                    kill=no
-                [/store_unit]
-                {VARIABLE_OP target rand "0..$targets.length"}
-                [store_locations]
-                    x,y=$targets[$target].x,$targets[$target].y
-                    variable=terrain
-                [/store_locations]
-                [set_variables]
-                    name=terrains
-                    mode=replace
-                    [split]
-                        list=$terrain.terrain
-                        key=identified
-                        separator="^"
-                        remove_empty=yes
-                    [/split]
-                [/set_variables]
-                {EARTHQUAKE (
-                    [terrain]
-                        x,y=$targets[$target].x,$targets[$target].y
-                        terrain=$terrains.identified|^Dr
-                    [/terrain]
-                )}
-                [redraw]
-                [/redraw]
-                [harm_unit]
-                    [filter]
-                        id=$targets[$target].id
-                    [/filter]
-                    amount=24
-                    damage_type=impact
-                    fire_event=yes
-                    animate=yes
-                    experience=no
-                    kill=yes
-                [/harm_unit]
-                {CLEAR_VARIABLE target,targets,terrains,terrain}
-            [/case]
-        [/switch]
-        [fire_event]
-            name=spellcast
-            [primary_unit]
-                id=$casters[$i]
-            [/primary_unit]
-        [/fire_event]
-    {NEXT i}
-    {CLEAR_VARIABLE casters,spell}
+        name=turn refresh
+        id=spellcasting_shadow
+        first_time_only=no
+        [store_unit]
+            [filter]
+                side=$side_number
+                ability=spellcasting_shadow
+            [/filter]
+            variable=casters
+            kill=no
+        [/store_unit]
+        [for]
+            array=casters
+            [do]
+                {VARIABLE_OP spell rand (desecrate,magic_storm,cave_in)}
+                [switch]
+                    variable=spell
+                    [case]
+                        value=desecrate
+                        [floating_text]
+                            x,y=$casters[$i].x,$casters[$i].y
+                            text=_"Desecate!"
+                        [/floating_text]
+                        {VARIABLE count 0}
+                        [while]
+                            [variable]
+                                name=count
+                                {QUANTITY less_than 4 5 6}
+                            [/variable]
+                            [do]
+                                {GENERIC_UNIT $side_number Soulless $casters[$i].x $casters[$i].y}
+                                [+unit]
+                                    attacks_left=0
+                                    moves=0
+                                [/unit]
+                                {VARIABLE_OP count add 1}
+                            [/do]
+                        [/while]
+                        {CLEAR_VARIABLE count}
+                    [/case]
+                    [case]
+                        value=magic_storm
+                        [floating_text]
+                            x,y=$casters[$i].x,$casters[$i].y
+                            text=_"Magic Storm!"
+                        [/floating_text]
+                        {VARIABLE count 0}
+                        [while]
+                            [variable]
+                                name=count
+                                {QUANTITY less_than 4 5 6}
+                            [/variable]
+                            [do]
+                                {GENERIC_UNIT $side_number "Magic Missile" $casters[$i].x $casters[$i].y}
+                                {VARIABLE_OP count add 1}
+                            [/do]
+                        [/while]
+                        {CLEAR_VARIABLE count}
+                        [event]
+                            name=turn end
+                            [kill]
+                                type=Magic Missile
+                                animate=no
+                                fire_event=no
+                            [/kill]
+                        [/event]
+                        [event]
+                            name=attacker hits
+                            first_time_only=no
+                            id=suicide_attacker_hits
+                            [filter_attack]
+                                special_id=suicide
+                            [/filter_attack]
+                            [kill]
+                                id=$unit.id
+                                animate=no
+                                experience=no
+                                fire_event=no
+                            [/kill]
+                        [/event]
+                    [/case]
+                    [case]
+                        value=cave_in
+                        [floating_text]
+                            x,y=$casters[$i].x,$casters[$i].y
+                            text=_"Cave In!"
+                        [/floating_text]
+                        [store_unit]
+                            [filter]
+                                [filter_side]
+                                    [enemy_of]
+                                        side=$side_number
+                                    [/enemy_of]
+                                [/filter_side]
+                            [/filter]
+                            variable=targets
+                            kill=no
+                        [/store_unit]
+                        {VARIABLE_OP target rand "0..$targets.length"}
+                        [store_locations]
+                            x,y=$targets[$target].x,$targets[$target].y
+                            variable=terrain
+                        [/store_locations]
+                        [set_variables]
+                            name=terrains
+                            mode=replace
+                            [split]
+                                list=$terrain.terrain
+                                key=identified
+                                separator="^"
+                                remove_empty=yes
+                            [/split]
+                        [/set_variables]
+                        {EARTHQUAKE (
+                            [terrain]
+                                x,y=$targets[$target].x,$targets[$target].y
+                                terrain=$terrains.identified|^Dr
+                            [/terrain]
+                        )}
+                        [redraw]
+                        [/redraw]
+                        [harm_unit]
+                            [filter]
+                                id=$targets[$target].id
+                            [/filter]
+                            amount=24
+                            damage_type=impact
+                            fire_event=yes
+                            animate=yes
+                            experience=no
+                            kill=yes
+                        [/harm_unit]
+                        {CLEAR_VARIABLE target,targets,terrains,terrain}
+                    [/case]
+                [/switch]
+                [fire_event]
+                    name=spellcast
+                    [primary_unit]
+                        id=$casters[$i]
+                    [/primary_unit]
+                [/fire_event]
+            [/do]
+        [/array]
+        {CLEAR_VARIABLE casters,spell}
     [/event]
 [/unit_type]

--- a/spinoffs/The_Beautiful_Child/utils/global_events.cfg
+++ b/spinoffs/The_Beautiful_Child/utils/global_events.cfg
@@ -1,4 +1,4 @@
-#textdomain wesnth-tbc
+#textdomain wesnoth-tbc
 #define REMOVE_FROM_RECALL_LIST NAME
     [for]
         array=party_members

--- a/spinoffs/The_Beautiful_Child/utils/global_events.cfg
+++ b/spinoffs/The_Beautiful_Child/utils/global_events.cfg
@@ -1,51 +1,53 @@
-#textdomain wesnoth-tbc
+#textdomain wesnth-tbc
 #define REMOVE_FROM_RECALL_LIST NAME
-{FOREACH party_members i}
-    [if]
-        [variable]
-            name=party_members[$i].id
-            equals={NAME}
-        [/variable]
-        [then]
-            {CLEAR_VARIABLE party_members[$i]}
-            {VARIABLE_OP i sub 1}
-        [/then]
-    [/if]
-{NEXT i}
+    [for]
+        array=party_members
+        [do]
+            [if]
+                [variable]
+                    name=party_members[$i].id
+                    equals={NAME}
+                [/variable]
+                [then]
+                    {CLEAR_VARIABLE party_members[$i]}
+                    {VARIABLE_OP i sub 1}
+                [/then]
+            [/if]
+        [/do]
+    [/for]
 #enddef
 #define TBC_GLOBAL_EVENTS_LIST
 
-[event]
-    name=diplomacy_tried
-    {VARIABLE_OP diplomacy_tried add 1}
-    [if]
-        [variable]
-            name=diplomacy_tried
-            equals=3
-        [/variable]
-        [then]
-            [message]
-                speaker=Rimaru
-                message= _ "I must tell that I like your efforts to do all of this without too much bloodshed."
-            [/message]
-        [/then]
-    [/if]
-    [if]
-        [variable]
-            name=diplomacy_tried
-            equals=5
-        [/variable]
-        [then]
-            [message]
-                speaker=Rimaru
-                message= _ "I always preferred diplomatic solutions over violence, just like you. It's a pity that Brothers of Light have different preferences."
-            [/message]
-        [/then]
-    [/if]
-[/event]
+    [event]
+        name=diplomacy_tried
+        {VARIABLE_OP diplomacy_tried add 1}
+        [if]
+            [variable]
+                name=diplomacy_tried
+                equals=3
+            [/variable]
+            [then]
+                [message]
+                    speaker=Rimaru
+                    message= _ "I must tell that I like your efforts to do all of this without too much bloodshed."
+                [/message]
+            [/then]
+        [/if]
+        [if]
+            [variable]
+                name=diplomacy_tried
+                equals=5
+            [/variable]
+            [then]
+                [message]
+                    speaker=Rimaru
+                    message= _ "I always preferred diplomatic solutions over violence, just like you. It's a pity that Brothers of Light have different preferences."
+                [/message]
+            [/then]
+        [/if]
+    [/event]
 
-
-# Deaths
+    # Deaths
 
     [event]
         name=last breath
@@ -109,179 +111,179 @@
         [message]
             speaker=unit
             message= _ "Goodbye."
-        [option]
-        message=_"Rest in peace, my elvish friend."
-        [command]
-        [/command]
-        [/option]
-        [option]
-        message=_"May you be reborn in a better place."
-        [command]
-            [message]
-                speaker=elf_merc
-                message= _ "Yes... Not enough war in here..."
-            [/message]
-        [/command]
-        [/option]
-        [option]
-        message=_"It's good to see you dead, despicable mercenary."
-        [command]
-            [message]
-                speaker=Rimaru
-                message= _ "That was ugly from you, my friend."
-            [/message]
-            [message]
-                speaker=player
-                message= _ "Doesn't matter, she's dead already."
-            [/message]
-        [/command]
-        [/option]
+            [option]
+                message=_"Rest in peace, my elvish friend."
+                [command]
+                [/command]
+            [/option]
+            [option]
+                message=_"May you be reborn in a better place."
+                [command]
+                    [message]
+                        speaker=elf_merc
+                        message= _ "Yes... Not enough war in here..."
+                    [/message]
+                [/command]
+            [/option]
+            [option]
+                message=_"It's good to see you dead, despicable mercenary."
+                [command]
+                    [message]
+                        speaker=Rimaru
+                        message= _ "That was ugly from you, my friend."
+                    [/message]
+                    [message]
+                        speaker=player
+                        message= _ "Doesn't matter, she's dead already."
+                    [/message]
+                [/command]
+            [/option]
         [/message]
         {VARIABLE chars.elf_merc_died yes}
-    {REMOVE_FROM_RECALL_LIST elf_merc}
+        {REMOVE_FROM_RECALL_LIST elf_merc}
     [/event]
     [event]
         name=last breath
         [filter]
             id=faithful_lieutenant
-        side=1
+            side=1
         [/filter]
-    [if]
-        [variable]
-            name=unit.hitpoints
-            greater_than=1
-        [/variable]
-        [else]
-            [message]
-                speaker=unit
-                message= _ "I am defeated. Nothing can save me now."
-            [/message]
-            [message]
-                speaker=Rimaru
-                message= _ "Darn, I should have protected you better. Who will care about the tactics now when you're dead?"
-            [/message]
-            [message]
-                speaker=unit
-                message= _ "You will manage, Rimaru."
-                [option]
-                message=_"Rest in peace, noble warrior."
-                [command]
-                [/command]
-                [/option]
-                [option]
-                message=_"Rimaru, can you do something to save him?"
-                [command]
-                    [message]
-                        speaker=Rimaru
-                        message= _ "I cannot, it is too late. He's bleeding faster than I can heal."
-                    [/message]
-                [/command]
-                [/option]
-                [option]
-                message=_"Finally you're dead, loathsome wretch. I was regretting my decision to spare you all the time."
-                [command]
-                    [message]
-                        speaker=Rimaru
-                        message= _ "You should not behave like this when our companions die. He did a good service to us."
-                    [/message]
-                [/command]
-                [/option]
-            [/message]
-            {VARIABLE chars.faithful_lieutenant_died yes}
-            {REMOVE_FROM_RECALL_LIST faithful_lieutenant}
-        [/else]
-    [/if]
+        [if]
+            [variable]
+                name=unit.hitpoints
+                greater_than=1
+            [/variable]
+            [else]
+                [message]
+                    speaker=unit
+                    message= _ "I am defeated. Nothing can save me now."
+                [/message]
+                [message]
+                    speaker=Rimaru
+                    message= _ "Darn, I should have protected you better. Who will care about the tactics now when you're dead?"
+                [/message]
+                [message]
+                    speaker=unit
+                    message= _ "You will manage, Rimaru."
+                    [option]
+                        message=_"Rest in peace, noble warrior."
+                        [command]
+                        [/command]
+                    [/option]
+                    [option]
+                        message=_"Rimaru, can you do something to save him?"
+                        [command]
+                            [message]
+                                speaker=Rimaru
+                                message= _ "I cannot, it is too late. He's bleeding faster than I can heal."
+                            [/message]
+                        [/command]
+                    [/option]
+                    [option]
+                        message=_"Finally you're dead, loathsome wretch. I was regretting my decision to spare you all the time."
+                        [command]
+                            [message]
+                                speaker=Rimaru
+                                message= _ "You should not behave like this when our companions die. He did a good service to us."
+                            [/message]
+                        [/command]
+                    [/option]
+                [/message]
+                {VARIABLE chars.faithful_lieutenant_died yes}
+                {REMOVE_FROM_RECALL_LIST faithful_lieutenant}
+            [/else]
+        [/if]
     [/event]
     [event]
         name=last breath
         [filter]
             id=bandit_merc
-        side=1
+            side=1
         [/filter]
-    [if]
-        [variable]
-            name=unit.hitpoints
-            greater_than=1
-        [/variable]
-        [else]
-            [message]
-                speaker=unit
-                message= _ "Eh, at least that I die in battle."
-            [/message]
-            [message]
-                speaker=Rimaru
-                message= _ "It's good to find peace when you die. I would not expect a bandit to succeed at that."
-            [/message]
-            [message]
-                speaker=unit
-                message= _ "I have always been a warrior. Not a loyal or faithful warrior, but a warrior. Every warrior's wish is to die in battle."
-                [option]
-                message=_"Yes. And you have achieved it. Rest now, my friend."
-                [command]
-                [/command]
-                [/option]
-                [option]
-                message=_"I don't think so. War is only a necessity when all other options fail and not living it times of war is the best thing that can happen."
-                [command]
-                    [message]
-                        speaker=unit
-                        message= _ "I disagree. But you can live in that illusion..."
-                    [/message]
-                [/command]
-                [/option]
-                [option]
-                message=_"You call yourself a warrior? Hmph..."
-                [command]
-                    [message]
-                        speaker=unit
-                        message= _ "Call me whatever you like, but I call myself a warrior."
-                    [/message]
-                [/command]
-                [/option]
-            [/message]
-            [message]
-                speaker=Rimaru
-                message= _ "Goodbye, friend"
-            [/message]
-            {VARIABLE chars.bandit_merc_died yes}
-            {REMOVE_FROM_RECALL_LIST bandit_merc}
-        [/else]
-     [/if]
+        [if]
+            [variable]
+                name=unit.hitpoints
+                greater_than=1
+            [/variable]
+            [else]
+                [message]
+                    speaker=unit
+                    message= _ "Eh, at least that I die in battle."
+                [/message]
+                [message]
+                    speaker=Rimaru
+                    message= _ "It's good to find peace when you die. I would not expect a bandit to succeed at that."
+                [/message]
+                [message]
+                    speaker=unit
+                    message= _ "I have always been a warrior. Not a loyal or faithful warrior, but a warrior. Every warrior's wish is to die in battle."
+                    [option]
+                        message=_"Yes. And you have achieved it. Rest now, my friend."
+                        [command]
+                        [/command]
+                    [/option]
+                    [option]
+                        message=_"I don't think so. War is only a necessity when all other options fail and not living it times of war is the best thing that can happen."
+                        [command]
+                            [message]
+                                speaker=unit
+                                message= _ "I disagree. But you can live in that illusion..."
+                            [/message]
+                        [/command]
+                    [/option]
+                    [option]
+                        message=_"You call yourself a warrior? Hmph..."
+                        [command]
+                            [message]
+                                speaker=unit
+                                message= _ "Call me whatever you like, but I call myself a warrior."
+                            [/message]
+                        [/command]
+                    [/option]
+                [/message]
+                [message]
+                    speaker=Rimaru
+                    message= _ "Goodbye, friend"
+                [/message]
+                {VARIABLE chars.bandit_merc_died yes}
+                {REMOVE_FROM_RECALL_LIST bandit_merc}
+            [/else]
+        [/if]
     [/event]
     [event]
         name=last breath
         [filter]
             id=she_brother
-        side=1
+            side=1
         [/filter]
-    [if]
-        [variable]
-            name=unit.hitpoints
-            greater_than=1
-        [/variable]
-        [else]
-            [message]
-                speaker=unit
-                message= _ "I... I wanted to rebuild the order. To save it from its corruption... But I failed. They will not pardon my deeds, they're unforgiving."
-            [/message]
-            [message]
-                speaker=Rimaru
-                message= _ "You have helped us with saving it from its corruption. Your work was amazing, your devotion was inspiring and your glory will never be forgotten."
-            [/message]
-            [message]
-                speaker=unit
-                message= _ "Thank you... Please, finish what we started, we're on a good way to achieve it."
-            [/message]
-            {VARIABLE chars.she_brother_died yes}
-            {REMOVE_FROM_RECALL_LIST she_brother}
-        [/else]
-    [/if]
+        [if]
+            [variable]
+                name=unit.hitpoints
+                greater_than=1
+            [/variable]
+            [else]
+                [message]
+                    speaker=unit
+                    message= _ "I... I wanted to rebuild the order. To save it from its corruption... But I failed. They will not pardon my deeds, they're unforgiving."
+                [/message]
+                [message]
+                    speaker=Rimaru
+                    message= _ "You have helped us with saving it from its corruption. Your work was amazing, your devotion was inspiring and your glory will never be forgotten."
+                [/message]
+                [message]
+                    speaker=unit
+                    message= _ "Thank you... Please, finish what we started, we're on a good way to achieve it."
+                [/message]
+                {VARIABLE chars.she_brother_died yes}
+                {REMOVE_FROM_RECALL_LIST she_brother}
+            [/else]
+        [/if]
     [/event]
     [event]
         name=last breath
         [filter]
             id=hired_swordsman
-        side=1
+            side=1
         [/filter]
         [message]
             speaker=unit
@@ -294,36 +296,36 @@
         [message]
             speaker=unit
             message= _ "Thank you."
-        [option]
-        message=_"No, we thank you for your service, master of the sword."
-        [command]
-            [message]
-                speaker=unit
-                message= _ "It was a... pleasure to fight your you... for your cause..."
-            [/message]
-        [/command]
-        [/option]
-        [option]
-        message=_"I wonder if it's a heroic death when a mercenary dies while fighting for money on the good side."
-        [command]
-            [message]
-                speaker=unit
-                message= _ "It does not matter to me... I liked fighting, I died fighting... I was fighting for the thrill of battle, not for money or glory. I demanded money only because I needed it for living."
-            [/message]
-        [/command]
-        [/option]
-        [option]
-        message=_"(stay silent)"
-        [command]
-        [/command]
-        [/option]
+            [option]
+                message=_"No, we thank you for your service, master of the sword."
+                [command]
+                    [message]
+                        speaker=unit
+                        message= _ "It was a... pleasure to fight your you... for your cause..."
+                    [/message]
+                [/command]
+            [/option]
+            [option]
+                message=_"I wonder if it's a heroic death when a mercenary dies while fighting for money on the good side."
+                [command]
+                    [message]
+                        speaker=unit
+                        message= _ "It does not matter to me... I liked fighting, I died fighting... I was fighting for the thrill of battle, not for money or glory. I demanded money only because I needed it for living."
+                    [/message]
+                [/command]
+            [/option]
+            [option]
+                message=_"(stay silent)"
+                [command]
+                [/command]
+            [/option]
         [/message]
         [message]
             speaker=Rimaru
             message= _ "Goodbye, friend"
         [/message]
         {VARIABLE chars.hired_swordsman_died yes}
-    {REMOVE_FROM_RECALL_LIST hired_swordsman}
+        {REMOVE_FROM_RECALL_LIST hired_swordsman}
     [/event]
     [event]
         name=last breath
@@ -362,40 +364,40 @@
         [message]
             speaker=Rimaru
             message= _ "We shall do that for you."
-        [option]
-        message=_"I will make you a beautiful tombstone so that nobody will forget you."
-        [command]
-            [message]
-                speaker=unit
-                message= _ "Thank you, my friend. Please, mention that I had a wife and five children."
-            [/message]
-        [/command]
-        [/option]
-        [option]
-        message=_"Rest in peace, noble warrior from distant lands, may your homeland forever remember your deeds."
-        [command]
-            [message]
-                speaker=unit
-                message= _ "Thank you for the wishes."
-            [/message]
-        [/command]
-        [/option]
-        [option]
-        message=_"I always hated such dark-skinned bearded liars wearing ugly blankets instead of clothes. Finally, you are dead."
-        [command]
-            [message]
-                speaker=Rimaru
-                message= _ "You should not behave like this, it's really ugly from you."
-            [/message]
-            [message]
-                speaker=player
-                message= _ "Hey, beardo, are you still here? Please know that your death was pointless."
-            [/message]
-        [/command]
-        [/option]
+            [option]
+                message=_"I will make you a beautiful tombstone so that nobody will forget you."
+                [command]
+                    [message]
+                        speaker=unit
+                        message= _ "Thank you, my friend. Please, mention that I had a wife and five children."
+                    [/message]
+                [/command]
+            [/option]
+            [option]
+                message=_"Rest in peace, noble warrior from distant lands, may your homeland forever remember your deeds."
+                [command]
+                    [message]
+                        speaker=unit
+                        message= _ "Thank you for the wishes."
+                    [/message]
+                [/command]
+            [/option]
+            [option]
+                message=_"I always hated such dark-skinned bearded liars wearing ugly blankets instead of clothes. Finally, you are dead."
+                [command]
+                    [message]
+                        speaker=Rimaru
+                        message= _ "You should not behave like this, it's really ugly from you."
+                    [/message]
+                    [message]
+                        speaker=player
+                        message= _ "Hey, beardo, are you still here? Please know that your death was pointless."
+                    [/message]
+                [/command]
+            [/option]
         [/message]
         {VARIABLE chars.al_ghareeb_died yes}
-    {REMOVE_FROM_RECALL_LIST "Al Ghareeb"}
+        {REMOVE_FROM_RECALL_LIST "Al Ghareeb"}
     [/event]
     [event]
         name=last breath
@@ -409,42 +411,42 @@
         [message]
             speaker=Rimaru
             message= _ "We shall send a letter describing your findings to your warlord."
-    [/message]
-    [message]
+        [/message]
+        [message]
             speaker=unit
             message= _ "Thank you. His name is Brugza, and he has a counsellor who can read."
-        [option]
-        message=_"Your deed to your people is done, noble warrior, you can rest in peace now."
-        [command]
-        [/command]
-        [/option]
-        [option]
-        message=_"Let your unfinished quest be, we will finish it your you."
-        [command]
-        [/command]
-        [/option]
-        [option]
-        message=_"There is one orc less in this world, celebrate!"
-        [command]
-            [message]
-                speaker=faithful_lieutenant
-                message= _ "Yes, our enemies have committed a heroic deed today, one that we could not do because of this cursed Rimaru."
-            [/message]
-            [message]
-                speaker=Rimaru
-                message= _ "Don't insult the dying. That is very insolent."
-            [/message]
-        [/command]
-        [/option]
+            [option]
+                message=_"Your deed to your people is done, noble warrior, you can rest in peace now."
+                [command]
+                [/command]
+            [/option]
+            [option]
+                message=_"Let your unfinished quest be, we will finish it your you."
+                [command]
+                [/command]
+            [/option]
+            [option]
+                message=_"There is one orc less in this world, celebrate!"
+                [command]
+                    [message]
+                        speaker=faithful_lieutenant
+                        message= _ "Yes, our enemies have committed a heroic deed today, one that we could not do because of this cursed Rimaru."
+                    [/message]
+                    [message]
+                        speaker=Rimaru
+                        message= _ "Don't insult the dying. That is very insolent."
+                    [/message]
+                [/command]
+            [/option]
         [/message]
         {VARIABLE chars.orc_died yes}
-    {REMOVE_FROM_RECALL_LIST orc}
+        {REMOVE_FROM_RECALL_LIST orc}
     [/event]
     [event]
         name=last breath
         [filter]
             id=hired_halberdier
-        side=1
+            side=1
         [/filter]
         [message]
             speaker=unit
@@ -457,36 +459,36 @@
         [message]
             speaker=unit
             message= _ "I have a son, Roderick is his name. I'd be happy if you found him."
-        [option]
-        message=_"We'll find him once this war ends."
-        [command]
-            [message]
-                speaker=unit
-                message= _ "Thank you."
-            [/message]
-        [/command]
-        [/option]
-        [option]
-        message=_"If we meet him, he can have them, but I can't assure that we'll ever find him."
-        [command]
-            [message]
-                speaker=unit
-                message= _ "I hope you will meet him, then."
-            [/message]
-        [/command]
-        [/option]
-        [option]
-        message=_"I think that we'll better keep them ourselves."
-        [command]
-            [message]
-                speaker=unit
-                message= _ "I knew that believing that you'll ever give my stuff to somebody if I die is a foolish belief. But well, I should not have died."
-            [/message]
-        [/command]
-        [/option]
+            [option]
+                message=_"We'll find him once this war ends."
+                [command]
+                    [message]
+                        speaker=unit
+                        message= _ "Thank you."
+                    [/message]
+                [/command]
+            [/option]
+            [option]
+                message=_"If we meet him, he can have them, but I can't assure that we'll ever find him."
+                [command]
+                    [message]
+                        speaker=unit
+                        message= _ "I hope you will meet him, then."
+                    [/message]
+                [/command]
+            [/option]
+            [option]
+                message=_"I think that we'll better keep them ourselves."
+                [command]
+                    [message]
+                        speaker=unit
+                        message= _ "I knew that believing that you'll ever give my stuff to somebody if I die is a foolish belief. But well, I should not have died."
+                    [/message]
+                [/command]
+            [/option]
         [/message]
         {VARIABLE chars.hired_halberdier_died yes}
-    {REMOVE_FROM_RECALL_LIST hired_halberdier}
+        {REMOVE_FROM_RECALL_LIST hired_halberdier}
     [/event]
     [event]
         name=last breath
@@ -529,32 +531,32 @@
         [message]
             speaker=unit
             message= _ "I am happy that I did something useful at last. After months of obeying those freaks, I finally did what I wanted and died for a good cause."
-        [option]
-        message=_"You help us a lot. May you be forever tranquil."
-        [command]
-        [/command]
-        [/option]
-        [option]
-        message=_"A pity they killed you so early."
-        [command]
-            [message]
-                speaker=unit
-                message= _ "Yes... a pity..."
-            [/message]
-        [/command]
-        [/option]
-        [option]
-        message=_"I was suspecting you to be a spy, but I am now sure that you won't spy anymore."
-        [command]
-            [message]
-                speaker=unit
-                message= _ "I wasn't a spy..."
-            [/message]
-        [/command]
-        [/option]
+            [option]
+                message=_"You help us a lot. May you be forever tranquil."
+                [command]
+                [/command]
+            [/option]
+            [option]
+                message=_"A pity they killed you so early."
+                [command]
+                    [message]
+                        speaker=unit
+                        message= _ "Yes... a pity..."
+                    [/message]
+                [/command]
+            [/option]
+            [option]
+                message=_"I was suspecting you to be a spy, but I am now sure that you won't spy anymore."
+                [command]
+                    [message]
+                        speaker=unit
+                        message= _ "I wasn't a spy..."
+                    [/message]
+                [/command]
+            [/option]
         [/message]
         {VARIABLE chars.wise_warrior_died yes}
-    {REMOVE_FROM_RECALL_LIST wise_warrior}
+        {REMOVE_FROM_RECALL_LIST wise_warrior}
     [/event]
     [event]
         name=last breath
@@ -583,33 +585,36 @@
     [/event]
 
     [event]
-    name=side 1 turn refresh
-    first_time_only=no
-    [store_unit]
-        [filter]
-            side=1
-        [/filter]
-        variable=fixing
-    [/store_unit]
-    {FOREACH fixing i}
-        [if]
-            [variable]
-                name=fixing[$i].variables.hero
-                equals=yes
-            [/variable]
-            [then]
-                {CLEAR_VARIABLE fixing[$i].variables.cant_pick}
-            [/then]
-            [else]
-                {VARIABLE fixing[$i].variables.cant_pick yes}
-            [/else]
-        [/if]
-        [unstore_unit]
-            variable=fixing[$i]
-            find_vacant=no
-        [/unstore_unit]
-    {NEXT i}
-    {CLEAR_VARIABLE fixing}
+        name=side 1 turn refresh
+        first_time_only=no
+        [store_unit]
+            [filter]
+                side=1
+            [/filter]
+            variable=fixing
+        [/store_unit]
+        [for]
+            array=fixing
+            [do]
+                [if]
+                    [variable]
+                        name=fixing[$i].variables.hero
+                        equals=yes
+                    [/variable]
+                    [then]
+                        {CLEAR_VARIABLE fixing[$i].variables.cant_pick}
+                    [/then]
+                    [else]
+                        {VARIABLE fixing[$i].variables.cant_pick yes}
+                    [/else]
+                [/if]
+                [unstore_unit]
+                    variable=fixing[$i]
+                    find_vacant=no
+                [/unstore_unit]
+            [/do]
+        [/for]
+        {CLEAR_VARIABLE fixing}
     [/event]
 
     [event]

--- a/spinoffs/The_Beautiful_Child/utils/utils.cfg
+++ b/spinoffs/The_Beautiful_Child/utils/utils.cfg
@@ -1,4 +1,4 @@
-#textdomain wesnoth-tbc
+#textdomain wesnth-tbc
 #define TBC_GLOBAL_EVENTS_RPG
 
     {DROPS 20 20 (axe,axe,staff,sword,sword,knife,bow,xbow,spear,spear,bow,dagger,mace) no 2,3,4,5,6,7,8}
@@ -61,160 +61,163 @@
 #enddef
 
 #define TBC_RECALL_ALL X Y
-{FOREACH party_members i}
-    [recall]
-        id=$party_members[$i].id
-        x,y={X},{Y}
-        show=no
-    [/recall]
-{NEXT i}
+    [foreach]
+        array=party_members
+        [do]
+            [recall]
+                id=$this_item.id
+                x,y={X},{Y}
+                show=no
+            [/recall]
+        [/do]
+    [/foreach]
 #enddef
 
 #define TBC_ORIGIN PREVIOUS X Y
-[if]
-    [variable]
-        name=previous_scenario
-        equals={PREVIOUS}
-    [/variable]
-    [then]
-        [teleport]
-            [filter]
-                id=player
-            [/filter]
-            x,y={X},{Y}
-            clear_shroud=yes
-        [/teleport]
-        {TBC_RECALL_ALL {X} {Y}}
-    [/then]
-[/if]
+    [if]
+        [variable]
+            name=previous_scenario
+            equals={PREVIOUS}
+        [/variable]
+        [then]
+            [teleport]
+                [filter]
+                    id=player
+                [/filter]
+                x,y={X},{Y}
+                clear_shroud=yes
+            [/teleport]
+            {TBC_RECALL_ALL {X} {Y}}
+        [/then]
+    [/if]
 #enddef
 
 #define TBC_TRANSITION RANGE_X RANGE_Y TARGET TARGET_DESC DESC_X DESC_Y
-[label]
-    x,y={DESC_X},{DESC_Y}
-    text={TARGET_DESC}
-    color=255,255,255
-[/label]
-[event]
-    name=moveto
-    first_time_only=no
-    [filter]
-        x,y={RANGE_X},{RANGE_Y}
-        side=1
-        [filter_wml]
-            [variables]
-                hero=yes
-            [/variables]
-        [/filter_wml]
-    [/filter]
-    [message]
-        speaker=narrator
-        caption=_"Area transition"
-        message=_"Do you want to go to " + {TARGET_DESC} + _"?"
-        [option]
-            message=_"Yes, of course."
-            [command]
-                {VARIABLE previous_scenario $current_scenario}
-                [endlevel]
-                    result=victory
-                    bonus=no
-                    next_scenario={TARGET}
-                    {NEW_GOLD_CARRYOVER 100}
-                [/endlevel]
-            [/command]
-        [/option]
-        [option]
-            message=_"No, that isn't the place where I wanted to go."
-            [command]
-                [allow_undo]
-                [/allow_undo]
-            [/command]
-        [/option]
-    [/message]
-[/event]
+    [label]
+        x,y={DESC_X},{DESC_Y}
+        text={TARGET_DESC}
+        color=255,255,255
+    [/label]
+    [event]
+        name=moveto
+        first_time_only=no
+        [filter]
+            x,y={RANGE_X},{RANGE_Y}
+            side=1
+            [filter_wml]
+                [variables]
+                    hero=yes
+                [/variables]
+            [/filter_wml]
+        [/filter]
+        [message]
+            speaker=narrator
+            caption=_"Area transition"
+            message=_"Do you want to go to " + {TARGET_DESC} + _"?"
+            [option]
+                message=_"Yes, of course."
+                [command]
+                    {VARIABLE previous_scenario $current_scenario}
+                    [endlevel]
+                        result=victory
+                        bonus=no
+                        next_scenario={TARGET}
+                        {NEW_GOLD_CARRYOVER 100}
+                    [/endlevel]
+                [/command]
+            [/option]
+            [option]
+                message=_"No, that isn't the place where I wanted to go."
+                [command]
+                    [allow_undo]
+                    [/allow_undo]
+                [/command]
+            [/option]
+        [/message]
+    [/event]
 #enddef
 
 #define TBC_PLACE_WAYPOINT X Y
-{PLACE_IMAGE scenery/monolith1.png {X} {Y}}
-[event]
-    name=moveto
-    first_time_only=no
-    [filter]
-        side=1
-        x,y={X},{Y}
-        [filter_wml]
-            [variables]
-                hero=yes
-            [/variables]
-        [/filter_wml]
-    [/filter]
-    [filter_condition]
-        [not]
-            [variable]
-                name=disallow_waypoint
-                equals=yes
-            [/variable]
-        [/not]
-    [/filter_condition]
-    [fire_event]
-        name=waypoint
-    [/fire_event]
-[/event]
-[event]
-    name=prestart
-    {TBC_ORIGIN waypoint {X} {Y}}
-[/event]
+    {PLACE_IMAGE scenery/monolith1.png {X} {Y}}
+    [event]
+        name=moveto
+        first_time_only=no
+        [filter]
+            side=1
+            x,y={X},{Y}
+            [filter_wml]
+                [variables]
+                    hero=yes
+                [/variables]
+            [/filter_wml]
+        [/filter]
+        [filter_condition]
+            [not]
+                [variable]
+                    name=disallow_waypoint
+                    equals=yes
+                [/variable]
+            [/not]
+        [/filter_condition]
+        [fire_event]
+            name=waypoint
+        [/fire_event]
+    [/event]
+    [event]
+        name=prestart
+        {TBC_ORIGIN waypoint {X} {Y}}
+    [/event]
 #enddef
 
 #define SCENARIO_DURATION_VARIABLE NAME VALUE
-{VARIABLE {NAME} {VALUE}}
-[event]
-    name=victory
-    id={NAME}_clear_event
-    {CLEAR_VARIABLE NAME}
-[/event]
+    {VARIABLE {NAME} {VALUE}}
+    [event]
+        name=victory
+        id={NAME}_clear_event
+        {CLEAR_VARIABLE NAME}
+    [/event]
 #enddef
 
 #define TBC_SPAWN_UNITS_NO_LEADER SIDE QUANTITY TYPES X Y
-{VARIABLE quantity $party_members.length}
-{VARIABLE_OP quantity multiply {QUANTITY}}
+    {VARIABLE quantity $party_members.length}
+    {VARIABLE_OP quantity multiply {QUANTITY}}
 #ifdef HARD
     {VARIABLE_OP quantity multiply 1.3}
 #endif
 #ifdef EASY
     {VARIABLE_OP quantity divide 1.2}
 #endif
-[while]
-    [variable]
-        name=quantity
-        greater_than=0
-    [/variable]
-    [do]
-        {VARIABLE_OP unit_type rand {TYPES}}
-        {GENERIC_UNIT {SIDE} $unit_type {X} {Y}}
-        {VARIABLE_OP quantity sub 1}
-    [/do]
-[/while]
-{CLEAR_VARIABLE quantity,unit_type}
+    [while]
+        [variable]
+            name=quantity
+            greater_than=0
+        [/variable]
+        [do]
+            {VARIABLE_OP unit_type rand {TYPES}}
+            {GENERIC_UNIT {SIDE} $unit_type {X} {Y}}
+            {VARIABLE_OP quantity sub 1}
+        [/do]
+    [/while]
+    {CLEAR_VARIABLE quantity,unit_type}
 #enddef
 
 #define TBC_SPAWN_UNITS SIDE QUANTITY TYPES X Y LEADER_TYPE LEADER_ID
-[unit]
-    side={SIDE}
-    type={LEADER_TYPE}
-    id={LEADER_ID}
-    generate_name=yes
-    x,y={X},{Y}
-    random_traits=yes
-    upkeep=full
-[/unit]
-{TBC_SPAWN_UNITS_NO_LEADER {SIDE} {QUANTITY} {TYPES} {X} {Y}}
+    [unit]
+        side={SIDE}
+        type={LEADER_TYPE}
+        id={LEADER_ID}
+        generate_name=yes
+        x,y={X},{Y}
+        random_traits=yes
+        upkeep=full
+    [/unit]
+    {TBC_SPAWN_UNITS_NO_LEADER {SIDE} {QUANTITY} {TYPES} {X} {Y}}
 #enddef
 
 #define TBC_DIPLOMACY_TRIED
-[fire_event]
-    name=diplomacy_tried
-[/fire_event]
+    [fire_event]
+        name=diplomacy_tried
+    [/fire_event]
 #enddef
 
 #define TBC_GOLD_CHEST X Y VAR
@@ -225,9 +228,9 @@
         [/variable]
         [else]
             {PLACE_IMAGE items/chest-plain-closed.png {X} {Y}}
-        [+item]
-        visible_in_fog=no
-        [/item]
+            [+item]
+                visible_in_fog=no
+            [/item]
             [event]
                 name=moveto
                 [filter]
@@ -259,16 +262,16 @@
 #enddef
 
 #define CLEAR_RECALLS
-[kill]
-    side=1
-    [not]
-        [filter_wml]
-            [variables]
-                hero=yes
-            [/variables]
-        [/filter_wml]
-    [/not]
-    fire_event=no
-    animate=no
-[/kill]
+    [kill]
+        side=1
+        [not]
+            [filter_wml]
+                [variables]
+                    hero=yes
+                [/variables]
+            [/filter_wml]
+        [/not]
+        fire_event=no
+        animate=no
+    [/kill]
 #enddef


### PR DESCRIPTION
Looks like wmlindent had a lot to do here.  The only changes I made were to replace the FOREACH loops with for/foreach, and I changed the loop variables in a couple cases that used i for both inner and outer loops (not wrong as I understand it, but IMO it's a lot more readable to just use unique and potentially less error-prone).

I haven't tested any of these.  I'm going to do some other cleanup stuff (have these been brought up to 1.16?  a recent forum comment said no) and then play test.

Ref #621 