### PR TITLE
tbc updates for 1.16

### DIFF
--- a/spinoffs/The_Beautiful_Child/scenarios/00_Intro.cfg
+++ b/spinoffs/The_Beautiful_Child/scenarios/00_Intro.cfg
@@ -32,195 +32,195 @@
     [/side]
     [event]
         name=start
-    {VARIABLE gender male}
-    [message]
-        speaker=narrator
-        message=_"Pick your main character's unit type:"
-                [option]
-                    image=units/human-loyalists/swordsman.png
-                        message=_"Swordsman"
-                        [command]
-                            {VARIABLE type_picked "Swordsman"}
-                        [/command]
-                [/option]
-                [option]
-                    image=units/human-loyalists/duelist.png
-                        message=_"Duelist"
-                        [command]
-                            {VARIABLE type_picked "Duelist"}
-                        [/command]
-                [/option]
-                [option]
-                    image=units/human-loyalists/shocktrooper.png
-                        message=_"Shock Trooper"
-                        [command]
-                            {VARIABLE type_picked "Shock Trooper"}
-                        [/command]
-                [/option]
-                [option]
-                    image=units/human-loyalists/javelineer.png
-                        message=_"Javelineer"
-                        [command]
-                            {VARIABLE type_picked "Javelineer"}
-                        [/command]
-                [/option]
-                [option]
-                    image=units/human-loyalists/lieutenant.png
-                        message=_"Lieutenant"
-                        [command]
-                            {VARIABLE type_picked "Lieutenant"}
-                        [/command]
-                [/option]
-                [option]
-                    image=units/human-loyalists/longbowman.png
-                        message=_"Longbowman"
-                        [command]
-                            {VARIABLE type_picked "Longbowman"}
-                        [/command]
-                [/option]
-                [option]
-                    image=units/humans/sword-mage.png
-                        message=_"Sword Mage"
-                        [command]
-                            {VARIABLE type_picked "Sword Mage"}
-                [message]
-                speaker=narrator
-                message= _ "Choose gender."
-                side_for=$side_number
-                image=wesnoth-icon.png
-                [option]
-                    image=units/humans/sword-mage.png
-                    message=_"Male"
-                    [command]
-                    {VARIABLE gender male}
-                    [/command]
-                [/option]
-                [option]
-                    image="units/humans/sword-mage+female.png"
-                    message=_"Female"
-                    [command]
-                    {VARIABLE gender female}
-                    [/command]
-                [/option]
-                [/message]
-                        [/command]
-                [/option]
-    [/message]
-    [store_unit]
-        [filter]
+        {VARIABLE gender male}
+        [message]
+            speaker=narrator
+            message=_"Pick your main character's unit type:"
+            [option]
+                image=units/human-loyalists/swordsman.png
+                message=_"Swordsman"
+                [command]
+                    {VARIABLE type_picked "Swordsman"}
+                [/command]
+            [/option]
+            [option]
+                image=units/human-loyalists/duelist.png
+                message=_"Duelist"
+                [command]
+                    {VARIABLE type_picked "Duelist"}
+                [/command]
+            [/option]
+            [option]
+                image=units/human-loyalists/shocktrooper.png
+                message=_"Shock Trooper"
+                [command]
+                    {VARIABLE type_picked "Shock Trooper"}
+                [/command]
+            [/option]
+            [option]
+                image=units/human-loyalists/javelineer.png
+                message=_"Javelineer"
+                [command]
+                    {VARIABLE type_picked "Javelineer"}
+                [/command]
+            [/option]
+            [option]
+                image=units/human-loyalists/lieutenant.png
+                message=_"Lieutenant"
+                [command]
+                    {VARIABLE type_picked "Lieutenant"}
+                [/command]
+            [/option]
+            [option]
+                image=units/human-loyalists/longbowman.png
+                message=_"Longbowman"
+                [command]
+                    {VARIABLE type_picked "Longbowman"}
+                [/command]
+            [/option]
+            [option]
+                image=units/humans/sword-mage.png
+                message=_"Sword Mage"
+                [command]
+                    {VARIABLE type_picked "Sword Mage"}
+                    [message]
+                        speaker=narrator
+                        message= _ "Choose gender."
+                        side_for=$side_number
+                        image=wesnoth-icon.png
+                        [option]
+                            image=units/humans/sword-mage.png
+                            message=_"Male"
+                            [command]
+                                {VARIABLE gender male}
+                            [/command]
+                        [/option]
+                        [option]
+                            image="units/humans/sword-mage+female.png"
+                            message=_"Female"
+                            [command]
+                                {VARIABLE gender female}
+                            [/command]
+                        [/option]
+                    [/message]
+                [/command]
+            [/option]
+        [/message]
+        [store_unit]
+            [filter]
+                id=player
+            [/filter]
+            variable=player_store
+            kill=yes
+        [/store_unit]
+        [unit]
+            side=1
+            canrecruit=yes
             id=player
-        [/filter]
-        variable=player_store
-        kill=yes
-    [/store_unit]
-    [unit]
-        side=1
-        canrecruit=yes
-        id=player
-        name=_"Puppyslayer"
-        x,y=$player_store.x,$player_store.y
-        type=$type_picked
-        gender=$gender
-        [variables]
-            hero=yes
-            player=yes
-        [/variables]
-        [modifications]
-            {TRAIT_INTELLIGENT}
-            {TRAIT_RESILIENT}
-        [/modifications]
-    [/unit]
-    {CLEAR_VARIABLE player_store,gender,type_picked}
-    [unit]
-        side=1
-        id=Rimaru
-        name=_"Rimaru"
-        x,y=12,4
-        type=White Mage
-        portrait=portraits/humans/transparent/mage-white.png~CS(-40,-40,-40)
-        [variables]
-            hero=yes
-        [/variables]
-        [modifications]
-            [advance]
-                id=portrait
-                [effect]
-                    apply_to=profile
-                    portrait=portraits/humans/transparent/mage-white.png~CS(-40,-40,-40)
-                [/effect]
-            [/advance]
-            [advance]
-                id=heal
-            [/advance]
-            [advance]
-                id=heal2
-            [/advance]
-            [advance]
-                id=heal3
-                [effect]
-                apply_to=remove_ability
-                [abilities]
-                    {ABILITY_CURES}
-                [/abilities]
-                [/effect]
-                [effect]
-                apply_to=new_ability
-                [abilities]
-                    {ABILITY_HEALS_OTHER 16}
-                [/abilities]
-                [/effect]
-            [/advance]
-        [/modifications]
-    [/unit]
+            name=_"Puppyslayer"
+            x,y=$player_store.x,$player_store.y
+            type=$type_picked
+            gender=$gender
+            [variables]
+                hero=yes
+                player=yes
+            [/variables]
+            [modifications]
+                {TRAIT_INTELLIGENT}
+                {TRAIT_RESILIENT}
+            [/modifications]
+        [/unit]
+        {CLEAR_VARIABLE player_store,gender,type_picked}
         [unit]
-        side=2
-        type=Peasant
-        id=guy_1
-        generate_name=yes
-        x,y=14,2
-        random_traits=yes
-        upkeep=full
+            side=1
+            id=Rimaru
+            name=_"Rimaru"
+            x,y=12,4
+            type=White Mage
+            portrait=portraits/humans/transparent/mage-white.png~CS(-40,-40,-40)
+            [variables]
+                hero=yes
+            [/variables]
+            [modifications]
+                [advancement]
+                    id=portrait
+                    [effect]
+                        apply_to=profile
+                        portrait=portraits/humans/transparent/mage-white.png~CS(-40,-40,-40)
+                    [/effect]
+                [/advancement]
+                [advancement]
+                    id=heal
+                [/advancement]
+                [advancement]
+                    id=heal2
+                [/advancement]
+                [advancement]
+                    id=heal3
+                    [effect]
+                        apply_to=remove_ability
+                        [abilities]
+                            {ABILITY_CURES}
+                        [/abilities]
+                    [/effect]
+                    [effect]
+                        apply_to=new_ability
+                        [abilities]
+                            {ABILITY_HEALS_OTHER 16}
+                        [/abilities]
+                    [/effect]
+                [/advancement]
+            [/modifications]
         [/unit]
         [unit]
-        side=2
-        type=Peasant
-        id=guy_2
-        generate_name=yes
-        x,y=11,4
-        random_traits=yes
-        upkeep=full
+            side=2
+            type=Peasant
+            id=guy_1
+            generate_name=yes
+            x,y=14,2
+            random_traits=yes
+            upkeep=full
         [/unit]
         [unit]
-        side=2
-        type=Peasant
-        id=guy_3
-        generate_name=yes
-        x,y=16,2
-        random_traits=yes
-        upkeep=full
+            side=2
+            type=Peasant
+            id=guy_2
+            generate_name=yes
+            x,y=11,4
+            random_traits=yes
+            upkeep=full
         [/unit]
-    [unit]
-        side=2
-        id=elf_merc
-        generate_name=yes
-        x,y=9,5
-        type=Elvish Archer
-        experience=20
-        gender=female
-        [variables]
-            hero=yes
-        [/variables]
-        [modifications]
-            {TRAIT_HIGHLANDER}
-            [advance]
-                id=portrait
-                [effect]
-                    apply_to=profile
-                    portrait="portraits/elves/transparent/archer+female.png"
-                [/effect]
-            [/advance]
-        [/modifications]
-    [/unit]
+        [unit]
+            side=2
+            type=Peasant
+            id=guy_3
+            generate_name=yes
+            x,y=16,2
+            random_traits=yes
+            upkeep=full
+        [/unit]
+        [unit]
+            side=2
+            id=elf_merc
+            generate_name=yes
+            x,y=9,5
+            type=Elvish Archer
+            experience=20
+            gender=female
+            [variables]
+                hero=yes
+            [/variables]
+            [modifications]
+                {TRAIT_HIGHLANDER}
+                [advancement]
+                    id=portrait
+                    [effect]
+                        apply_to=profile
+                        portrait="portraits/elves/transparent/archer+female.png"
+                    [/effect]
+                [/advancement]
+            [/modifications]
+        [/unit]
     [/event]
     [event]
         name=start
@@ -273,53 +273,53 @@
             message=_"What can they do to me? I will tell them the same as I told you and they will cry how corrupt they are. Uhm... speak of the devil..."
         [/message]
         [unit]
-        side=2
-        type=Mage of Light
-        id=brother_1
-        generate_name=yes
-        x,y=1,4
-        random_traits=yes
-        gender=male
-        upkeep=full
+            side=2
+            type=Mage of Light
+            id=brother_1
+            generate_name=yes
+            x,y=1,4
+            random_traits=yes
+            gender=male
+            upkeep=full
         [/unit]
         [unit]
-        side=2
-        type=White Mage
-        id=brother_2
-        generate_name=yes
-        x,y=2,3
-        random_traits=yes
-        gender=male
-        upkeep=full
+            side=2
+            type=White Mage
+            id=brother_2
+            generate_name=yes
+            x,y=2,3
+            random_traits=yes
+            gender=male
+            upkeep=full
         [/unit]
         [unit]
-        side=2
-        type=White Mage
-        id=she_brother
-        generate_name=yes
-        x,y=2,4
-        gender=female
-        upkeep=full
-        [modifications]
-            {TRAIT_DEXTROUS}
-            {TRAIT_INTELLIGENT}
-            [advance]
-                id=portrait
-                [effect]
-                    apply_to=profile
-                    portrait="portraits/humans/transparent/mage-white+female.png"
-                [/effect]
-            [/advance]
-        [/modifications]
+            side=2
+            type=White Mage
+            id=she_brother
+            generate_name=yes
+            x,y=2,4
+            gender=female
+            upkeep=full
+            [modifications]
+                {TRAIT_DEXTROUS}
+                {TRAIT_INTELLIGENT}
+                [advancement]
+                    id=portrait
+                    [effect]
+                        apply_to=profile
+                        portrait="portraits/humans/transparent/mage-white+female.png"
+                    [/effect]
+                [/advancement]
+            [/modifications]
         [/unit]
         [move_unit]
             side=2
-        [not]
-        type=Peasant
-        [/not]
-        [not]
-        race=elf
-        [/not]
+            [not]
+                type=Peasant
+            [/not]
+            [not]
+                race=elf
+            [/not]
             to_x=11
             to_y=4
             fire_event=no
@@ -496,9 +496,9 @@
             speaker=brother_1
             message=_"Well, who shall do it?"
         [/message]
-    [delay]
-        time=1000
-    [/delay]
+        [delay]
+            time=1000
+        [/delay]
         [message]
             speaker=brother_1
             message=_"Nobody?"
@@ -521,29 +521,29 @@
         [/message]
         [move_unit]
             side=2
-        [not]
-        type=Peasant
-        [/not]
-        [not]
-        race=elf
-        [/not]
+            [not]
+                type=Peasant
+            [/not]
+            [not]
+                race=elf
+            [/not]
             to_x=1
             to_y=4
             fire_event=no
         [/move_unit]
-    [store_unit]
-        [filter]
-            side=2
+        [store_unit]
+            [filter]
+                side=2
                 [not]
-                type=Peasant
+                    type=Peasant
                 [/not]
                 [not]
-                race=elf
+                    race=elf
                 [/not]
-        [/filter]
-        variable=brothers_store
-        kill=yes
-    [/store_unit]
+            [/filter]
+            variable=brothers_store
+            kill=yes
+        [/store_unit]
         [message]
             speaker=Rimaru
             message=_"Do you like the Brothers of Larceny?"
@@ -555,179 +555,179 @@
         [message]
             speaker=Rimaru
             message=_"Wimps! Cowards! You don't like them, you agree with me, yet neither of you supports me. Is there a single person in this place who is not afraid? Like you, mercenary. Do you have a name?"
-        [text_input]
-        variable=player_name
-        label=_"The desired name of your character:"
-        max_length=20
-        text= _ "Puppyslayer"
-        [/text_input]
+            [text_input]
+                variable=player_name
+                label=_"The desired name of your character:"
+                max_length=20
+                text= _ "Puppyslayer"
+            [/text_input]
         [/message]
-    [store_unit]
-        [filter]
-            id=player
-        [/filter]
-        variable=player_store
-        kill=no
-    [/store_unit]
-    {VARIABLE player_store.name $player_name}
-    [unstore_unit]
-        variable=player_store
-        find_vacant=no
-    [/unstore_unit]
+        [store_unit]
+            [filter]
+                id=player
+            [/filter]
+            variable=player_store
+            kill=no
+        [/store_unit]
+        {VARIABLE player_store.name $player_name}
+        [unstore_unit]
+            variable=player_store
+            find_vacant=no
+        [/unstore_unit]
         [message]
             speaker=Rimaru
             message=_"I have seen you a few times, yet I know nothing of you. What can you tell me about yourself?"
-        {LEGACY_MESSAGE_OPTIONS legacy} # This one is defined in LotI, but it's just for this case - so that adding legacies would not require updating this campaign
+            {LEGACY_MESSAGE_OPTIONS legacy} # This one is defined in LotI, but it's just for this case - so that adding legacies would not require updating this campaign
         [/message]
-    [set_variables]
-        name=player_store.modifications.advance[$player_store.modifications.advance.length]
-        mode=replace
-        [value]
-            id=$legacy
-        [/value]
-    [/set_variables]
-    [set_variables]
-        name=player_store.modifications.advance[$player_store.modifications.advance.length]
-        mode=replace
-        [value]
-            id=awareness
-        [/value]
-    [/set_variables]
-    [unstore_unit]
-        variable=player_store
-        find_vacant=no
-    [/unstore_unit]
-    {CLEAR_VARIABLE players_store,legacy}
+        [set_variables]
+            name=player_store.modifications.advance[$player_store.modifications.advance.length]
+            mode=replace
+            [value]
+                id=$legacy
+            [/value]
+        [/set_variables]
+        [set_variables]
+            name=player_store.modifications.advance[$player_store.modifications.advance.length]
+            mode=replace
+            [value]
+                id=awareness
+            [/value]
+        [/set_variables]
+        [unstore_unit]
+            variable=player_store
+            find_vacant=no
+        [/unstore_unit]
+        {CLEAR_VARIABLE players_store,legacy}
         [message]
             speaker=Rimaru
             message=_"Interesting. I thought you were just an unimportant wanderer. Anyway, are you a coward or you will help me with these Brothers of Larceny?"
-        [option]
-        message= _ "Sure I will. I always like to fight for a good cause!"
-        [command]
-            [message]
-                speaker=Rimaru
-                message=_"That is what I like to hear."
-            [/message]
-        [/command]
-        [/option]
-        [option]
-        message= _ "You called me a mercenary. I am not. I am protecting this village from possible bandit attacks."
-        [command]
-            [message]
-                speaker=Rimaru
-                message=_"Bandits? There are no bandits around except these Brothers of Larceny. I have shown you their real motivations. Would you protect us from them?"
-            [/message]
-            [message]
-                speaker=player
-                message=_"Uhm... yes."
-            [/message]
-        [/command]
-        [/option]
-        [option]
-        message= _ "If I will be paid..."
-        [command]
-            [message]
-                speaker=Rimaru
-                message=_"I have more money than I made them think I have. I have a secret reserve. Consider yourself hired!"
-            [/message]
-        [/command]
-        [/option]
+            [option]
+                message= _ "Sure I will. I always like to fight for a good cause!"
+                [command]
+                    [message]
+                        speaker=Rimaru
+                        message=_"That is what I like to hear."
+                    [/message]
+                [/command]
+            [/option]
+            [option]
+                message= _ "You called me a mercenary. I am not. I am protecting this village from possible bandit attacks."
+                [command]
+                    [message]
+                        speaker=Rimaru
+                        message=_"Bandits? There are no bandits around except these Brothers of Larceny. I have shown you their real motivations. Would you protect us from them?"
+                    [/message]
+                    [message]
+                        speaker=player
+                        message=_"Uhm... yes."
+                    [/message]
+                [/command]
+            [/option]
+            [option]
+                message= _ "If I will be paid..."
+                [command]
+                    [message]
+                        speaker=Rimaru
+                        message=_"I have more money than I made them think I have. I have a secret reserve. Consider yourself hired!"
+                    [/message]
+                [/command]
+            [/option]
         [/message]
-    [modify_unit]
-        [filter]
-            id=Rimaru
-        [/filter]
-        canrecruit=yes
-    [/modify_unit]
-    {VARIABLE party_members[0].id player}
-    {VARIABLE party_members[1].id Rimaru}
+        [modify_unit]
+            [filter]
+                id=Rimaru
+            [/filter]
+            canrecruit=yes
+        [/modify_unit]
+        {VARIABLE party_members[0].id player}
+        {VARIABLE party_members[1].id Rimaru}
         [message]
             speaker=guy_1
             message=_"Now there is two of you? I can see a rebellion rising."
         [/message]
-    [message]
-        speaker=Rimaru
-        message=_"Wait, that was sarcasm? I never expected you to be capable of that!"
-    [/message]
+        [message]
+            speaker=Rimaru
+            message=_"Wait, that was sarcasm? I never expected you to be capable of that!"
+        [/message]
         [message]
             speaker=guy_1
             message=_"Huh, what is sarcasm?"
         [/message]
-    [message]
-        speaker=Rimaru
-        message=_"Eh, let that be... Hey you, elf, do you want to be hired too?"
-    [/message]
-    [message]
-        speaker=elf_merc
-        message=_"Will I get a share of the booty?"
-    [/message]
-    [message]
-        speaker=Rimaru
-        message=_"Yes."
-    [/message]
-    [message]
-        speaker=elf_merc
-        message=_"I want a third of all the loot."
-    [/message]
-    [message]
-        speaker=Rimaru
-        message=_"We will have more allies when we finish, your share will depend on the quantity of allies we'll get, okay?"
-    [/message]
-    [message]
-        speaker=elf_merc
-        message=_"Yes."
-    [/message]
-    [message]
-        speaker=Rimaru
-        message=_"You're surprising me how much of a mercenary you are. Do you even care about our goal?"
-    [/message]
-    [message]
-        speaker=elf_merc
-        message=_"It is not my religion. Brothers of Light are out of my concern. I fight for the one who pays more. As long as it does not look like a suicide, if I died, I would have no use for the money."
-    [/message]
-    [message]
-        speaker=Rimaru
-        message=_"What a damned sellsword you are. Shall we let her join us? I am afraid of her somehow."
-        [option]
-        message= _ "We need everyone willing to fight for us."
-        [command]
-            [message]
-                speaker=Rimaru
-                message=_"Well, I can't say that I like her, but you're right, we need allies."
-            [/message]
-            [modify_unit]
-                [filter]
-                    id=elf_merc
-                [/filter]
-                side=1
-                canrecruit=yes
-            [/modify_unit]
-            {VARIABLE party_members[2].id elf_merc}
-            [message]
-                speaker=elf_merc
-                message=_"I won't let you down. Unless I lose faith that we'll ever get to loot their main temple, haha."
-            [/message]
-        [/command]
-        [/option]
-        [option]
-        message= _ "I usually don't mind mercenaries, but this one is a bit too much a hired killer."
-        [command]
-            [message]
-                speaker=Rimaru
-                message=_"I agree."
-            [/message]
-            [message]
-                speaker=elf_merc
-                message=_"Consider the possibility that I might be later hired by the Brothers of Light. They're known for hiring mercenaries if they need protection. They would pay less than your game, but if I can't join you..."
-            [/message]
-        [/command]
-        [/option]
-    [/message]
-    [message]
-        speaker=Rimaru
-        message=_"Fine. Now I have somebody to fight with when we leave this tavern. Their hired fighters will attack us, I expect. Come on!"
-    [/message]
-    {VARIABLE previous_scenario intro}
+        [message]
+            speaker=Rimaru
+            message=_"Eh, let that be... Hey you, elf, do you want to be hired too?"
+        [/message]
+        [message]
+            speaker=elf_merc
+            message=_"Will I get a share of the booty?"
+        [/message]
+        [message]
+            speaker=Rimaru
+            message=_"Yes."
+        [/message]
+        [message]
+            speaker=elf_merc
+            message=_"I want a third of all the loot."
+        [/message]
+        [message]
+            speaker=Rimaru
+            message=_"We will have more allies when we finish, your share will depend on the quantity of allies we'll get, okay?"
+        [/message]
+        [message]
+            speaker=elf_merc
+            message=_"Yes."
+        [/message]
+        [message]
+            speaker=Rimaru
+            message=_"You're surprising me how much of a mercenary you are. Do you even care about our goal?"
+        [/message]
+        [message]
+            speaker=elf_merc
+            message=_"It is not my religion. Brothers of Light are out of my concern. I fight for the one who pays more. As long as it does not look like a suicide, if I died, I would have no use for the money."
+        [/message]
+        [message]
+            speaker=Rimaru
+            message=_"What a damned sellsword you are. Shall we let her join us? I am afraid of her somehow."
+            [option]
+                message= _ "We need everyone willing to fight for us."
+                [command]
+                    [message]
+                        speaker=Rimaru
+                        message=_"Well, I can't say that I like her, but you're right, we need allies."
+                    [/message]
+                    [modify_unit]
+                        [filter]
+                            id=elf_merc
+                        [/filter]
+                        side=1
+                        canrecruit=yes
+                    [/modify_unit]
+                    {VARIABLE party_members[2].id elf_merc}
+                    [message]
+                        speaker=elf_merc
+                        message=_"I won't let you down. Unless I lose faith that we'll ever get to loot their main temple, haha."
+                    [/message]
+                [/command]
+            [/option]
+            [option]
+                message= _ "I usually don't mind mercenaries, but this one is a bit too much a hired killer."
+                [command]
+                    [message]
+                        speaker=Rimaru
+                        message=_"I agree."
+                    [/message]
+                    [message]
+                        speaker=elf_merc
+                        message=_"Consider the possibility that I might be later hired by the Brothers of Light. They're known for hiring mercenaries if they need protection. They would pay less than your game, but if I can't join you..."
+                    [/message]
+                [/command]
+            [/option]
+        [/message]
+        [message]
+            speaker=Rimaru
+            message=_"Fine. Now I have somebody to fight with when we leave this tavern. Their hired fighters will attack us, I expect. Come on!"
+        [/message]
+        {VARIABLE previous_scenario intro}
         [endlevel]
             result=victory
             bonus=no

--- a/spinoffs/The_Beautiful_Child/scenarios/00_Intro.cfg
+++ b/spinoffs/The_Beautiful_Child/scenarios/00_Intro.cfg
@@ -580,14 +580,14 @@
             {LEGACY_MESSAGE_OPTIONS legacy} # This one is defined in LotI, but it's just for this case - so that adding legacies would not require updating this campaign
         [/message]
         [set_variables]
-            name=player_store.modifications.advance[$player_store.modifications.advance.length]
+            name=player_store.modifications.advancement[$player_store.modifications.advancement.length]
             mode=replace
             [value]
                 id=$legacy
             [/value]
         [/set_variables]
         [set_variables]
-            name=player_store.modifications.advance[$player_store.modifications.advance.length]
+            name=player_store.modifications.advancement[$player_store.modifications.advancement.length]
             mode=replace
             [value]
                 id=awareness

--- a/spinoffs/The_Beautiful_Child/scenarios/00_Intro.cfg
+++ b/spinoffs/The_Beautiful_Child/scenarios/00_Intro.cfg
@@ -228,7 +228,6 @@
             speaker=Rimaru
             message=_"You're working all day, the noblemen take a half of your crops for themselves, the rest can barely feed the family and you buy beer for anything that remains. The drunken state is all the good you have in your life. Unless your wife is beautiful but the amount of work peasant women have to do is too damn high and they aren't beautiful. What god would allow that?"
         [/message]
-#ifdef ADDDADADASDAAADASDASDAD
         [message]
             speaker=guy_1
             message=_"Well, there must be a reason for it."
@@ -545,7 +544,6 @@
             variable=brothers_store
             kill=yes
         [/store_unit]
-#endif
         [message]
             speaker=Rimaru
             message=_"Do you like the Brothers of Larceny?"

--- a/spinoffs/The_Beautiful_Child/scenarios/00_Intro.cfg
+++ b/spinoffs/The_Beautiful_Child/scenarios/00_Intro.cfg
@@ -228,6 +228,7 @@
             speaker=Rimaru
             message=_"You're working all day, the noblemen take a half of your crops for themselves, the rest can barely feed the family and you buy beer for anything that remains. The drunken state is all the good you have in your life. Unless your wife is beautiful but the amount of work peasant women have to do is too damn high and they aren't beautiful. What god would allow that?"
         [/message]
+#ifdef ADDDADADASDAAADASDASDAD
         [message]
             speaker=guy_1
             message=_"Well, there must be a reason for it."
@@ -544,6 +545,7 @@
             variable=brothers_store
             kill=yes
         [/store_unit]
+#endif
         [message]
             speaker=Rimaru
             message=_"Do you like the Brothers of Larceny?"
@@ -586,17 +588,16 @@
                 id=$legacy
             [/value]
         [/set_variables]
-        [set_variables]
-            name=player_store.modifications.advancement[$player_store.modifications.advancement.length]
-            mode=replace
-            [value]
-                id=awareness
-            [/value]
-        [/set_variables]
         [unstore_unit]
             variable=player_store
             find_vacant=no
         [/unstore_unit]
+        [modify_unit]
+            [filter]
+                id=player
+            [/filter]
+            {LEGACY_DISCOVERY $legacy}
+        [/modify_unit]
         {CLEAR_VARIABLE players_store,legacy}
         [message]
             speaker=Rimaru

--- a/spinoffs/The_Beautiful_Child/scenarios/04_Marching_into_War.cfg
+++ b/spinoffs/The_Beautiful_Child/scenarios/04_Marching_into_War.cfg
@@ -66,7 +66,7 @@
     village_gold=3
     recruit=Swordsman,Pikeman,Javelineer,Longbowman,Dragoon,Shock Trooper
     [modifications]
-        [advance]
+        [advancement]
             id=warrior_instead_of_mage
             [effect]
                 apply_to=attack
@@ -86,7 +86,7 @@
                     {ABILITY_CURES}
                 [/abilities]
             [/effect]
-        [/advance]
+        [/advancement]
     [/modifications]
     [ai]
         aggression=1.0

--- a/spinoffs/The_Beautiful_Child/scenarios/05_Coming_of_the_Tide.cfg
+++ b/spinoffs/The_Beautiful_Child/scenarios/05_Coming_of_the_Tide.cfg
@@ -122,13 +122,13 @@
         name= _"Konrad II"
         canrecruit=yes
         [modifications]
-            [advance]
+            [advancement]
                 id=portrait
                 [effect]
                     apply_to=profile
                     portrait="portraits/humans/transparent/fencer.png"
                 [/effect]
-            [/advance]
+            [/advancement]
         [/modifications]
     [/unit]
     [teleport]

--- a/spinoffs/The_Beautiful_Child/scenarios/07_Siege_of_Ziggurat.cfg
+++ b/spinoffs/The_Beautiful_Child/scenarios/07_Siege_of_Ziggurat.cfg
@@ -30,13 +30,13 @@
     name= _"Konrad II"
     canrecruit=yes
     [modifications]
-        [advance]
+        [advancement]
             id=portrait
             [effect]
                 apply_to=profile
                 portrait="portraits/humans/transparent/fencer.png"
             [/effect]
-        [/advance]
+        [/advancement]
     [/modifications]
         side=2
         team_name=good

--- a/spinoffs/The_Beautiful_Child/scenarios/08_Bringing_the_Light.cfg
+++ b/spinoffs/The_Beautiful_Child/scenarios/08_Bringing_the_Light.cfg
@@ -34,7 +34,13 @@
         recruit=Royal Guard,Halberdier,Iron Mauler,Master Bowman,Cavalier
         [ai]
             aggression=1
+            [avoid]   # stay off tops of stairs, probably redundant since side turn event still necessary
+                x=28,37,33,45
+                y=38,21,22,13
+            [/avoid]
         [/ai]
+        shroud=yes
+        fog=yes
     [/side]
     [side]
         no_leader=yes
@@ -228,6 +234,19 @@
             [/then]
         [/if]
     [/event]
+    [event]  # Units can get spawned on top of stairway
+        name=side turn end
+        id=get_off_stairs_{X2}_{Y2}
+        side=2,3
+        first_time_only=no
+        [move_unit]
+            side=2,3
+            x={X2}
+            y={Y2}
+            dir=n,n
+        [/move_unit]
+    [/event]
+
 #enddef
 
     {STAIRS 1-21,27-39 18 28 28 38 room2}
@@ -850,14 +869,13 @@
         [/message]
         [message]
             speaker=third_bringer
-            message=_"We will stay here both. These are the same warriors as those who murdered Luke. Luke was more powerful than we are, so neither of us can handle them alone."
+            message=_"We will both stay here. These are the same warriors as those who murdered Luke. Luke was more powerful than we are, so neither of us can handle them alone."
         [/message]
         [message]
             speaker=second_bringer
             message=_"That is right. Either we both defeat them, or we both die."
         [/message]
     [/event]
-
     [event]
         name=last breath
         [filter]

--- a/spinoffs/The_Beautiful_Child/scenarios/Burkes_Castle.cfg
+++ b/spinoffs/The_Beautiful_Child/scenarios/Burkes_Castle.cfg
@@ -183,13 +183,13 @@
                     random_traits=yes
                     canrecruit=yes
                     [modifications]
-                        [advance]
+                        [advancement]
                             id=portrait
                             [effect]
                                 apply_to=profile
                                 portrait="portraits/humans/transparent/duelist.png"
                             [/effect]
-                        [/advance]
+                        [/advancement]
                     [/modifications]
                 [/unit]
 

--- a/spinoffs/The_Beautiful_Child/scenarios/Crooked_Ravine.cfg
+++ b/spinoffs/The_Beautiful_Child/scenarios/Crooked_Ravine.cfg
@@ -91,100 +91,109 @@
                         speaker=brother_1
                         message=_"So here you are. The rebels. The ridiculous little rebellion."
                     [/message]
+                    [if]
+                        [variable]
+                            name=quests.ravine_brothers_met
+                            equals=yes
+                        [/variable]
+                        [else]
+                            [message]
+                                speaker=Rimaru
+                                message=_"So here you are. Brothers of Light. You started all of this trouble. Now, prepare to pay."
+                                [option]
+                                    message=_"Calm yourself, Rimaru, you were the peaceful man here."
+                                    [command]
+                                        [message]
+                                            speaker=Rimaru
+                                            message=_"These men are warmongers! But well, I am only angry, I am not bloodthirsty. Don't worry, I'll be merciful when it comes to combat. That is quite inevitable."
+                                        [/message]
+                                        [message]
+                                            speaker=bandit_merc
+                                            message=_"Skin them alive!"
+                                        [/message]
+                                        {TBC_DIPLOMACY_TRIED}
+                                    [/command]
+                                [/option]
+                                [option]
+                                    message=_"You caused all this war, you <i>pyjama wearers</i>, and you deserve punishment for it."
+                                    [command]
+                                        [message]
+                                            speaker=elf_merc
+                                            message=_"Or payment, I will get money thanks to their scheme..."
+                                        [/message]
+                                    [/command]
+                                [/option]
+                                [option]
+                                    message=_"We will beat impale you on sticks, skin you alive and boil you to death afterwards!"
+                                    [command]
+                                        [message]
+                                            speaker=Rimaru
+                                            message=_"I did not mean to do such horrible things to them. I do not need to kill the people I hate, I kill only if it becomes necessary."
+                                        [/message]
+                                    [/command]
+                                [/option]
+                            [/message]
+                            [message]
+                                speaker=she_brother
+                                message=_"That won't help you much. We have already contacted baron Burke and he's ready to send an army to kill you all. And wipe your pathetic Farborough from existence."
+                            [/message]
+                            [message]
+                                speaker=faithful_lieutenant
+                                message=_"Burke's army is not so huge, we might deal with them with enough support of the villagers. But it won't be possible without casualties."
+                            [/message]
+                            [message]
+                                speaker=Rimaru
+                                message=_"I think that I will take you captive to make sure that you won't do more harm. And maybe it will help fix you overly callous ways of thinking and undo the harms that brainwashing has done on you."
+                            [/message]
+                            [message]
+                                speaker=brother_2
+                                message=_"Rimaru, I think that your problem with us is personal. It is not about this increase in tithes, but it is your old pain."
+                            [/message]
+                            [message]
+                                speaker=she_brother
+                                message=_"What old pain?"
+                            [/message]
+                            [message]
+                                speaker=Rimaru
+                                message=_"It is an old affair. I may be a grumpy man in my thirties, but I was not like that before. I was a young, aspirant Brother of Light, excelling at healing. I had a little sister named Sicaria to care about after my parents died. I loved her, I cared about her as much as I could, she was also close to becoming a member. We loved each other, because we had no one else."
+                            [/message]
+                            [message]
+                                speaker=Rimaru
+                                message=_"But then, she got sick. I was trying to heal her, but the disease was too strong. I don't know what disease it was, or if it really was a disease. My cures did not help her to recover, only to slow down its progress. I asked my superiors to help her, to call somebody better at healing, but they told me that I am a very good healer and assigned the task to heal her to me. The best healer himself made that decision. He made much greater miracles in the past, yet..."
+                            [/message]
+                            [message]
+                                speaker=Rimaru
+                                message=_"He was too lazy to heal her, or it did not fit into his scheme. I could not ask regular Brothers to help me, because their skills were inferior to mine. I struggled for a week, but then she was gone. They probably feared that my brotherly love for her would have brought me to a necromancer who can save even the dead in his own dark way, so they took her to a morgue where I could not go. I haven't even seen her burial, not even her grave."
+                            [/message]
+                            [message]
+                                speaker=Rimaru
+                                message=_"I have a feeling that there was something darker behind her illness. I had a feeling that my superiors thought that I loved my sister a bit too much and I put her needs above my duties. They were right, I missed many pathetic events of the community because my little sister needed somebody to hold her hand while she falls asleep. I was teaching her some white magic too. It was just an excuse so that I could miss these boring meetings."
+                            [/message]
+                            [message]
+                                speaker=she_brother
+                                message=_"Stop accusing us of such things. Our order would never have done something so heinous!"
+                            [/message]
+                            [message]
+                                speaker=Rimaru
+                                message=_"The low-ranking members hardly know what schemes their superiors are working on."
+                            [/message]
+                            [message]
+                                speaker=brother_1
+                                message=_"I wasn't aware of that story. I never knew why you had left our order. I thought you were forced to leave because of your poisonous talks. But it seems that you became as grumpy as you are now after being removed. We are sorry for the thing that happened to your sister, but that does not excuse your recent actions."
+                            [/message]
+                            [message]
+                                speaker=Rimaru
+                                message=_"It merely opened my eyes so that I could see through your shallow plots and understand your real intentions. It was money. A lot of money. Hoarding them. Embracing them. Swimming in golden coins."
+                            [/message]
+                            [message]
+                                speaker=brother_1
+                                message=_"You have gone way too far, Rimaru. For dregs like you, there is only one possible solution. Death. Kill them!"
+                            [/message]
+                            {VARIABLE quests.ravine_brothers_met yes}
+                        [/else]
+                    [/if]
                     [message]
-                        speaker=Rimaru
-                        message=_"So here you are. Brothers of Light. You started all of this trouble. Now, prepare to pay."
-                        [option]
-                            message=_"Calm yourself, Rimaru, you were the peaceful man here."
-                            [command]
-                                [message]
-                                    speaker=Rimaru
-                                    message=_"These men are warmongers! But well, I am only angry, I am not bloodthirsty. Don't worry, I'll be merciful when it comes to combat. That is quite inevitable."
-                                [/message]
-                                [message]
-                                    speaker=bandit_merc
-                                    message=_"Skin them alive!"
-                                [/message]
-                                {TBC_DIPLOMACY_TRIED}
-                            [/command]
-                        [/option]
-                        [option]
-                            message=_"You caused all this war, you <i>pyjama wearers</i>, and you deserve punishment for it."
-                            [command]
-                                [message]
-                                    speaker=elf_merc
-                                    message=_"Or payment, I will get money thanks to their scheme..."
-                                [/message]
-                            [/command]
-                        [/option]
-                        [option]
-                            message=_"We will beat impale you on sticks, skin you alive and boil you to death afterwards!"
-                            [command]
-                                [message]
-                                    speaker=Rimaru
-                                    message=_"I did not mean to do such horrible things to them. I do not need to kill the people I hate, I kill only if it becomes necessary."
-                                [/message]
-                            [/command]
-                        [/option]
-                    [/message]
-                    [message]
-                        speaker=she_brother
-                        message=_"That won't help you much. We have already contacted baron Burke and he's ready to send an army to kill you all. And wipe your pathetic Farborough from existence."
-                    [/message]
-                    [message]
-                        speaker=faithful_lieutenant
-                        message=_"Burke's army is not so huge, we might deal with them with enough support of the villagers. But it won't be possible without casualties."
-                    [/message]
-                    [message]
-                        speaker=Rimaru
-                        message=_"I think that I will take you captive to make sure that you won't do more harm. And maybe it will help fix you overly callous ways of thinking and undo the harms that brainwashing has done on you."
-                    [/message]
-                    [message]
-                        speaker=brother_2
-                        message=_"Rimaru, I think that your problem with us is personal. It is not about this increase in tithes, but it is your old pain."
-                    [/message]
-                    [message]
-                        speaker=she_brother
-                        message=_"What old pain?"
-                    [/message]
-                    [message]
-                        speaker=Rimaru
-                        message=_"It is an old affair. I may be a grumpy man in my thirties, but I was not like that before. I was a young, aspirant Brother of Light, excelling at healing. I had a little sister named Sicaria to care about after my parents died. I loved her, I cared about her as much as I could, she was also close to becoming a member. We loved each other, because we had no one else."
-                    [/message]
-                    [message]
-                        speaker=Rimaru
-                        message=_"But then, she got sick. I was trying to heal her, but the disease was too strong. I don't know what disease it was, or if it really was a disease. My cures did not help her to recover, only to slow down its progress. I asked my superiors to help her, to call somebody better at healing, but they told me that I am a very good healer and assigned the task to heal her to me. The best healer himself made that decision. He made much greater miracles in the past, yet..."
-                    [/message]
-                    [message]
-                        speaker=Rimaru
-                        message=_"He was too lazy to heal her, or it did not fit into his scheme. I could not ask regular Brothers to help me, because their skills were inferior to mine. I struggled for a week, but then she was gone. They probably feared that my brotherly love for her would have brought me to a necromancer who can save even the dead in his own dark way, so they took her to a morgue where I could not go. I haven't even seen her burial, not even her grave."
-                    [/message]
-                    [message]
-                        speaker=Rimaru
-                        message=_"I have a feeling that there was something darker behind her illness. I had a feeling that my superiors thought that I loved my sister a bit too much and I put her needs above my duties. They were right, I missed many pathetic events of the community because my little sister needed somebody to hold her hand while she falls asleep. I was teaching her some white magic too. It was just an excuse so that I could miss these boring meetings."
-                    [/message]
-                    [message]
-                        speaker=she_brother
-                        message=_"Stop accusing us of such things. Our order would never have done something so heinous!"
-                    [/message]
-                    [message]
-                        speaker=Rimaru
-                        message=_"The low-ranking members hardly know what schemes their superiors are working on."
-                    [/message]
-                    [message]
-                        speaker=brother_1
-                        message=_"I wasn't aware of that story. I never knew why you had left our order. I thought you were forced to leave because of your poisonous talks. But it seems that you became as grumpy as you are now after being removed. We are sorry for the thing that happened to your sister, but that does not excuse your recent actions."
-                    [/message]
-                    [message]
-                        speaker=Rimaru
-                        message=_"It merely opened my eyes so that I could see through your shallow plots and understand your real intentions. It was money. A lot of money. Hoarding them. Embracing them. Swimming in golden coins."
-                    [/message]
-                    [message]
-                        speaker=brother_1
-                        message=_"You have gone way too far, Rimaru. For dregs like you, there is only one possible solution. Death. Kill them!"
-                    [/message]
-                    [message]
-                        speaker=bandit_merc
+                        speaker=player
                         message=_"Leave no one alive!"
                     [/message]
                     [event]
@@ -448,7 +457,7 @@
 
         [if]
             [variable]
-                name=quests.seen_ravine_camp
+                name=quests.ravine_seen_camp
                 equals=yes
             [/variable]
             [else]
@@ -470,7 +479,7 @@
                         speaker=bandit_merc
                         message=_"Yes, it is a common trick to let the victims investigate some place or camp there for the night. It will let you attack them unexpectedly and in a place you know very well."
                     [/message]
-                    {VARIABLE quests.seen_ravine_camp yes}
+                    {VARIABLE quests.ravine_seen_camp yes}
                 [/event]
             [/else]
         [/if]
@@ -947,7 +956,7 @@
                 [/command]
             [/option]
             [option]
-                message=_"I do not trust her. She has always been hateful to us and this conversion has been to sudden."
+                message=_"I do not trust her. She has always been hateful to us and this conversion has been too sudden."
                 [command]
                     [message]
                         speaker=she_brother
@@ -955,11 +964,25 @@
                     [/message]
                     [message]
                         speaker=Rimaru
-                        message=_"I think that your explanation is insufficient. You can't risk having you with us and otherwise you would continue fighting us. I am sorry, but I am trying to achieve something."
+                        message=_"I think that your explanation is insufficient. We can't risk having you with us and otherwise you would continue fighting us. I am sorry, but I am trying to achieve something."
                     [/message]
                 [/command]
             [/option]
         [/message]
+        [for]
+            array=brothers_store
+            [do]
+                [if]
+                    [variable]
+                        name=brothers_store[$i].id
+                        equals="she_brother"
+                    [/variable]
+                    [then]
+                        {CLEAR_VARIABLE brothers_store[$i]}
+                    [/then]
+                [/if]
+            [/do]
+        [/for]
         [fire_event]
             name=brothers_dead_check
         [/fire_event]

--- a/spinoffs/The_Beautiful_Child/scenarios/Faithdome.cfg
+++ b/spinoffs/The_Beautiful_Child/scenarios/Faithdome.cfg
@@ -1430,7 +1430,7 @@
                             kill=yes
                         [/store_unit]
                         [set_variables]
-                            name=sicaria_store.modifications.advance[$sicaria_store.modifications.advance]
+                            name=sicaria_store.modifications.advancement[$sicaria_store.modifications.advancement.length]
                             mode=replace
                             [value]
                                 id=sicarias_ring
@@ -1479,7 +1479,7 @@
                                 hero=yes
                             [/variables]
                             [insert_tag]
-                                name=advance
+                                name=advancement
                                 variable=sicaria_store.modifications
                             [/insert_tag]
                             animate=no

--- a/spinoffs/The_Beautiful_Child/scenarios/Faithdome.cfg
+++ b/spinoffs/The_Beautiful_Child/scenarios/Faithdome.cfg
@@ -83,14 +83,14 @@
                             name= _"Konrad II"
                             canrecruit=yes
                             [modifications]
-                                [advance]
+                                [advancement]
                                     id=portrait
                                     [effect]
                                         apply_to=profile
                                         portrait="portraits/humans/transparent/fencer.png"
                                     [/effect]
                                 [/advance]
-                            [/modifications]
+                            [/modificationsment]
                         [/unit]
                     [/then]
                 [/if]
@@ -172,13 +172,13 @@
                     canrecruit=yes
                     random_traits=yes
                     [modifications]
-                        [advance]
+                        [advancement]
                             id=portrait
                             [effect]
                                 apply_to=profile
                                 portrait="portraits/humans/transparent/heavy-infantry.png"
                             [/effect]
-                        [/advance]
+                        [/advancement]
                         {TRAIT_INTELLIGENT}
                     [/modifications]
                     [variables]
@@ -763,13 +763,13 @@
                         type=Royal Warrior
                         canrecruit=yes
                         [modifications]
-                            [advance]
+                            [advancement]
                                 id=portrait
                                 [effect]
                                     apply_to=profile
                                     portrait="portraits/humans/transparent/marshal-2.png"
                                 [/effect]
-                            [/advance]
+                            [/advancement]
                         [/modifications]
                     [/unit]
                     [unit]
@@ -780,13 +780,13 @@
                         name= _"Konrad II"
                         canrecruit=yes
                         [modifications]
-                            [advance]
+                            [advancement]
                                 id=portrait
                                 [effect]
                                     apply_to=profile
                                     portrait="portraits/humans/transparent/fencer.png"
                                 [/effect]
-                            [/advance]
+                            [/advancement]
                         [/modifications]
                     [/unit]
                     [move_unit]
@@ -1277,19 +1277,19 @@
                             name= _"Sicaria"
                             canrecruit=yes
                             [modifications]
-                                [advance]
+                                [advancement]
                                     id=portrait
                                     [effect]
                                         apply_to=profile
                                         portrait="portraits/humans/transparent/assassin+female.png"
                                     [/effect]
-                                [/advance]
-                                [advance]
+                                [/advancement]
+                                [advancement]
                                     id=legacy_of_sorrow
-                                [/advance]
-                                [advance]
+                                [/advancement]
+                                [advancement]
                                     id=awareness
-                                [/advance]
+                                [/advancement]
                             [/modifications]
                             animate=yes
                         [/unit]

--- a/spinoffs/The_Beautiful_Child/scenarios/Farborough.cfg
+++ b/spinoffs/The_Beautiful_Child/scenarios/Farborough.cfg
@@ -104,13 +104,13 @@
                     random_traits=yes
                     upkeep=full
                     [modifications]
-                        [advance]
+                        [advancement]
                             id=portrait
                             [effect]
                                 apply_to=profile
                                 portrait="portraits/humans/transparent/lieutenant.png"
                             [/effect]
-                        [/advance]
+                        [/advancement]
                     [/modifications]
                 [/unit]
             [/else]
@@ -544,13 +544,13 @@
                         random_traits=yes
                         upkeep=full
                         [modifications]
-                            [advance]
+                            [advancement]
                                 id=portrait
                                 [effect]
                                     apply_to=profile
                                     portrait="portraits/humans/transparent/outlaw.png"
                                 [/effect]
-                            [/advance]
+                            [/advancement]
                         [/modifications]
                     [/unit]
                     {TBC_SPAWN_UNITS_NO_LEADER 4 0.8 "Thug,Footpad,Poacher,Thief" 23 8}

--- a/spinoffs/The_Beautiful_Child/scenarios/Fertile_Lands.cfg
+++ b/spinoffs/The_Beautiful_Child/scenarios/Fertile_Lands.cfg
@@ -29,1024 +29,1023 @@
         side=2
         team_name=twisted_good
         user_team_name=_"Twisted Good"
-    [ai]
-        aggression=1.0
-        grouping=no
-    [/ai]
+        [ai]
+            aggression=1.0
+            grouping=no
+        [/ai]
     [/side]
 
     {TBC_PLACE_WAYPOINT 22 22}
 
     [event]
-    name=prestart
-    {CLEAR_RECALLS}
-    {VARIABLE current_scenario fertile_lands}
-    {TBC_ORIGIN thunderhold 13 3}
-    {TBC_ORIGIN faithdome 19 45}
-    {TBC_ORIGIN coming_of_the_tide 13 4}
-    {TBC_TRANSITION 1-33 1-2 Thunderhold _"Thunderhold" 13 1}
-    [if]
-        [variable]
-            name=quests.overall
-            greater_than=9
-        [/variable]
-        [then]
-            {TBC_TRANSITION 1-33 45-46 Faithdome _"Faithdome" 19 45}
-        [/then]
-        [else]
-            [event]
-                name=moveto
-                [filter]
-                    side=1
-                    x,y=1-33,45-46
-                [/filter]
-                [message]
-                    speaker=Burke
-                    message=_"The last thing we need is to attack Faithdome when it's well guarded."
-                [/message]
-            [/event]
-            [event]
-                name=moveto
-                [filter]
-                    side=1
-                    x,y=6,37
-                [/filter]
-                [unit]
-                    side=1
-                    x,y=6,37
-                    type=Master at Arms
-                    id=Konrad_II
-                    name= _"Konrad II"
-                    canrecruit=yes
-                    [variables]
-                        hero=yes
-                    [/variables]
-                    [modifications]
-                        [advancement]
-                            id=portrait
-                            [effect]
-                                apply_to=profile
-                                portrait="portraits/humans/transparent/fencer.png"
-                            [/effect]
-                        [/advancement]
-                    [/modifications]
-                    {VARIABLE party_members[$party_members.length].id "Konrad II"}
-                [/unit]
-                [message]
-                    speaker=Konrad_II
-                    message=_"You saved me! I don't know who you are, but thank you from saving me from that stinking dungeon."
-                    [option]
-                    message=_"We were sent by your father. He needed you in safety before he starts an open confrontations with the Brothers of Light."
-                    [command]
-                        [message]
-                            speaker=Konrad_II
-                            message=_"I told him that the Brothers of Light were a leecherous band of liars pretending to spread good. It seems that he understood it now."
-                        [/message]
-                    [/command]
-                    [/option]
-                    [option]
-                    message=_"You will come with us."
-                    [command]
-                        [message]
-                            speaker=Konrad_II
-                            message=_"Are you friends or foes?"
-                        [/message]
-                        [message]
-                            speaker=Rimaru
-                            message=_"Friends, don't scare him, there is no need for that."
-                        [/message]
-                        [message]
-                            speaker=player
-                            message=_"Sorry. But I am in a scaring mood after trying to get the information about his location from these soldiers."
-                        [/message]
-                        [message]
-                            speaker=Rimaru
-                            message=_"We are taking you to your father, Konrad."
-                        [/message]
-                    [/command]
-                    [/option]
-                    [option]
-                    message=_"We are disguised orcs, plundering this area. We needed to get you out of the dungeon so that we could kill you."
-                    [show_if]
-                        [have_unit]
-                            id=orc
-                        [/have_unit]
-                    [/show_if]
-                    [command]
-                        [message]
-                            speaker=Konrad_II
-                            message=_"Nooooooooo!"
-                        [/message]
-                        [message]
-                            speaker=orc
-                            message=_"I will enjoy it... Human spleen is so tasty... juicy..."
-                        [/message]
-                        [message]
-                            speaker=elf_merc
-                            message=_"Don't you think that we have scared him enough?"
-                        [/message]
-                        [message]
-                            speaker=Rimaru
-                            message=_"He was joking. We are taking you to your father."
-                        [/message]
-                    [/command]
-                    [/option]
-                [/message]
-                [message]
-                    speaker=Burke
-                    message=_"To keep you informed, we are starting an uprising against the Brothers of Light. They're driven by pride, lust for power and greed. Your father is a member of our alliance. Our future plans are to be discussed."
-                [/message]
-                [message]
-                    speaker=Konrad_II
-                    message=_"Thank you for rescuing me. I will follow you to my father."
-                [/message]
-                {VARIABLE quests.overall 8}
-            [/event]
-        [/else]
-    [/if]
+        name=prestart
+        {CLEAR_RECALLS}
+        {VARIABLE current_scenario fertile_lands}
+        {TBC_ORIGIN thunderhold 13 3}
+        {TBC_ORIGIN faithdome 19 45}
+        {TBC_ORIGIN coming_of_the_tide 13 4}
+        {TBC_TRANSITION 1-33 1-2 Thunderhold _"Thunderhold" 13 1}
+        [if]
+            [variable]
+                name=quests.overall
+                greater_than=9
+            [/variable]
+            [then]
+                {TBC_TRANSITION 1-33 45-46 Faithdome _"Faithdome" 19 45}
+            [/then]
+            [else]
+                [event]
+                    name=moveto
+                    [filter]
+                        side=1
+                        x,y=1-33,45-46
+                    [/filter]
+                    [message]
+                        speaker=Burke
+                        message=_"The last thing we need is to attack Faithdome when it's well guarded."
+                    [/message]
+                [/event]
+                [event]
+                    name=moveto
+                    [filter]
+                        side=1
+                        x,y=6,37
+                    [/filter]
+                    [unit]
+                        side=1
+                        x,y=6,37
+                        type=Master at Arms
+                        id=Konrad_II
+                        name= _"Konrad II"
+                        canrecruit=yes
+                        [variables]
+                            hero=yes
+                        [/variables]
+                        [modifications]
+                            [advancement]
+                                id=portrait
+                                [effect]
+                                    apply_to=profile
+                                    portrait="portraits/humans/transparent/fencer.png"
+                                [/effect]
+                            [/advancement]
+                        [/modifications]
+                    [/unit]
+                    {VARIABLE party_members[$party_members.length].id "Konrad_II"}
+                    [message]
+                        speaker=Konrad_II
+                        message=_"You saved me! I don't know who you are, but thank you from saving me from that stinking dungeon."
+                        [option]
+                            message=_"We were sent by your father. He needed you in safety before he starts an open confrontations with the Brothers of Light."
+                            [command]
+                                [message]
+                                    speaker=Konrad_II
+                                    message=_"I told him that the Brothers of Light were a leecherous band of liars pretending to spread good. It seems that he understood it now."
+                                [/message]
+                            [/command]
+                        [/option]
+                        [option]
+                            message=_"You will come with us."
+                            [command]
+                                [message]
+                                    speaker=Konrad_II
+                                    message=_"Are you friends or foes?"
+                                [/message]
+                                [message]
+                                    speaker=Rimaru
+                                    message=_"Friends, don't scare him, there is no need for that."
+                                [/message]
+                                [message]
+                                    speaker=player
+                                    message=_"Sorry. But I am in a scaring mood after trying to get the information about his location from these soldiers."
+                                [/message]
+                                [message]
+                                    speaker=Rimaru
+                                    message=_"We are taking you to your father, Konrad."
+                                [/message]
+                            [/command]
+                        [/option]
+                        [option]
+                            message=_"We are disguised orcs, plundering this area. We needed to get you out of the dungeon so that we could kill you."
+                            [show_if]
+                                [have_unit]
+                                    id=orc
+                                [/have_unit]
+                            [/show_if]
+                            [command]
+                                [message]
+                                    speaker=Konrad_II
+                                    message=_"Nooooooooo!"
+                                [/message]
+                                [message]
+                                    speaker=orc
+                                    message=_"I will enjoy it... Human spleen is so tasty... juicy..."
+                                [/message]
+                                [message]
+                                    speaker=elf_merc
+                                    message=_"Don't you think that we have scared him enough?"
+                                [/message]
+                                [message]
+                                    speaker=Rimaru
+                                    message=_"He was joking. We are taking you to your father."
+                                [/message]
+                            [/command]
+                        [/option]
+                    [/message]
+                    [message]
+                        speaker=Burke
+                        message=_"To keep you informed, we are starting an uprising against the Brothers of Light. They're driven by pride, lust for power and greed. Your father is a member of our alliance. Our future plans are to be discussed."
+                    [/message]
+                    [message]
+                        speaker=Konrad_II
+                        message=_"Thank you for rescuing me. I will follow you to my father."
+                    [/message]
+                    {VARIABLE quests.overall 8}
+                [/event]
+            [/else]
+        [/if]
 #define PICK_SPAWN
 #ifdef EASY
-{VARIABLE_OP unit_type rand "Swordsman,Spearman,Javelineer,Pikeman,Duelist,Fencer,Lieutenant,General,Cavalryman,Red Mage,White Mage"}
+    {VARIABLE_OP unit_type rand "Swordsman,Spearman,Javelineer,Pikeman,Duelist,Fencer,Lieutenant,General,Cavalryman,Red Mage,White Mage"}
 #endif
 #ifdef NORMAL
-{VARIABLE_OP unit_type rand "Swordsman,Spearman,Javelineer,Pikeman,Halberdier,Duelist,Fencer,Lieutenant,General,Horseman,Red Mage,White Mage"}
+    {VARIABLE_OP unit_type rand "Swordsman,Spearman,Javelineer,Pikeman,Halberdier,Duelist,Fencer,Lieutenant,General,Horseman,Red Mage,White Mage"}
 #endif
 #ifdef HARD
-{VARIABLE_OP unit_type rand "Swordsman,Spearman,Javelineer,Pikeman,Halberdier,Duelist,Master at Arms,Fencer,Royal Guard,Lieutenant,General,Horseman,Dragoon,Red Mage,White Mage"}
+    {VARIABLE_OP unit_type rand "Swordsman,Spearman,Javelineer,Pikeman,Halberdier,Duelist,Master at Arms,Fencer,Royal Guard,Lieutenant,General,Horseman,Dragoon,Red Mage,White Mage"}
 #endif
 #enddef
-    [if]
-        [variable]
-            name=quests.overall
-            equals=10
-        [/variable]
-        [not]
-            [have_unit]
-                side=1
-                y=38-46
-            [/have_unit]
-        [/not]
-        [then]
-            {VARIABLE quantity $party_members.length}
-            {VARIABLE_OP quantity multiply 3}
-            [while]
-                [variable]
-                    name=quantity
-                    greater_than=0
-                [/variable]
-                [do]
+        [if]
+            [variable]
+                name=quests.overall
+                equals=10
+            [/variable]
+            [not]
+                [have_unit]
+                    side=1
+                    y=38-46
+                [/have_unit]
+            [/not]
+            [then]
+                {VARIABLE quantity $party_members.length}
+                {VARIABLE_OP quantity multiply 3}
+                [while]
+                    [variable]
+                        name=quantity
+                        greater_than=0
+                    [/variable]
+                    [do]
+                        {PICK_SPAWN}
+                        {VARIABLE_OP to_x rand 1..33}
+                        {VARIABLE_OP to_y rand 1..46}
+                        {GENERIC_UNIT 2 $unit_type $to_x $to_y}
+                        {VARIABLE_OP quantity sub 1}
+                    [/do]
+                [/while]
+                {CLEAR_VARIABLE unit_type,quantity,to_x,to_y}
+                [event]
+                    name=new turn
+                    first_time_only=no
                     {PICK_SPAWN}
-                    {VARIABLE_OP to_x rand 1..33}
-                    {VARIABLE_OP to_y rand 1..46}
-                    {GENERIC_UNIT 2 $unit_type $to_x $to_y}
-                    {VARIABLE_OP quantity sub 1}
-                [/do]
-            [/while]
-            {CLEAR_VARIABLE unit_type,quantity,to_x,to_y}
-            [event]
-                name=new turn
-                first_time_only=no
-                {PICK_SPAWN}
-                {GENERIC_UNIT 2 $unit_type 20 46}
-                [move_unit]
-                    side=2
-                    type=$unit_type
-                    x=20
-                    y=46
-                    to_x=20
-                    to_y=45
-                    fire_event=no
-                [/move_unit]
-                {CLEAR_VARIABLE unit_type}
-            [/event]
-            [if]
-                [variable]
-                    name=party_members.length
-                    greater_than=5
-                [/variable]
-                [then]
-                    [event]
-                        name=new turn
-                        first_time_only=no
-                        {PICK_SPAWN}
-                        {GENERIC_UNIT 2 $unit_type 6 46}
-                        [move_unit]
-                            side=2
-                            type=$unit_type
-                            x=6
-                            y=46
-                            to_x=13
-                            to_y=45
-                            fire_event=no
-                        [/move_unit]
-                        {CLEAR_VARIABLE unit_type}
-                    [/event]
-                [/then]
-            [/if]
-            [if]
-                [variable]
-                    name=party_members.length
-                    greater_than=7
-                [/variable]
-                [then]
-                    [event]
-                        name=new turn
-                        first_time_only=no
-                        {PICK_SPAWN}
-                        {GENERIC_UNIT 2 $unit_type 28 46}
-                        [move_unit]
-                            side=2
-                            type=$unit_type
-                            x=28
-                            y=46
-                            to_x=28
-                            to_y=44
-                            fire_event=no
-                        [/move_unit]
-                        {CLEAR_VARIABLE unit_type}
-                    [/event]
-                [/then]
-            [/if]
-            [if]
-                [variable]
-                    name=party_members.length
-                    greater_than=9
-                [/variable]
-                [then]
-                    [event]
-                        name=new turn
-                        first_time_only=no
-                        {PICK_SPAWN}
-                        {GENERIC_UNIT 2 $unit_type 12 46}
-                        [move_unit]
-                            side=2
-                            type=$unit_type
-                            x=12
-                            y=46
-                            to_x=14
-                            to_y=45
-                            fire_event=no
-                        [/move_unit]
-                        {CLEAR_VARIABLE unit_type}
-                    [/event]
-                [/then]
-            [/if]
+                    {GENERIC_UNIT 2 $unit_type 20 46}
+                    [move_unit]
+                        side=2
+                        type=$unit_type
+                        x=20
+                        y=46
+                        to_x=20
+                        to_y=45
+                        fire_event=no
+                    [/move_unit]
+                    {CLEAR_VARIABLE unit_type}
+                [/event]
+                [if]
+                    [variable]
+                        name=party_members.length
+                        greater_than=5
+                    [/variable]
+                    [then]
+                        [event]
+                            name=new turn
+                            first_time_only=no
+                            {PICK_SPAWN}
+                            {GENERIC_UNIT 2 $unit_type 6 46}
+                            [move_unit]
+                                side=2
+                                type=$unit_type
+                                x=6
+                                y=46
+                                to_x=13
+                                to_y=45
+                                fire_event=no
+                            [/move_unit]
+                            {CLEAR_VARIABLE unit_type}
+                        [/event]
+                    [/then]
+                [/if]
+                [if]
+                    [variable]
+                        name=party_members.length
+                        greater_than=7
+                    [/variable]
+                    [then]
+                        [event]
+                            name=new turn
+                            first_time_only=no
+                            {PICK_SPAWN}
+                            {GENERIC_UNIT 2 $unit_type 28 46}
+                            [move_unit]
+                                side=2
+                                type=$unit_type
+                                x=28
+                                y=46
+                                to_x=28
+                                to_y=44
+                                fire_event=no
+                            [/move_unit]
+                            {CLEAR_VARIABLE unit_type}
+                        [/event]
+                    [/then]
+                [/if]
+                [if]
+                    [variable]
+                        name=party_members.length
+                        greater_than=9
+                    [/variable]
+                    [then]
+                        [event]
+                            name=new turn
+                            first_time_only=no
+                            {PICK_SPAWN}
+                            {GENERIC_UNIT 2 $unit_type 12 46}
+                            [move_unit]
+                                side=2
+                                type=$unit_type
+                                x=12
+                                y=46
+                                to_x=14
+                                to_y=45
+                                fire_event=no
+                            [/move_unit]
+                            {CLEAR_VARIABLE unit_type}
+                        [/event]
+                    [/then]
+                [/if]
 #undef PICK_SPAWN
-        [/then]
-    [/if]
+            [/then]
+        [/if]
     [/event]
 
     [event]
-    name=start
-    [if]
-        [variable]
-            name=quests.entered_fertile_lands
-            equals=yes
-        [/variable]
-        [else] 
-            {GENERIC_UNIT 2 "Swordsman" 20 5}
-            [+unit]
-                id=boss_1
-            [/unit]
-            [message]
-                speaker=Rimaru
-                message=_"We are here. In lord Uver's land."
-            [/message]
-            [move_unit]
-                id=boss_1
-                to_x=14
-                to_y=4
-                fire_event=no
-            [/move_unit]
-            [message]
-                speaker=elf_merc
-                message=_"Oh, somebody is coming to greet us. Do you think that he would like to have some arrows in his chest?"
-            [/message]
-            [message]
-                speaker=hired_halberdier
-                message=_"Are they attacking already?"
-            [/message]
-            [message]
-                speaker=boss_1
-                message=_"Who are you?"
-                [option]
-                message=_"We are travellers, travelling from north to south."
-                [command]
-                    [message]
-                        speaker=boss_1
-                        message=_"What are you looking for?"
-                    [/message]
-                    [message]
-                        speaker=elf_merc
-                        message=_"The end of the rainbow..."
-                    [/message]
-                    [message]
-                        speaker=Rimaru
-                        message=_"We only need passage. What's your problem? Is it forbidden to go here?"
-                    [/message]
-                    [message]
-                        speaker=boss_1
-                        message=_"It isn't forbidden. But it's forbidden for armed squads who have no explanations why they're going here."
-                    [/message]
-                    [message]
-                        speaker=Rimaru
-                        message=_"We are on our way to visit my uncle Ronald. He may be known here only as Ron."
-                    [/message]
-                [/command]
-                [/option]
-                [option]
-                message=_"We are going south to fight against the Sand Empire. We are loyal supporters of our beloved king."
-                [command]
-                    [message]
-                        speaker=Rimaru
-                        message=_"You know about the war in the south, do you?"
-                    [/message]
-                    [message]
-                        speaker=boss_1
-                        message=_"You're far away from there. I would not travel there by foot, it would take you months. Furthermore, you don't have much supplies."
-                    [/message]
-                    [message]
-                        speaker=Burke
-                        message=_"We are assembling not far from here to prepare for the massive march south."
-                    [/message]
-                [/command]
-                [/option]
-                [option]
-                message=_"We are going to release Konrad II from illegal captivity by lord Uver."
-                [command]
-                    [message]
-                        speaker=bandit_merc
-                        message=_"Why the hell did you say the that?"
-                    [/message]
-                    [message]
-                        speaker=orc
-                        message=_"You're an idiot!"
-                    [/message]
-                    [message]
-                        speaker=boss_1
-                        message=_"I will not allow that. His capture was a large success of our military forces and we'll not give it up so easily."
-                    [/message]
-                    [message]
-                        speaker=Rimaru
-                        message=_"You can't understand jokes? Do you think that would we ever tell the truth if we were really going to release that boy from prison?"
-                    [/message]
-                    [message]
-                        speaker=boss_1
-                        message=_"You have accidentally told the truth, I can see that."
-                    [/message]
-                    [message]
-                        speaker=orc
-                        message=_"You're an idiot. Even goblins aren't so dumb."
-                    [/message]
-                    [message]
-                        speaker=Burke
-                        message=_"Are you joking or are you really so stupid?"
-                    [/message]
-                [/command]
-                [/option]
-                [option]
-                message=_"We will never tell it to you. You don't need to know it."
-                [command]
-                    [message]
-                        speaker=boss_1
-                        message=_"But I do need to know where are you going. But I understand your reply. You want to do something harmful here. This is your last chance. What do you want to here if it isn't something we would not like you to do?"
-                    [/message]
-                    [message]
-                        speaker=Rimaru
-                        message=_"It's a secret mission under control of lord Uver."
-                    [/message]
-                [/command]
-                [/option]
-                [option]
-                message=_"We are going to kill you and all your allies here and claim this land for us."
-                [command]
-                    [message]
-                        speaker=boss_1
-                        message=_"Now, what is the true intention of your visit? I want no more attempts to scare me off."
-                    [/message]
-                    [message]
-                        speaker=Rimaru
-                        message=_"We're just passing. South. We need to visit lord Carcery's estate."
-                    [/message]
-                    [message]
-                        speaker=boss_1
-                        message=_"Lord Carcery is commanding some divisions in the war against the Sand Empire. If you were visiting him, you'd know that he is gone."
-                    [/message]
-                    [message]
-                        speaker=Burke
-                        message=_"Dammit!"
-                    [/message]
-                [/command]
-                [/option]
-            [/message]
-            [message]
-                speaker=boss_1
-                message=_"One does not need much knowledge of this place to know that your intentions in this land are malicious."
-            [/message]
-            [message]
-                speaker=Burke
-                message=_"I am baron Burke. How does it happen that you dare to call me malicious?"
-            [/message]
-            [message]
-                speaker=boss_1
-                message=_"You are known for descending into blasphemy, Burke. All of your titles were revoked."
-            [/message]
-            [message]
-                speaker=Burke
-                message=_"How does it happen that a weak man alone dares to call a group of well-armed people malicious?"
-            [/message]
-            [message]
-                speaker=boss_1
-                message=_"I am not alone. I have a few soldiers in my keep. They will support me."
-            [/message]
-            [message]
-                speaker=Rimaru
-                message=_"So you shall fall all. You're not giving us any other option but to use force. Now, tell me where lord Konrad's son is or we'll kill you!"
-            [/message]
-            [message]
-                speaker=boss_1
-                message=_"I will not do that."
-            [/message]
-            [message]
-                speaker=Rimaru
-                message=_"So we'll kill you."
-            [/message]
-            {VARIABLE quests.fertile_lands_scare_count 1}
-            {TBC_SPAWN_UNITS_NO_LEADER 2 0.7 "Pikeman,Swordsman,Longbowman,Royal Guard,Shock Trooper,Iron Mauler" 21 7}
-            {VARIABLE quests.entered_fertile_lands yes}
-        [/else]
-    [/if]
-
-    [if]
-        [variable]
-            name=quests.fertile_lands_need_quick
-            equals=yes
-        [/variable]
-        [else]
-            [if]
-                [variable]
-                    name=quests.overall
-                    equals=10
-                [/variable]
-                [then]
-                    [message]
-                        speaker=Rimaru
-                        message=_"Now, we need to rush south quickly. There are many enemies around, but they aren't organised well yet, I believe that they're going to join the siege of Thunderhold. We need to attack Faithdome before they realise that they failed and regroup."
-                    [/message]
-                    [message]
-                        speaker=hired_swordsman
-                        message=_"Yes, I always liked fighting more than talking."
-                    [/message]
-                    {VARIABLE quests.fertile_lands_need_quick yes}
-                    [event]
-                        name=moveto
-                        [filter]
-                            x,y=1-33,45-46
-                            side=1
-                        [/filter]
-                        [message]
-                            speaker=Burke
-                            message=_"Faithdome awaits us."
-                        [/message]
-                        [message]
-                            speaker=Al Ghareeb
-                            message=_"Quickly, no time to talk."
-                        [/message]
-                    [/event]
-                [/then]
-            [/if]
-        [/else]
-    [/if]
-
-    [if]
-        [variable]
-            name=quests.fertile_lands_northeastern_ambush
-            equals=yes
-        [/variable]
-        [else]
-            [event]
-                name=moveto
-                [filter]
-                    x,y=22-34,5-16
-                    side=1
-                [/filter]
-                {TBC_SPAWN_UNITS 2 1 "Pikeman,Swordsman,Longbowman,Royal Guard,Shock Trooper,Master Bowman" 28 11 General boss_2}
+        name=start
+        [if]
+            [variable]
+                name=quests.entered_fertile_lands
+                equals=yes
+            [/variable]
+            [else]
+                {GENERIC_UNIT 2 "Swordsman" 20 5}
+                [+unit]
+                    id=boss_1
+                [/unit]
                 [message]
-                    speaker=boss_2
-                    message=_"Destroy the invaders!"
+                    speaker=Rimaru
+                    message=_"We are here. In lord Uver's land."
                 [/message]
-                {VARIABLE quests.fertile_lands_northeastern_ambush yes}
-            [/event]
-        [/else]
-    [/if]
-
-    [if]
-        [variable]
-            name=quests.fertile_lands_eastern_ambush
-            equals=yes
-        [/variable]
-        [else]
-            [event]
-                name=moveto
-                [filter]
-                    x,y=26-33,17-29
-                    side=1
-                [/filter]
-                {TBC_SPAWN_UNITS 2 1 "Pikeman,Swordsman,Longbowman,Duelist,Shock Trooper,Halberdier" 28 22 "Master at Arms" boss_3}
+                [move_unit]
+                    id=boss_1
+                    to_x=14
+                    to_y=4
+                    fire_event=no
+                [/move_unit]
                 [message]
-                    speaker=boss_3
-                    message=_"Protect our homeland!"
+                    speaker=elf_merc
+                    message=_"Oh, somebody is coming to greet us. Do you think that he would like to have some arrows in his chest?"
                 [/message]
+                [message]
+                    speaker=hired_halberdier
+                    message=_"Are they attacking already?"
+                [/message]
+                [message]
+                    speaker=boss_1
+                    message=_"Who are you?"
+                    [option]
+                        message=_"We are travellers, travelling from north to south."
+                        [command]
+                            [message]
+                                speaker=boss_1
+                                message=_"What are you looking for?"
+                            [/message]
+                            [message]
+                                speaker=elf_merc
+                                message=_"The end of the rainbow..."
+                            [/message]
+                            [message]
+                                speaker=Rimaru
+                                message=_"We only need passage. What's your problem? Is it forbidden to go here?"
+                            [/message]
+                            [message]
+                                speaker=boss_1
+                                message=_"It isn't forbidden. But it's forbidden for armed squads who have no explanations why they're going here."
+                            [/message]
+                            [message]
+                                speaker=Rimaru
+                                message=_"We are on our way to visit my uncle Ronald. He may be known here only as Ron."
+                            [/message]
+                        [/command]
+                    [/option]
+                    [option]
+                        message=_"We are going south to fight against the Sand Empire. We are loyal supporters of our beloved king."
+                        [command]
+                            [message]
+                                speaker=Rimaru
+                                message=_"You know about the war in the south, do you?"
+                            [/message]
+                            [message]
+                                speaker=boss_1
+                                message=_"You're far away from there. I would not travel there by foot, it would take you months. Furthermore, you don't have much supplies."
+                            [/message]
+                            [message]
+                                speaker=Burke
+                                message=_"We are assembling not far from here to prepare for the massive march south."
+                            [/message]
+                        [/command]
+                    [/option]
+                    [option]
+                        message=_"We are going to release Konrad II from illegal captivity by lord Uver."
+                        [command]
+                            [message]
+                                speaker=bandit_merc
+                                message=_"Why the hell did you say the that?"
+                            [/message]
+                            [message]
+                                speaker=orc
+                                message=_"You're an idiot!"
+                            [/message]
+                            [message]
+                                speaker=boss_1
+                                message=_"I will not allow that. His capture was a large success of our military forces and we'll not give it up so easily."
+                            [/message]
+                            [message]
+                                speaker=Rimaru
+                                message=_"You can't understand jokes? Do you think that would we ever tell the truth if we were really going to release that boy from prison?"
+                            [/message]
+                            [message]
+                                speaker=boss_1
+                                message=_"You have accidentally told the truth, I can see that."
+                            [/message]
+                            [message]
+                                speaker=orc
+                                message=_"You're an idiot. Even goblins aren't so dumb."
+                            [/message]
+                            [message]
+                                speaker=Burke
+                                message=_"Are you joking or are you really so stupid?"
+                            [/message]
+                        [/command]
+                    [/option]
+                    [option]
+                        message=_"We will never tell it to you. You don't need to know it."
+                        [command]
+                            [message]
+                                speaker=boss_1
+                                message=_"But I do need to know where are you going. But I understand your reply. You want to do something harmful here. This is your last chance. What do you want to here if it isn't something we would not like you to do?"
+                            [/message]
+                            [message]
+                                speaker=Rimaru
+                                message=_"It's a secret mission under control of lord Uver."
+                            [/message]
+                        [/command]
+                    [/option]
+                    [option]
+                        message=_"We are going to kill you and all your allies here and claim this land for us."
+                        [command]
+                            [message]
+                                speaker=boss_1
+                                message=_"Now, what is the true intention of your visit? I want no more attempts to scare me off."
+                            [/message]
+                            [message]
+                                speaker=Rimaru
+                                message=_"We're just passing. South. We need to visit lord Carcery's estate."
+                            [/message]
+                            [message]
+                                speaker=boss_1
+                                message=_"Lord Carcery is commanding some divisions in the war against the Sand Empire. If you were visiting him, you'd know that he is gone."
+                            [/message]
+                            [message]
+                                speaker=Burke
+                                message=_"Dammit!"
+                            [/message]
+                        [/command]
+                    [/option]
+                [/message]
+                [message]
+                    speaker=boss_1
+                    message=_"One does not need much knowledge of this place to know that your intentions in this land are malicious."
+                [/message]
+                [message]
+                    speaker=Burke
+                    message=_"I am baron Burke. How does it happen that you dare to call me malicious?"
+                [/message]
+                [message]
+                    speaker=boss_1
+                    message=_"You are known for descending into blasphemy, Burke. All of your titles were revoked."
+                [/message]
+                [message]
+                    speaker=Burke
+                    message=_"How does it happen that a weak man alone dares to call a group of well-armed people malicious?"
+                [/message]
+                [message]
+                    speaker=boss_1
+                    message=_"I am not alone. I have a few soldiers in my keep. They will support me."
+                [/message]
+                [message]
+                    speaker=Rimaru
+                    message=_"So you shall fall all. You're not giving us any other option but to use force. Now, tell me where lord Konrad's son is or we'll kill you!"
+                [/message]
+                [message]
+                    speaker=boss_1
+                    message=_"I will not do that."
+                [/message]
+                [message]
+                    speaker=Rimaru
+                    message=_"So we'll kill you."
+                [/message]
+                {VARIABLE quests.fertile_lands_scare_count 1}
+                {TBC_SPAWN_UNITS_NO_LEADER 2 0.7 "Pikeman,Swordsman,Longbowman,Royal Guard,Shock Trooper,Iron Mauler" 21 7}
+                {VARIABLE quests.entered_fertile_lands yes}
+            [/else]
+        [/if]
+
+        [if]
+            [variable]
+                name=quests.fertile_lands_need_quick
+                equals=yes
+            [/variable]
+            [else]
                 [if]
                     [variable]
                         name=quests.overall
-                        less_than=8
+                        equals=10
                     [/variable]
                     [then]
                         [message]
-                            speaker=unit
-                            message=_"Release Konrad II, who is being held captive here against the law and we'll let your land be."
+                            speaker=Rimaru
+                            message=_"Now, we need to rush south quickly. There are many enemies around, but they aren't organised well yet, I believe that they're going to join the siege of Thunderhold. We need to attack Faithdome before they realise that they failed and regroup."
                         [/message]
                         [message]
-                            speaker=boss_3
-                            message=_"Never!"
+                            speaker=hired_swordsman
+                            message=_"Yes, I always liked fighting more than talking."
                         [/message]
+                        {VARIABLE quests.fertile_lands_need_quick yes}
+                        [event]
+                            name=moveto
+                            [filter]
+                                x,y=1-33,45-46
+                                side=1
+                            [/filter]
+                            [message]
+                                speaker=Burke
+                                message=_"Faithdome awaits us."
+                            [/message]
+                            [message]
+                                speaker=Al Ghareeb
+                                message=_"Quickly, no time to talk."
+                            [/message]
+                        [/event]
                     [/then]
+                [/if]
+            [/else]
+        [/if]
+
+        [if]
+            [variable]
+                name=quests.fertile_lands_northeastern_ambush
+                equals=yes
+            [/variable]
+            [else]
+                [event]
+                    name=moveto
+                    [filter]
+                        x,y=22-34,5-16
+                        side=1
+                    [/filter]
+                    {TBC_SPAWN_UNITS 2 1 "Pikeman,Swordsman,Longbowman,Royal Guard,Shock Trooper,Master Bowman" 28 11 General boss_2}
+                    [message]
+                        speaker=boss_2
+                        message=_"Destroy the invaders!"
+                    [/message]
+                    {VARIABLE quests.fertile_lands_northeastern_ambush yes}
+                [/event]
+            [/else]
+        [/if]
+
+        [if]
+            [variable]
+                name=quests.fertile_lands_eastern_ambush
+                equals=yes
+            [/variable]
+            [else]
+                [event]
+                    name=moveto
+                    [filter]
+                        x,y=26-33,17-29
+                        side=1
+                    [/filter]
+                    {TBC_SPAWN_UNITS 2 1 "Pikeman,Swordsman,Longbowman,Duelist,Shock Trooper,Halberdier" 28 22 "Master at Arms" boss_3}
+                    [message]
+                        speaker=boss_3
+                        message=_"Protect our homeland!"
+                    [/message]
+                    [if]
+                        [variable]
+                            name=quests.overall
+                            less_than=8
+                        [/variable]
+                        [then]
+                            [message]
+                                speaker=unit
+                                message=_"Release Konrad II, who is being held captive here against the law and we'll let your land be."
+                            [/message]
+                            [message]
+                                speaker=boss_3
+                                message=_"Never!"
+                            [/message]
+                        [/then]
+                        [else]
+                            [message]
+                                speaker=unit
+                                message=_"We are not invading your homeland. Get out of our way and we might let you live."
+                            [/message]
+                            [message]
+                                speaker=boss_3
+                                message=_"Death to invaders!"
+                            [/message]
+                            [message]
+                                speaker=unit
+                                message=_"Listen, we are no invaders. We are merely annoyed by the likes of you attacking us for no apparent reason."
+                            [/message]
+                            [message]
+                                speaker=boss_3
+                                message=_"Death to invaders!"
+                            [/message]
+                            [message]
+                                speaker=unit
+                                message=_"Do you see any invaders around? Because I cannot!"
+                            [/message]
+                            [message]
+                                speaker=boss_3
+                                message=_"Death to invaders!"
+                            [/message]
+                            [message]
+                                speaker=unit
+                                message=_"I think I will attack you now."
+                            [/message]
+                        [/else]
+                    [/if]
+                    {VARIABLE quests.fertile_lands_eastern_ambush yes}
+                [/event]
+            [/else]
+        [/if]
+
+        [if]
+            [variable]
+                name=quests.fertile_lands_southeastern_ambush
+                equals=yes
+            [/variable]
+            [else]
+                [event]
+                    name=moveto
+                    [filter]
+                        x,y=22-33,33-46
+                        side=1
+                    [/filter]
+                    {TBC_SPAWN_UNITS 2 1.1 "Pikeman,Swordsman,Longbowman,Duelist,Shock Trooper,Heavy Infantryman" 29 40 "Iron Mauler" boss_4}
+                    [message]
+                        speaker=boss_4
+                        message=_"Invaders must die."
+                    [/message]
+                    [message]
+                        speaker=unit
+                        message=_"Did you consider who is actually stronger, whether us, the invaders, or you?"
+                    [/message]
+                    {VARIABLE quests.fertile_lands_southeastern_ambush yes}
+                [/event]
+            [/else]
+        [/if]
+
+        [if]
+            [variable]
+                name=quests.fertile_lands_northwestern_ambush
+                equals=yes
+            [/variable]
+            [else]
+                [event]
+                    name=moveto
+                    [filter]
+                        x,y=1-14,10-27
+                        side=1
+                    [/filter]
+                    {TBC_SPAWN_UNITS 2 1.1 "Dragoon,Swordsman,Longbowman,Duelist,Shock Trooper,Cavalryman" 8 28 Swordmaster boss_5}
+                    [message]
+                        speaker=boss_5
+                        message=_"Destroy the plunderers!"
+                    [/message]
+                    [message]
+                        speaker=unit
+                        message=_"We aren't plundering, we are rescuing!"
+                    [/message]
+                    [message]
+                        speaker=boss_5
+                        message=_"Destroy the lying plunderers!"
+                    [/message]
+                    {VARIABLE quests.fertile_lands_northwestern_ambush yes}
+                [/event]
+            [/else]
+        [/if]
+
+        [if]
+            [variable]
+                name=quests.fertile_lands_western_ambush
+                equals=yes
+            [/variable]
+            [else]
+                [event]
+                    name=moveto
+                    [filter]
+                        x,y=1-16,22-34
+                        side=1
+                    [/filter]
+                    {TBC_SPAWN_UNITS 2 1 "Dragoon,Swordsman,Longbowman,Halberdier,Shock Trooper,Cavalier" 8 28 Swordmaster boss_6}
+                    [message]
+                        speaker=boss_6
+                        message=_"You don't belong here! We'll not let you defile this land with your heretic speeches!"
+                    [/message]
+                    [message]
+                        speaker=unit
+                        message=_"Another moron telling these empty words?"
+                    [/message]
+                    {VARIABLE quests.fertile_lands_western_ambush yes}
+                [/event]
+            [/else]
+        [/if]
+
+        [if]
+            [variable]
+                name=quests.fertile_lands_southwestern_ambush
+                equals=yes
+            [/variable]
+            [else]
+                [event]
+                    name=moveto
+                    [filter]
+                        x,y=22-33,33-46
+                        side=1
+                    [/filter]
+                    {TBC_SPAWN_UNITS 2 1 "Pikeman,Swordsman,Longbowman,Cavalier,Shock Trooper,Iron Mauler" 10 41 Swordmaster boss_7}
+                    [message]
+                        speaker=boss_7
+                        message=_"You should not be here."
+                    [/message]
+                    [message]
+                        speaker=unit
+                        message=_"And?"
+                    [/message]
+                    [message]
+                        speaker=boss_7
+                        message=_"We'll kill you for that."
+                    [/message]
+                    {VARIABLE quests.fertile_lands_southwestern_ambush yes}
+                [/event]
+            [/else]
+        [/if]
+
+        [if]
+            [variable]
+                name=quests.overall
+                less_than=8
+            [/variable]
+            [then]
+                [event]
+                    name=last breath
+                    first_time_only=no
+                    [filter]
+                        side=2
+                    [/filter]
+                    [filter_condition]
+                        [variable]
+                            name=quests.overall
+                            less_than=8
+                        [/variable]
+                    [/filter_condition]
+                    [switch]
+                        variable=quests.fertile_lands_scare_count
+                        [case]
+                            value=2
+                            [message]
+                                speaker=second_unit
+                                message=_"Where is Konrad's son hidden?"
+                            [/message]
+                            [message]
+                                speaker=unit
+                                message=_"I will not betray my religion. You will never learn it."
+                            [/message]
+                        [/case]
+                        [case]
+                            value=3
+                            [message]
+                                speaker=second_unit
+                                message=_"Where did you hide young Konrad II?"
+                            [/message]
+                            [message]
+                                speaker=unit
+                                message=_"I have no idea!"
+                            [/message]
+                            [message]
+                                speaker=second_unit
+                                message=_"You are lying!"
+                            [/message]
+                            [message]
+                                speaker=unit
+                                message=_"I don't know. And I will not learn it before I... I... die..."
+                            [/message]
+                        [/case]
+                        [case]
+                            value=4
+                            [message]
+                                speaker=second_unit
+                                message=_"Where have you hidden the son of lord Konrad?"
+                            [/message]
+                            [message]
+                                speaker=unit
+                                message=_"Somewhere... south from..."
+                            [/message]
+                            [message]
+                                speaker=Rimaru
+                                message=_"Too bad that he didn't survive, but at least we know that it isn't somewhere north from this place."
+                            [/message]
+                        [/case]
+                        [case]
+                            value=5
+                            [message]
+                                speaker=second_unit
+                                message=_"Where did Uver imprison young lord Konrad II?"
+                            [/message]
+                            [message]
+                                speaker=unit
+                                message=_"He does not tell it to soldiers like me. He was always unsure about my loyalty."
+                            [/message]
+                            [message]
+                                speaker=second_unit
+                                message=_"He sent you to slaughter so you should betray him in your vengeance. Any ideas where he might be?"
+                            [/message]
+                            [message]
+                                speaker=unit
+                                message=_"No idea, sorry."
+                            [/message]
+                        [/case]
+                        [case]
+                            value=7
+                            [message]
+                                speaker=second_unit
+                                message=_"Where did you lock up the son of lord Konrad?"
+                            [/message]
+                            [message]
+                                speaker=unit
+                                message=_"I did not..."
+                            [/message]
+                            [message]
+                                speaker=second_unit
+                                message=_"Your comrades did!"
+                            [/message]
+                            [message]
+                                speaker=unit
+                                message=_"But I don't know where..."
+                            [/message]
+                            [message]
+                                speaker=second_unit
+                                message=_"You know! Wait... you're dead already..."
+                            [/message]
+                        [/case]
+                        [case]
+                            value=8
+                            [message]
+                                speaker=second_unit
+                                message=_"Where was the son of lord Konrad hidden?"
+                            [/message]
+                            [message]
+                                speaker=unit
+                                message=_"You will never know, hahahaha!"
+                            [/message]
+                        [/case]
+                        [case]
+                            value=10
+                            [message]
+                                speaker=second_unit
+                                message=_"Where did your lord hide the son of lord Konrad?"
+                            [/message]
+                            [message]
+                                speaker=unit
+                                message=_"Into a castle... No, I should not have told you that, invader!"
+                            [/message]
+                            [message]
+                                speaker=second_unit
+                                message=_"Which castle?"
+                            [/message]
+                            [message]
+                                speaker=unit
+                                message=_"No... idea... I... will... not..."
+                            [/message]
+                        [/case]
+                        [case]
+                            value=12
+                            [message]
+                                speaker=second_unit
+                                message=_"The son of lord Konrad. Where was he hidden?"
+                            [/message]
+                            [message]
+                                speaker=unit
+                                message=_"You'd like to know, eh? Ask somebody else, I don't know and if I knew, I would not tell it to you."
+                            [/message]
+                        [/case]
+                        [case]
+                            value=14
+                            [message]
+                                speaker=second_unit
+                                message=_"Tell me where the son of lord Konrad was hidden."
+                            [/message]
+                            [message]
+                                speaker=unit
+                                message=_"You will never find that abandoned place..."
+                            [/message]
+                            [message]
+                                speaker=second_unit
+                                message=_"Thank you."
+                            [/message]
+                            [message]
+                                speaker=Rimaru
+                                message=_"To sum up, he is hidden rather southwards, in an abandoned castle. There are many castles around, though."
+                            [/message]
+                        [/case]
+                        [case]
+                            value=17
+                            [message]
+                                speaker=second_unit
+                                message=_"Tell me now, where is the son of lord Konrad, Konrad II?"
+                            [/message]
+                            [message]
+                                speaker=unit
+                                message=_"I will never tell you (tries to spit)."
+                            [/message]
+                            [message]
+                                speaker=second_unit
+                                message=_"You will!"
+                            [/message]
+                            [message]
+                                speaker=unit
+                                message=_"I... won't... I am dead... now..."
+                            [/message]
+                        [/case]
+                        [case]
+                            value=19
+                            [message]
+                                speaker=second_unit
+                                message=_"Where did your friends lock up Konrad II?"
+                            [/message]
+                            [message]
+                                speaker=unit
+                                message=_"I have no idea. There were rumours that he was imprisoned, but I have no idea where could it be. Maybe beneath Uver's castle."
+                            [/message]
+                        [/case]
+                        [case]
+                            value=22
+                            [message]
+                                speaker=second_unit
+                                message=_"Where is young lord Konrad? Where did you imprison him?"
+                            [/message]
+                            [message]
+                                speaker=unit
+                                message=_"I know it very well. Yet, I will not tell it to you. I will take this secret into my grave!"
+                            [/message]
+                            [message]
+                                speaker=second_unit
+                                message=_"Tell it or I'll kill you!"
+                            [/message]
+                            [message]
+                                speaker=unit
+                                message=_"I will die very soon anyway, fool..."
+                            [/message]
+                        [/case]
+                        [case]
+                            value=25
+                            [message]
+                                speaker=second_unit
+                                message=_"Some of your friends hid a young lord nearby. Konrad was his name. Where is he?"
+                            [/message]
+                            [message]
+                                speaker=unit
+                                message=_"In that abandoned castle..."
+                            [/message]
+                            [message]
+                                speaker=second_unit
+                                message=_"Which one?"
+                            [/message]
+                            [message]
+                                speaker=unit
+                                message=_"..."
+                            [/message]
+                        [/case]
+                        [case]
+                            value=29
+                            [message]
+                                speaker=second_unit
+                                message=_"Konrad the Second! Where is he?!"
+                            [/message]
+                            [message]
+                                speaker=unit
+                                message=_"Learn it elsewhere!"
+                            [/message]
+                        [/case]
+                        [case]
+                            value=33
+                            [message]
+                                speaker=second_unit
+                                message=_"Where is Konrad II imprisoned?"
+                            [/message]
+                            [message]
+                                speaker=unit
+                                message=_"In that abandoned castle in the southwestern parts of these fields between Thunderhold and Faithdome. Please don't hurt me even more!"
+                            [/message]
+                            [message]
+                                speaker=second_unit
+                                message=_"Thank you."
+                            [/message]
+                        [/case]
+                    [/switch]
+                    {VARIABLE_OP quests.fertile_lands_scare_count add 1}
+                [/event]
+            [/then]
+        [/if]
+
+        [if]
+            [variable]
+                name=quests.overall
+                greater_than=14
+            [/variable]
+            [then]
+                [if]
+                    [variable]
+                        name=quests.fertile_lands_later_ambush_1
+                        equals=yes
+                    [/variable]
                     [else]
-                        [message]
-                            speaker=unit
-                            message=_"We are not invading your homeland. Get out of our way and we might let you live."
-                        [/message]
-                        [message]
-                            speaker=boss_3
-                            message=_"Death to invaders!"
-                        [/message]
-                        [message]
-                            speaker=unit
-                            message=_"Listen, we are no invaders. We are merely annoyed by the likes of you attacking us for no apparent reason."
-                        [/message]
-                        [message]
-                            speaker=boss_3
-                            message=_"Death to invaders!"
-                        [/message]
-                        [message]
-                            speaker=unit
-                            message=_"Do you see any invaders around? Because I cannot!"
-                        [/message]
-                        [message]
-                            speaker=boss_3
-                            message=_"Death to invaders!"
-                        [/message]
-                        [message]
-                            speaker=unit
-                            message=_"I think I will attack you now."
-                        [/message]
+                        [event]
+                            name=moveto
+                            [filter]
+                                x,y=15-32,7-23
+                                side=1
+                            [/filter]
+                            {TBC_SPAWN_UNITS_NO_LEADER 2 1.2 "Highwayman,Halberdier,Master Bowman,Royal Guard,Halberdier,White Mage" 20 15}
+                            {VARIABLE quests.fertile_lands_later_ambush_1 yes}
+                        [/event]
                     [/else]
                 [/if]
-                {VARIABLE quests.fertile_lands_eastern_ambush yes}
-            [/event]
-        [/else]
-    [/if]
-
-    [if]
-        [variable]
-            name=quests.fertile_lands_southeastern_ambush
-            equals=yes
-        [/variable]
-        [else]
-            [event]
-                name=moveto
-                [filter]
-                    x,y=22-33,33-46
-                    side=1
-                [/filter]
-                {TBC_SPAWN_UNITS 2 1.1 "Pikeman,Swordsman,Longbowman,Duelist,Shock Trooper,Heavy Infantryman" 29 40 "Iron Mauler" boss_4}
-                [message]
-                    speaker=boss_4
-                    message=_"Invaders must die."
-                [/message]
-                [message]
-                    speaker=unit
-                    message=_"Did you consider who is actually stronger, whether us, the invaders, or you?"
-                [/message]
-                {VARIABLE quests.fertile_lands_southeastern_ambush yes}
-            [/event]
-        [/else]
-    [/if]
-
-    [if]
-        [variable]
-            name=quests.fertile_lands_northwestern_ambush
-            equals=yes
-        [/variable]
-        [else]
-            [event]
-                name=moveto
-                [filter]
-                    x,y=1-14,10-27
-                    side=1
-                [/filter]
-                {TBC_SPAWN_UNITS 2 1.1 "Dragoon,Swordsman,Longbowman,Duelist,Shock Trooper,Cavalryman" 8 28 Swordmaster boss_5}
-                [message]
-                    speaker=boss_5
-                    message=_"Destroy the plunderers!"
-                [/message]
-                [message]
-                    speaker=unit
-                    message=_"We aren't plundering, we are rescuing!"
-                [/message]
-                [message]
-                    speaker=boss_5
-                    message=_"Destroy the lying plunderers!"
-                [/message]
-                {VARIABLE quests.fertile_lands_northwestern_ambush yes}
-            [/event]
-        [/else]
-    [/if]
-
-    [if]
-        [variable]
-            name=quests.fertile_lands_western_ambush
-            equals=yes
-        [/variable]
-        [else]
-            [event]
-                name=moveto
-                [filter]
-                    x,y=1-16,22-34
-                    side=1
-                [/filter]
-                {TBC_SPAWN_UNITS 2 1 "Dragoon,Swordsman,Longbowman,Halberdier,Shock Trooper,Cavalier" 8 28 Swordmaster boss_6}
-                [message]
-                    speaker=boss_6
-                    message=_"You don't belong here! We'll not let you defile this land with your heretic speeches!"
-                [/message]
-                [message]
-                    speaker=unit
-                    message=_"Another moron telling these empty words?"
-                [/message]
-                {VARIABLE quests.fertile_lands_western_ambush yes}
-            [/event]
-        [/else]
-    [/if]
-
-    [if]
-        [variable]
-            name=quests.fertile_lands_southwestern_ambush
-            equals=yes
-        [/variable]
-        [else]
-            [event]
-                name=moveto
-                [filter]
-                    x,y=22-33,33-46
-                    side=1
-                [/filter]
-                {TBC_SPAWN_UNITS 2 1 "Pikeman,Swordsman,Longbowman,Cavalier,Shock Trooper,Iron Mauler" 10 41 Swordmaster boss_7}
-                [message]
-                    speaker=boss_7
-                    message=_"You should not be here."
-                [/message]
-                [message]
-                    speaker=unit
-                    message=_"And?"
-                [/message]
-                [message]
-                    speaker=boss_7
-                    message=_"We'll kill you for that."
-                [/message]
-                {VARIABLE quests.fertile_lands_southwestern_ambush yes}
-            [/event]
-        [/else]
-    [/if]
-
-    [if]
-        [variable]
-            name=quests.overall
-            less_than=8
-        [/variable]
-        [then]
-            [event]
-                name=last breath
-                first_time_only=no
-                [filter]
-                    side=2
-                [/filter]
-                [filter_condition]
+                [if]
                     [variable]
-                        name=quests.overall
-                        less_than=8
+                        name=quests.fertile_lands_later_ambush_2
+                        equals=yes
                     [/variable]
-                [/filter_condition]
-                [switch]
-                    variable=quests.fertile_lands_scare_count
-                    [case]
-                        value=2
-                        [message]
-                            speaker=second_unit
-                            message=_"Where is Konrad's son hidden?"
-                        [/message]
-                        [message]
-                            speaker=unit
-                            message=_"I will not betray my religion. You will never learn it."
-                        [/message]
-                    [/case]
-                    [case]
-                        value=3
-                        [message]
-                            speaker=second_unit
-                            message=_"Where did you hide young Konrad II?"
-                        [/message]
-                        [message]
-                            speaker=unit
-                            message=_"I have no idea!"
-                        [/message]
-                        [message]
-                            speaker=second_unit
-                            message=_"You are lying!"
-                        [/message]
-                        [message]
-                            speaker=unit
-                            message=_"I don't know. And I will not learn it before I... I... die..."
-                        [/message]
-                    [/case]
-                    [case]
-                        value=4
-                        [message]
-                            speaker=second_unit
-                            message=_"Where have you hidden the son of lord Konrad?"
-                        [/message]
-                        [message]
-                            speaker=unit
-                            message=_"Somewhere... south from..."
-                        [/message]
-                        [message]
-                            speaker=Rimaru
-                            message=_"Too bad that he didn't survive, but at least we know that it isn't somewhere north from this place."
-                        [/message]
-                    [/case]
-                    [case]
-                        value=5
-                        [message]
-                            speaker=second_unit
-                            message=_"Where did Uver imprison young lord Konrad II?"
-                        [/message]
-                        [message]
-                            speaker=unit
-                            message=_"He does not tell it to soldiers like me. He was always unsure about my loyalty."
-                        [/message]
-                        [message]
-                            speaker=second_unit
-                            message=_"He sent you to slaughter so you should betray him in your vengeance. Any ideas where he might be?"
-                        [/message]
-                        [message]
-                            speaker=unit
-                            message=_"No idea, sorry."
-                        [/message]
-                    [/case]
-                    [case]
-                        value=7
-                        [message]
-                            speaker=second_unit
-                            message=_"Where did you lock up the son of lord Konrad?"
-                        [/message]
-                        [message]
-                            speaker=unit
-                            message=_"I did not..."
-                        [/message]
-                        [message]
-                            speaker=second_unit
-                            message=_"Your comrades did!"
-                        [/message]
-                        [message]
-                            speaker=unit
-                            message=_"But I don't know where..."
-                        [/message]
-                        [message]
-                            speaker=second_unit
-                            message=_"You know! Wait... you're dead already..."
-                        [/message]
-                    [/case]
-                    [case]
-                        value=8
-                        [message]
-                            speaker=second_unit
-                            message=_"Where was the son of lord Konrad hidden?"
-                        [/message]
-                        [message]
-                            speaker=unit
-                            message=_"You will never know, hahahaha!"
-                        [/message]
-                    [/case]
-                    [case]
-                        value=10
-                        [message]
-                            speaker=second_unit
-                            message=_"Where did your lord hide the son of lord Konrad?"
-                        [/message]
-                        [message]
-                            speaker=unit
-                            message=_"Into a castle... No, I should not have told you that, invader!"
-                        [/message]
-                        [message]
-                            speaker=second_unit
-                            message=_"Which castle?"
-                        [/message]
-                        [message]
-                            speaker=unit
-                            message=_"No... idea... I... will... not..."
-                        [/message]
-                    [/case]
-                    [case]
-                        value=12
-                        [message]
-                            speaker=second_unit
-                            message=_"The son of lord Konrad. Where was he hidden?"
-                        [/message]
-                        [message]
-                            speaker=unit
-                            message=_"You'd like to know, eh? Ask somebody else, I don't know and if I knew, I would not tell it to you."
-                        [/message]
-                    [/case]
-                    [case]
-                        value=14
-                        [message]
-                            speaker=second_unit
-                            message=_"Tell me where the son of lord Konrad was hidden."
-                        [/message]
-                        [message]
-                            speaker=unit
-                            message=_"You will never find that abandoned place..."
-                        [/message]
-                        [message]
-                            speaker=second_unit
-                            message=_"Thank you."
-                        [/message]
-                        [message]
-                            speaker=Rimaru
-                            message=_"To sum up, he is hidden rather southwards, in an abandoned castle. There are many castles around, though."
-                        [/message]
-                    [/case]
-                    [case]
-                        value=17
-                        [message]
-                            speaker=second_unit
-                            message=_"Tell me now, where is the son of lord Konrad, Konrad II?"
-                        [/message]
-                        [message]
-                            speaker=unit
-                            message=_"I will never tell you (tries to spit)."
-                        [/message]
-                        [message]
-                            speaker=second_unit
-                            message=_"You will!"
-                        [/message]
-                        [message]
-                            speaker=unit
-                            message=_"I... won't... I am dead... now..."
-                        [/message]
-                    [/case]
-                    [case]
-                        value=19
-                        [message]
-                            speaker=second_unit
-                            message=_"Where did your friends lock up Konrad II?"
-                        [/message]
-                        [message]
-                            speaker=unit
-                            message=_"I have no idea. There were rumours that he was imprisoned, but I have no idea where could it be. Maybe beneath Uver's castle."
-                        [/message]
-                    [/case]
-                    [case]
-                        value=22
-                        [message]
-                            speaker=second_unit
-                            message=_"Where is young lord Konrad? Where did you imprison him?"
-                        [/message]
-                        [message]
-                            speaker=unit
-                            message=_"I know it very well. Yet, I will not tell it to you. I will take this secret into my grave!"
-                        [/message]
-                        [message]
-                            speaker=second_unit
-                            message=_"Tell it or I'll kill you!"
-                        [/message]
-                        [message]
-                            speaker=unit
-                            message=_"I will die very soon anyway, fool..."
-                        [/message]
-                    [/case]
-                    [case]
-                        value=25
-                        [message]
-                            speaker=second_unit
-                            message=_"Some of your friends hid a young lord nearby. Konrad was his name. Where is he?"
-                        [/message]
-                        [message]
-                            speaker=unit
-                            message=_"In that abandoned castle..."
-                        [/message]
-                        [message]
-                            speaker=second_unit
-                            message=_"Which one?"
-                        [/message]
-                        [message]
-                            speaker=unit
-                            message=_"..."
-                        [/message]
-                    [/case]
-                    [case]
-                        value=29
-                        [message]
-                            speaker=second_unit
-                            message=_"Konrad the Second! Where is he?!"
-                        [/message]
-                        [message]
-                            speaker=unit
-                            message=_"Learn it elsewhere!"
-                        [/message]
-                    [/case]
-                    [case]
-                        value=33
-                        [message]
-                            speaker=second_unit
-                            message=_"Where is Konrad II imprisoned?"
-                        [/message]
-                        [message]
-                            speaker=unit
-                            message=_"In that abandoned castle in the southwestern parts of these fields between Thunderhold and Faithdome. Please don't hurt me even more!"
-                        [/message]
-                        [message]
-                            speaker=second_unit
-                            message=_"Thank you."
-                        [/message]
-                    [/case]
-                [/switch]
-                {VARIABLE_OP quests.fertile_lands_scare_count add 1}
-            [/event]
-        [/then]
-    [/if]
-
-    [if]
-        [variable]
-            name=quests.overall
-            greater_than=14
-        [/variable]
-        [then]
-            [if]
-                [variable]
-                    name=quests.fertile_lands_later_ambush_1
-                    equals=yes
-                [/variable]
-                [else]
-                    [event]
-                        name=moveto
-                        [filter]
-                            x,y=15-32,7-23
-                            side=1
-                        [/filter]
-                        {TBC_SPAWN_UNITS_NO_LEADER 2 1.2 "Highwayman,Halberdier,Master Bowman,Royal Guard,Halberdier,White Mage" 20 15}
-                        {VARIABLE quests.fertile_lands_later_ambush_1 yes}
-                    [/event]
-                [/else]
-            [/if]
-            [if]
-                [variable]
-                    name=quests.fertile_lands_later_ambush_2
-                    equals=yes
-                [/variable]
-                [else]
-                    [event]
-                        name=moveto
-                        [filter]
-                            x,y=1-17,23-34
-                            side=1
-                        [/filter]
-                        {TBC_SPAWN_UNITS_NO_LEADER 2 1.2 "Highwayman,Halberdier,Master Bowman,Royal Guard,Halberdier,White Mage" 9 28}
-                        {VARIABLE quests.fertile_lands_later_ambush_2 yes}
-                    [/event]
-                [/else]
-            [/if]
-            [if]
-                [variable]
-                    name=quests.fertile_lands_later_ambush_3
-                    equals=yes
-                [/variable]
-                [else]
-                    [event]
-                        name=moveto
-                        [filter]
-                            x,y=14-30,27-41
-                            side=1
-                        [/filter]
-                        {TBC_SPAWN_UNITS_NO_LEADER 2 1.2 "Highwayman,Halberdier,Master Bowman,Royal Guard,Halberdier,White Mage" 21 35}
-                        {VARIABLE quests.fertile_lands_later_ambush_3 yes}
-                    [/event]
-                [/else]
-            [/if]
-        [/then]
-    [/if]
-
+                    [else]
+                        [event]
+                            name=moveto
+                            [filter]
+                                x,y=1-17,23-34
+                                side=1
+                            [/filter]
+                            {TBC_SPAWN_UNITS_NO_LEADER 2 1.2 "Highwayman,Halberdier,Master Bowman,Royal Guard,Halberdier,White Mage" 9 28}
+                            {VARIABLE quests.fertile_lands_later_ambush_2 yes}
+                        [/event]
+                    [/else]
+                [/if]
+                [if]
+                    [variable]
+                        name=quests.fertile_lands_later_ambush_3
+                        equals=yes
+                    [/variable]
+                    [else]
+                        [event]
+                            name=moveto
+                            [filter]
+                                x,y=14-30,27-41
+                                side=1
+                            [/filter]
+                            {TBC_SPAWN_UNITS_NO_LEADER 2 1.2 "Highwayman,Halberdier,Master Bowman,Royal Guard,Halberdier,White Mage" 21 35}
+                            {VARIABLE quests.fertile_lands_later_ambush_3 yes}
+                        [/event]
+                    [/else]
+                [/if]
+            [/then]
+        [/if]
     [/event]
 
     {TBC_GLOBAL_EVENTS_RPG}

--- a/spinoffs/The_Beautiful_Child/scenarios/Fertile_Lands.cfg
+++ b/spinoffs/The_Beautiful_Child/scenarios/Fertile_Lands.cfg
@@ -82,13 +82,13 @@
                         hero=yes
                     [/variables]
                     [modifications]
-                        [advance]
+                        [advancement]
                             id=portrait
                             [effect]
                                 apply_to=profile
                                 portrait="portraits/humans/transparent/fencer.png"
                             [/effect]
-                        [/advance]
+                        [/advancement]
                     [/modifications]
                     {VARIABLE party_members[$party_members.length].id "Konrad II"}
                 [/unit]

--- a/spinoffs/The_Beautiful_Child/scenarios/Fertile_Lands.cfg
+++ b/spinoffs/The_Beautiful_Child/scenarios/Fertile_Lands.cfg
@@ -737,6 +737,10 @@
                             name=quests.overall
                             less_than=8
                         [/variable]
+                        [variable]  # Some attacks, like shockwave, have secondary effects which we'll skip so units don't interrogate themselves
+                            name=unit.id
+                            not_equals=$second_unit.id
+                        [/variable]
                     [/filter_condition]
                     [switch]
                         variable=quests.fertile_lands_scare_count

--- a/spinoffs/The_Beautiful_Child/scenarios/Goonville.cfg
+++ b/spinoffs/The_Beautiful_Child/scenarios/Goonville.cfg
@@ -36,12 +36,12 @@
             generate_name=yes
             ai_special=guardian
             [modifications]
-                [advance]
+                [advancement]
                     [effect]
                         apply_to=movement
                         set=0
                     [/effect]
-                [/advance]
+                [/advancement]
             [/modifications]
         [/unit]
         [unit]
@@ -51,12 +51,12 @@
             generate_name=yes
             ai_special=guardian
             [modifications]
-                [advance]
+                [advancement]
                     [effect]
                         apply_to=movement
                         set=0
                     [/effect]
-                [/advance]
+                [/advancement]
             [/modifications]
         [/unit]
         [unit]
@@ -66,12 +66,12 @@
             generate_name=yes
             ai_special=guardian
             [modifications]
-                [advance]
+                [advancement]
                     [effect]
                         apply_to=movement
                         set=0
                     [/effect]
-                [/advance]
+                [/advancement]
             [/modifications]
         [/unit]
     [ai]
@@ -377,13 +377,13 @@
                 canrecruit=yes
                 random_traits=yes
                 [modifications]
-                [advance]
+                [advancement]
                     id=portrait
                     [effect]
                         apply_to=profile
                         portrait="portraits/humans/transparent/swordsman-3.png"
                     [/effect]
-                [/advance]
+                [/advancement]
                  [/modifications]
             [/unit]
             [if]

--- a/spinoffs/The_Beautiful_Child/scenarios/Grey_Hills.cfg
+++ b/spinoffs/The_Beautiful_Child/scenarios/Grey_Hills.cfg
@@ -431,13 +431,13 @@
             hero=yes
         [/variables]
         [modifications]
-            [advance]
+            [advancement]
                 id=portrait
                 [effect]
                     apply_to=profile
                     portrait="portraits/orcs/transparent/grunt-5.png"
                 [/effect]
-            [/advance]
+            [/advancement]
             {TRAIT_STRONG}
             {TRAIT_INTELLIGENT}
         [/modifications]

--- a/spinoffs/The_Beautiful_Child/scenarios/Thunderhold.cfg
+++ b/spinoffs/The_Beautiful_Child/scenarios/Thunderhold.cfg
@@ -39,12 +39,12 @@
             generate_name=yes
             ai_special=guardian
             [modifications]
-                [advance]
+                [advancement]
                     [effect]
                         apply_to=movement
                         set=0
                     [/effect]
-                [/advance]
+                [/advancement]
             [/modifications]
         [/unit]
         [unit]
@@ -54,12 +54,12 @@
             generate_name=yes
             ai_special=guardian
             [modifications]
-                [advance]
+                [advancement]
                     [effect]
                         apply_to=movement
                         set=0
                     [/effect]
-                [/advance]
+                [/advancement]
             [/modifications]
         [/unit]
         [unit]
@@ -69,12 +69,12 @@
             generate_name=yes
             ai_special=guardian
             [modifications]
-                [advance]
+                [advancement]
                     [effect]
                         apply_to=movement
                         set=0
                     [/effect]
-                [/advance]
+                [/advancement]
             [/modifications]
         [/unit]
         [unit]
@@ -84,12 +84,12 @@
             generate_name=yes
             ai_special=guardian
             [modifications]
-                [advance]
+                [advancement]
                     [effect]
                         apply_to=movement
                         set=0
                     [/effect]
-                [/advance]
+                [/advancement]
             [/modifications]
         [/unit]
     [/side]
@@ -191,13 +191,13 @@
                     type=Royal Warrior
                     canrecruit=yes
                     [modifications]
-                        [advance]
+                        [advancement]
                             id=portrait
                             [effect]
                                 apply_to=profile
                                 portrait="portraits/humans/transparent/marshal-2.png"
                             [/effect]
-                        [/advance]
+                        [/advancement]
                     [/modifications]
                 [/unit]
             [/then]
@@ -218,13 +218,13 @@
                     canrecruit=yes
                     random_traits=yes
                     [modifications]
-                        [advance]
+                        [advancement]
                             id=portrait
                             [effect]
                                 apply_to=profile
                                 portrait="portraits/humans/transparent/halberdier.png"
                             [/effect]
-                        [/advance]
+                        [/advancement]
                     [/modifications]
                 [/unit]
                 [if]
@@ -687,12 +687,12 @@
                         type=Iron Mauler
                         generate_name=yes
                         [modifications]
-                            [advance]
+                            [advancement]
                                 [effect]
                                     apply_to=movement
                                     set=0
                                 [/effect]
-                            [/advance]
+                            [/advancement]
                         [/modifications]
                     [/unit]
                     [message]

--- a/spinoffs/The_Beautiful_Child/scenarios/Thunderhold.cfg
+++ b/spinoffs/The_Beautiful_Child/scenarios/Thunderhold.cfg
@@ -287,6 +287,10 @@
                                 [/variable]
                             [/show_if]
                             [command]
+                                [gold]
+                                    side=1
+                                    amount=-80
+                                [/gold]
                                 {VARIABLE quests.thunderhold_recruited_pikeman yes}
                                 [store_unit]
                                     [filter]

--- a/spinoffs/The_Beautiful_Child/scenarios/Valley_Passage.cfg
+++ b/spinoffs/The_Beautiful_Child/scenarios/Valley_Passage.cfg
@@ -73,13 +73,13 @@
                     name= _"Konrad II"
                     canrecruit=yes
                     [modifications]
-                        [advance]
+                        [advancement]
                             id=portrait
                             [effect]
                                 apply_to=profile
                                 portrait="portraits/humans/transparent/fencer.png"
                             [/effect]
-                        [/advance]
+                        [/advancement]
                     [/modifications]
                 [/unit]
             [/else]

--- a/spinoffs/The_Beautiful_Child/scenarios/Valley_Passage.cfg
+++ b/spinoffs/The_Beautiful_Child/scenarios/Valley_Passage.cfg
@@ -283,12 +283,7 @@
                         radius=7
                         side=1
                     [/remove_shroud]
-                    [move_unit]
-                        side=1
-                        to_x=17
-                        to_y=12
-                        fire_event=no
-                    [/move_unit]
+                    {MOVE_SIDE_TO 1 17 12}
                     [message]
                         speaker=Luke
                         message=_"Work, dig in the ground, the ancient vault must be somewhere around here. If I was Niflheim the Horror from the Northern Wastelands, I would hide it somewhere around here."
@@ -890,42 +885,55 @@
                         [store_unit]
                             [filter]
                                 side=1
-                                [filter_wml]
-                                    [movement_costs]
-                                        mountains={UNREACHABLE}
-                                    [/movement_costs]
-                                [/filter_wml]
                             [/filter]
-                            variable=cant_pass
+                            variable=side1
                         [/store_unit]
+                        {VARIABLE changed_mnt_cost no}
                         [for]
-                            array=cant_pass
+                            array=side1
                             [do]
-                                [set_variables]
-                                    name=cant_pass[$i].modifications.advancement[$cant_pass[$i].modifications.advancement.length]
-                                    mode=replace
-                                    [value]
-                                        id=mountain_passing
-                                        [effect]
-                                            apply_to=movement_costs
-                                            replace=true
-                                            [movement_costs]
-                                                mountains=3
-                                            [/movement_costs]
-                                        [/effect]
-                                    [/value]
-                                [/set_variables]
-                                {VARIABLE cant_pass[$i].movement_costs.mountains 3}
-                                [unstore_unit]
-                                    variable=cant_pass[$i]
-                                    find_vacant=no
-                                [/unstore_unit]
+                                [if]
+                                    [variable]
+                                        name=side1[$i].movement_costs.mountains
+                                        greater_than=0    # not null
+                                    [/variable]
+                                    [and]
+                                        [variable]
+                                            name=side1[$i].movement_costs.mountains
+                                            less_than=4
+                                        [/variable]
+                                    [/and]
+                                    [else]
+                                        {VARIABLE changed_mnt_cost yes}
+                                        {VARIABLE helped $side1[$i].id}
+                                        [set_variables]
+                                            name=side1[$i].modifications.advancement[$side1[$i].modifications.advancement.length]
+                                            mode=replace
+                                            [value]
+                                                id=mountain_passing
+                                                [effect]
+                                                    apply_to=movement_costs
+                                                    replace=true
+                                                    [movement_costs]
+                                                        mountains=3
+                                                    [/movement_costs]
+                                                [/effect]
+                                            [/value]
+                                        [/set_variables]
+                                        {VARIABLE side1[$i].movement_costs.mountains 3}
+                                        [unstore_unit]
+                                            variable=side1[$i]
+                                            find_vacant=no
+                                        [/unstore_unit]
+                                    [/else]
+                                [/if]
                             [/do]
                         [/for]
+                        {CLEAR_VARIABLE side1}
                         [if]
                             [variable]
-                                name=cant_pass.length
-                                greater_than=0
+                                name=changed_mnt_cost
+                                equals=yes
                             [/variable]
                             [then]
                                 [message]
@@ -933,7 +941,7 @@
                                     message= _ "I think that we'll need a heavy hike through the mountains, can all of us pass through mountains?"
                                 [/message]
                                 [message]
-                                    id=$cant_pass.id
+                                    id=$helped
                                     message= _ "I hope I'll manage."
                                 [/message]
                                 [message]
@@ -948,7 +956,7 @@
                                 [/message]
                             [/else]
                         [/if]
-                        {CLEAR_VARIABLE cant_pass}
+                        {CLEAR_VARIABLE changed_mnt_cost,helped}
                         [message]
                             speaker=Sicaria
                             message= _ "And we'll see Konrad then, right?"

--- a/spinoffs/The_Beautiful_Child/scenarios/Valley_Passage.cfg
+++ b/spinoffs/The_Beautiful_Child/scenarios/Valley_Passage.cfg
@@ -902,7 +902,7 @@
                             array=cant_pass
                             [do]
                                 [set_variables]
-                                    name=cant_pass[$i].modifications.advance[$cant_pass[$i].modifications.advance.length]
+                                    name=cant_pass[$i].modifications.advancement[$cant_pass[$i].modifications.advancement.length]
                                     mode=replace
                                     [value]
                                         id=mountain_passing

--- a/spinoffs/The_Beautiful_Child/scenarios/Ziggurat_Town.cfg
+++ b/spinoffs/The_Beautiful_Child/scenarios/Ziggurat_Town.cfg
@@ -46,12 +46,12 @@
             generate_name=yes
             ai_special=guardian
             [modifications]
-                [advance]
+                [advancement]
                     [effect]
                         apply_to=movement
                         set=0
                     [/effect]
-                [/advance]
+                [/advancement]
             [/modifications]
         [/unit]
         [unit]
@@ -61,12 +61,12 @@
             generate_name=yes
             ai_special=guardian
             [modifications]
-                [advance]
+                [advancement]
                     [effect]
                         apply_to=movement
                         set=0
                     [/effect]
-                [/advance]
+                [/advancement]
             [/modifications]
         [/unit]
         [unit]
@@ -76,12 +76,12 @@
             generate_name=yes
             ai_special=guardian
             [modifications]
-                [advance]
+                [advancement]
                     [effect]
                         apply_to=movement
                         set=0
                     [/effect]
-                [/advance]
+                [/advancement]
             [/modifications]
         [/unit]
     [/side]
@@ -131,13 +131,13 @@
         name= _"Konrad II"
         canrecruit=yes
         [modifications]
-            [advance]
+            [advancement]
                 id=portrait
                 [effect]
                     apply_to=profile
                     portrait="portraits/humans/transparent/fencer.png"
                 [/effect]
-            [/advance]
+            [/advancement]
         [/modifications]
     [/unit]
     {GUARDIAN_UNIT 2 "General" 8 13}

--- a/spinoffs/The_Beautiful_Child/units/Bringer_of_Light.cfg
+++ b/spinoffs/The_Beautiful_Child/units/Bringer_of_Light.cfg
@@ -512,7 +512,7 @@
                                     moves=0
                                     attacks_left=0
                                     [modifications]
-                                        [advance]
+                                        [advancement]
                                             id=dazzle_effect
                                             [effect]
                                                 apply_to=attack
@@ -520,7 +520,7 @@
                                                     {DAZZLE_COUNTER}
                                                 [/set_specials]
                                             [/effect]
-                                        [/advance]
+                                        [/advancement]
                                     [/modifications]
                                 [/unit]
                                 {VARIABLE_OP count add 1}

--- a/spinoffs/The_Beautiful_Child/units/Bringer_of_Light.cfg
+++ b/spinoffs/The_Beautiful_Child/units/Bringer_of_Light.cfg
@@ -1,21 +1,4 @@
 #textdomain wesnoth-tbc
-#define DAZZLE_COUNTER
-    [chance_to_hit]
-        id=dazzle_counter
-        value=30
-        apply_to=opponent
-        [filter_base_value]
-            greater_than=30
-        [/filter_base_value]
-        [filter_opponent]
-            [filter_wml]
-                [variables]
-                    dazzled=yes
-                [/variables]
-            [/filter_wml]
-        [/filter_opponent]
-    [/chance_to_hit]
-#enddef
 [unit_type]
     id=Bringer of Light
     name= _ "Bringer of Light"
@@ -163,7 +146,7 @@
         icon=attacks/mace-spiked.png
         attack_weight=0
         [specials]
-            {DAZZLE_COUNTER}
+            {BLIND_COUNTER}
         [/specials]
     [/attack]
     [attack]
@@ -173,7 +156,7 @@
         range=ranged
         [specials]
             {WEAPON_SPECIAL_MAGICAL}
-            {DAZZLE_COUNTER}
+            {BLIND_COUNTER}
         [/specials]
         damage=12
         number=4
@@ -186,7 +169,7 @@
         [specials]
             {WEAPON_SPECIAL_MAGICAL}
             {WEAPON_SPECIAL_STORM}
-            {DAZZLE_COUNTER}
+            {BLIND_COUNTER}
         [/specials]
         range=ranged
         damage=25
@@ -513,11 +496,11 @@
                                     attacks_left=0
                                     [modifications]
                                         [advancement]
-                                            id=dazzle_effect
+                                            id=blind_effect
                                             [effect]
                                                 apply_to=attack
                                                 [set_specials]
-                                                    {DAZZLE_COUNTER}
+                                                    {BLIND_COUNTER}
                                                 [/set_specials]
                                             [/effect]
                                         [/advancement]
@@ -558,7 +541,7 @@
                             array=targets
                             variable=t
                             [do]
-                                {VARIABLE targets[$t].variables.dazzled yes}
+                                {VARIABLE targets[$t].variables.blinded yes}
                                 [unstore_unit]
                                     variable=targets[$t]
                                     find_vacant=no
@@ -575,14 +558,14 @@
                                         [filter]
                                             id=$targets[$t].id
                                         [/filter]
-                                        variable=undazzled
+                                        variable=blinded
                                     [/store_unit]
-                                    {CLEAR_VARIABLE undazzled.variables.dazzled}
+                                    {CLEAR_VARIABLE targets[$t].variables.blinded}
                                     [unstore_unit]
-                                        variable=undazzled
+                                        variable=blinded
                                         find_vacant=no
                                     [/unstore_unit]
-                                    {CLEAR_VARIABLE undazzled}
+                                    {CLEAR_VARIABLE blinded}
                                 [/event]
                             [/do]
                         [/for]
@@ -653,4 +636,3 @@
         {CLEAR_VARIABLE this_side}
     [/event]
 [/unit_type]
-#undef DAZZLE_COUNTER

--- a/spinoffs/The_Beautiful_Child/units/Bringer_of_Light.cfg
+++ b/spinoffs/The_Beautiful_Child/units/Bringer_of_Light.cfg
@@ -560,7 +560,7 @@
                                         [/filter]
                                         variable=blinded
                                     [/store_unit]
-                                    {CLEAR_VARIABLE targets[$t].variables.blinded}
+                                    {CLEAR_VARIABLE blinded.variables.blinded}
                                     [unstore_unit]
                                         variable=blinded
                                         find_vacant=no

--- a/spinoffs/The_Beautiful_Child/units/Bringer_of_Light2.cfg
+++ b/spinoffs/The_Beautiful_Child/units/Bringer_of_Light2.cfg
@@ -420,14 +420,25 @@
         name=turn refresh
         id=spellcasting_light_2
         first_time_only=no
-        [store_unit]
-            [filter]
-                side=$side_number
-                ability=spellcasting_light_2
-            [/filter]
-            variable=casters
-            kill=no
-        [/store_unit]
+        [if]
+            [have_unit]
+                side=1
+                [filter_vision]
+                    visible=yes
+                    side=$side_number
+                [/filter_vision]
+            [/have_unit]
+            [then]
+                [store_unit]
+                    [filter]
+                        side=$side_number
+                        ability=spellcasting_light_2
+                    [/filter]
+                    variable=casters
+                    kill=no
+                [/store_unit]
+            [/then]
+        [/if]
         [for]
             array=casters
             [do]
@@ -470,7 +481,7 @@
                             [/variable]
                             [do]
                                 {VARIABLE_OP type rand "Deathblade,Revenant,Bone Shooter,Wraith,Shadow"}
-                                {GENERIC_UNIT $side_number $type $casters[$i].x $casters[$i].y}
+                                {GENERIC_UNIT_PASSABLE $side_number $type $casters[$i].x $casters[$i].y}
                                 [+unit]
                                     animate=yes
                                     moves=0

--- a/spinoffs/The_Beautiful_Child/units/Bringer_of_Light2.cfg
+++ b/spinoffs/The_Beautiful_Child/units/Bringer_of_Light2.cfg
@@ -476,7 +476,7 @@
                                     moves=0
                                     attacks_left=0
                                     [modifications]
-                                        [advance]
+                                        [advancement]
                                             id=dazzle_effect
                                             [effect]
                                                 apply_to=attack
@@ -484,7 +484,7 @@
                                                     {DAZZLE_COUNTER}
                                                 [/set_specials]
                                             [/effect]
-                                        [/advance]
+                                        [/advancement]
                                     [/modifications]
                                 [/unit]
                                 {VARIABLE_OP count add 1}

--- a/spinoffs/The_Beautiful_Child/units/Bringer_of_Light2.cfg
+++ b/spinoffs/The_Beautiful_Child/units/Bringer_of_Light2.cfg
@@ -1,21 +1,4 @@
 #textdomain wesnoth-tbc
-#define DAZZLE_COUNTER
-    [chance_to_hit]
-        id=dazzle_counter
-        value=30
-        apply_to=opponent
-        [filter_base_value]
-            greater_than=30
-        [/filter_base_value]
-        [filter_opponent]
-            [filter_wml]
-                [variables]
-                    dazzled=yes
-                [/variables]
-            [/filter_wml]
-        [/filter_opponent]
-    [/chance_to_hit]
-#enddef
 [unit_type]
     id=Bringer of Light2
     name= _ "Bringer of Light"
@@ -165,7 +148,7 @@
         icon=attacks/mace-spiked.png
         attack_weight=0
         [specials]
-            {DAZZLE_COUNTER}
+            {BLIND_COUNTER}
         [/specials]
     [/attack]
     [attack]
@@ -177,7 +160,7 @@
         [specials]
             {WEAPON_SPECIAL_MAGICAL}
             {WEAPON_SPECIAL_SLOW}
-            {DAZZLE_COUNTER}
+            {BLIND_COUNTER}
         [/specials]
         damage=8
         number=4
@@ -488,11 +471,11 @@
                                     attacks_left=0
                                     [modifications]
                                         [advancement]
-                                            id=dazzle_effect
+                                            id=blind_effect
                                             [effect]
                                                 apply_to=attack
                                                 [set_specials]
-                                                    {DAZZLE_COUNTER}
+                                                    {BLIND_COUNTER}
                                                 [/set_specials]
                                             [/effect]
                                         [/advancement]
@@ -533,7 +516,7 @@
                             array=targets
                             variable=t
                             [do]
-                                {VARIABLE targets[$t].variables.dazzled yes}
+                                {VARIABLE targets[$t].variables.blinded yes}
                                 [unstore_unit]
                                     variable=targets[$t]
                                     find_vacant=no
@@ -550,14 +533,14 @@
                                         [filter]
                                             id=$targets[$t].id
                                         [/filter]
-                                        variable=undazzled
+                                        variable=blinded
                                     [/store_unit]
-                                    {CLEAR_VARIABLE undazzled.variables.dazzled}
+                                    {CLEAR_VARIABLE targets[$t].variables.blinded}
                                     [unstore_unit]
-                                        variable=undazzled
+                                        variable=blinded
                                         find_vacant=no
                                     [/unstore_unit]
-                                    {CLEAR_VARIABLE undazzled}
+                                    {CLEAR_VARIABLE blinded}
                                 [/event]
                             [/do]
                         [/for]
@@ -575,4 +558,3 @@
         {CLEAR_VARIABLE casters,spell}
     [/event]
 [/unit_type]
-#undef DAZZLE_COUNTER

--- a/spinoffs/The_Beautiful_Child/units/Bringer_of_Light2.cfg
+++ b/spinoffs/The_Beautiful_Child/units/Bringer_of_Light2.cfg
@@ -535,7 +535,7 @@
                                         [/filter]
                                         variable=blinded
                                     [/store_unit]
-                                    {CLEAR_VARIABLE targets[$t].variables.blinded}
+                                    {CLEAR_VARIABLE blinded.variables.blinded}
                                     [unstore_unit]
                                         variable=blinded
                                         find_vacant=no

--- a/spinoffs/The_Beautiful_Child/units/Bringer_of_Light3.cfg
+++ b/spinoffs/The_Beautiful_Child/units/Bringer_of_Light3.cfg
@@ -59,23 +59,7 @@
     {LIGHTNING_FRAME missile10 3 15 -70}
     {LIGHTNING_FRAME missile11 1 25 -25}
 #enddef
-#define DAZZLE_COUNTER
-    [chance_to_hit]
-        id=dazzle_counter
-        value=30
-        apply_to=opponent
-        [filter_base_value]
-            greater_than=30
-        [/filter_base_value]
-        [filter_opponent]
-            [filter_wml]
-                [variables]
-                    dazzled=yes
-                [/variables]
-            [/filter_wml]
-        [/filter_opponent]
-    [/chance_to_hit]
-#enddef
+{BLIND_COUNTER}
 [unit_type]
     id=Bringer of Light3
     name= _ "Bringer of Light"
@@ -225,7 +209,7 @@
         icon=attacks/mace-spiked.png
         attack_weight=0
         [specials]
-            {DAZZLE_COUNTER}
+            {BLIND_COUNTER}
         [/specials]
     [/attack]
     [attack]
@@ -236,7 +220,7 @@
         range=ranged
         [specials]
             {WEAPON_SPECIAL_MAGICAL}
-            {DAZZLE_COUNTER}
+            {BLIND_COUNTER}
         [/specials]
         damage=12
         number=4
@@ -610,62 +594,63 @@
                             variable=targets
                             kill=no
                         [/store_unit]
-                        {FOREACH targets i}
-                            [for]
-                                array=targets
-                                variable=t
-                                [do]
-                                    {EARTHQUAKE (
-                                        [terrain]
-                                            x,y=$targets[$t].x,$targets[$t].y
-                                            terrain=Qxu
-                                        [/terrain]
-                                        {VARIABLE target_x $targets[$t].x}
-                                        {VARIABLE_OP target_x sub 18}
-                                        [teleport]
-                                            [filter]
-                                                id=$targets[$t].id
-                                            [/filter]
-                                            x,y=$target_x,$targets[$t].y
-                                        [/teleport]
-                                        [terrain]
-                                            x,y=$target_x,$targets[$t].y
-                                            terrain=Iwr^Dr
-                                        [/terrain]
-                                    )}
-                                    [harm_unit]
+                        [for]
+                            array=targets
+                            variable=t
+                            [do]
+                                {EARTHQUAKE (
+                                    [terrain]
+                                        x,y=$targets[$t].x,$targets[$t].y
+                                        terrain=Qxu
+                                    [/terrain]
+                                    {VARIABLE target_x $targets[$t].x}
+                                    {VARIABLE_OP target_x sub 18}
+                                    [teleport]
                                         [filter]
-                                            x,y=$target_x,$targets[$t].y
+                                            id=$targets[$t].id
                                         [/filter]
-                                        amount=32
-                                        damage_type=impact
-                                        kill=yes
-                                        fire_event=yes
-                                    [/harm_unit]
-                                    {CLEAR_VARIABLE target_x}
-                                [/do]
-                            [/for]
-                            {CLEAR_VARIABLE targets}
-                        [/case]
-                    [/switch]
-                    [fire_event]
-                        name=spellcast
-                        [primary_unit]
-                            id=$casters[$i]
-                        [/primary_unit]
-                    [/fire_event]
-                [/do]
-            [/for]
-            {CLEAR_VARIABLE casters,spell}
-        [/event]
-        [event]
-            name=turn_refresh
-            first_time_only=no
-            [store_side]
-                side=$side_number
-                variable=this_side
-            [/store_side]
-            {FOREACH cleansing_rain i}
+                                        x,y=$target_x,$targets[$t].y
+                                    [/teleport]
+                                    [terrain]
+                                        x,y=$target_x,$targets[$t].y
+                                        terrain=Iwr^Dr
+                                    [/terrain]
+                                )}
+                                [harm_unit]
+                                    [filter]
+                                        x,y=$target_x,$targets[$t].y
+                                    [/filter]
+                                    amount=32
+                                    damage_type=impact
+                                    kill=yes
+                                    fire_event=yes
+                                [/harm_unit]
+                                {CLEAR_VARIABLE target_x}
+                            [/do]
+                        [/for]
+                        {CLEAR_VARIABLE targets}
+                    [/case]
+                [/switch]
+                [fire_event]
+                    name=spellcast
+                    [primary_unit]
+                        id=$casters[$i]
+                    [/primary_unit]
+                [/fire_event]
+            [/do]
+        [/for]
+        {CLEAR_VARIABLE casters,spell}
+    [/event]
+    [event]
+        name=turn_refresh
+        first_time_only=no
+        [store_side]
+            side=$side_number
+            variable=this_side
+        [/store_side]
+        [foreach]
+            array=cleansing_rain
+            [do]
                 [store_side]
                     side=$cleansing_rain[$i].side
                     variable=rain_side
@@ -692,11 +677,10 @@
                 [/if]
                 {CLEAR_VARIABLE rain_side}
             [/do]
-        [/for]
+        [/foreach]
         {CLEAR_VARIABLE this_side}
     [/event]
 [/unit_type]
-#undef DAZZLE_COUNTER
 #undef MISSILE_FRAME_LIGHTNING_STORM
 #undef LIGHTNING_FRAME
 #undef LIGHTNING_FRAME_INIT

--- a/spinoffs/The_Beautiful_Child/units/Shuja.cfg
+++ b/spinoffs/The_Beautiful_Child/units/Shuja.cfg
@@ -7,42 +7,42 @@
     hitpoints=70
     movement_type=smallfoot
     [movement_costs]
-            shallow_water=3
-            reef=2
-            swamp_water=3
-            flat=1
-            sand=1
-            forest=2
-            hills=2
-            mountains=3
-            village=1
-            castle=1
-            cave=2
-            frozen=3
-            fungus=2
+        shallow_water=3
+        reef=2
+        swamp_water=3
+        flat=1
+        sand=1
+        forest=2
+        hills=2
+        mountains=3
+        village=1
+        castle=1
+        cave=2
+        frozen=3
+        fungus=2
     [/movement_costs]
     [defense]
-            shallow_water=80
-            reef=70
-            swamp_water=70
-            flat=60
-            sand=50
-            forest=60
-            hills=40
-            mountains=60
-            village=50
-            castle=40
-            cave=60
-            frozen=80
-            fungus=60
+        shallow_water=80
+        reef=70
+        swamp_water=70
+        flat=60
+        sand=50
+        forest=60
+        hills=40
+        mountains=60
+        village=50
+        castle=40
+        cave=60
+        frozen=80
+        fungus=60
     [/defense]
     [resistance]
-            blade=80
-            pierce=80
-            impact=110
-            fire=100
-            cold=100
-            arcane=80
+        blade=80
+        pierce=80
+        impact=110
+        fire=100
+        cold=100
+        arcane=80
     [/resistance]
     movement=5
     {QUANTITY experience 120 140 160}
@@ -362,4 +362,5 @@
             [/effect]
         [/advancement]
     ) "Shuja tbc"}
+[/unit_type]
 # wmlxgettext: [/unit_type]

--- a/spinoffs/The_Beautiful_Child/utils/utils.cfg
+++ b/spinoffs/The_Beautiful_Child/utils/utils.cfg
@@ -1,4 +1,4 @@
-#textdomain wesnth-tbc
+#textdomain wesnoth-tbc
 #define TBC_GLOBAL_EVENTS_RPG
 
     {DROPS 20 20 (axe,axe,staff,sword,sword,knife,bow,xbow,spear,spear,bow,dagger,mace) no 2,3,4,5,6,7,8}
@@ -61,16 +61,16 @@
 #enddef
 
 #define TBC_RECALL_ALL X Y
-    [foreach]
+    [for]
         array=party_members
         [do]
             [recall]
-                id=$this_item.id
+                id=$party_members[$i].id
                 x,y={X},{Y}
                 show=no
             [/recall]
         [/do]
-    [/foreach]
+    [/for]
 #enddef
 
 #define TBC_ORIGIN PREVIOUS X Y
@@ -194,7 +194,7 @@
         [/variable]
         [do]
             {VARIABLE_OP unit_type rand {TYPES}}
-            {GENERIC_UNIT {SIDE} $unit_type {X} {Y}}
+            {GENERIC_UNIT_PASSABLE {SIDE} $unit_type {X} {Y}}
             {VARIABLE_OP quantity sub 1}
         [/do]
     [/while]

--- a/spinoffs/The_Beautiful_Child/utils/utils.cfg
+++ b/spinoffs/The_Beautiful_Child/utils/utils.cfg
@@ -275,3 +275,21 @@
         animate=no
     [/kill]
 #enddef
+
+#define BLIND_COUNTER
+    [chance_to_hit]
+        id=blind_counter
+        value=30
+        apply_to=opponent
+        [filter_base_value]
+            greater_than=30
+        [/filter_base_value]
+        [filter_opponent]
+            [filter_wml]
+                [variables]
+                    blinded=yes
+                [/variables]
+            [/filter_wml]
+        [/filter_opponent]
+    [/chance_to_hit]
+#enddef

--- a/utils/utils.cfg
+++ b/utils/utils.cfg
@@ -1707,20 +1707,11 @@ $item_info.description"
 
 #define  MOVE_SIDE_TO SIDE X Y
     # Move all units on SIDE to X,Y
-    [store_unit]
-        [filter]
-            side={SIDE}
-        [/filter]
-        kill=no
-        variable=movement_store
-    [/store_unit]
-    [for]
-        array=movement_store
-        [do]
-            {MOVE_UNIT x,y=$movement_store[$i].x,$movement_store[$i].y {X} {Y} }
-        [/do]
-    [/for]
-    {CLEAR_VARIABLE movement_store}
+    [move_unit]
+         side={SIDE}
+         to_x={X}
+         to_y={Y}
+    [/move_unit]
 #enddef
 
 #define TELEPORT_TO_LEADER_MENU LEADER EASY NORMAL HARD


### PR DESCRIPTION
Change advance -> advancement

In Crooked Ravine:
    - Remove she_brother from brothers_store when killed/defected
    - Make most of brothers appearance dialog one time only
    - rename quest variable for consistency
    
Limit main character to one legacy (was two)

Add Konrad II to your party when found

One of the mercs was missing payment when recruited

In Fertile Lands, units killed by secondary effect like that from shockwave interrogate themself, skip that

In Valley Passage, after killing Luke, units that couldn't traverse mountains couldn't traverse mountains.

In final scenario, enemies may block stairway (specifically, if you enter the final room and then leave, they will just keep spawning new units, which does not honor the [ai][avoid]), blocking you from re-entering room.
    - Added [avoid], may not be needed
    - Added turn end event so that units spawned on top of stairs (and leader may move there ignoring avoid, probably trying to get to a keep -- should that tile be a keep?) will move.
    - This works until enemy has 50 or so units in room7.  Changed BoL2 to only cast spells when side 1 is visible.  They still recruit, which will probably block the stairs at some point, but it's only 1 unit per turn.  Could/should move the keeps.

"error wml: [unstore_unit]: variable 'undazzled' doesn't exist" - might be debug-only
    - changed dazzle to blind.  untested other than it loads

TODO:
warning wml: Couldn't find right animation for unit player  (he's a Duke)

info deprecation: [set_specials]mode=<unset> has been deprecated indefinitely.; The mode defaults to 'replace', but should often be 'append' instead. The default may change in a future version, or the attribute may become mandatory.

Balancing:  Playing on normal, I find this super hard at first (I have to constantly run away using obelisk until I get enough advancement to fight).  Then by about Fertile Lands I could probably just about walk through with 3 units (I suppose it's fun for people who just want to collect tons of items and explore AMLAs), and the merchants before the final scenario are completely unnecessary.  Also, I'm not sure there's much difference in levels.  Thoughts:
  - Change the  drop frequency by difficulty (and turn it down by at least 25% on normal, likely a lot more)
  - When you fight Luke, he gets crippled if your party is "small".  Either don't do that on hard, or change the limits.
  - Gold starts off pretty hard to get (which is okay, not much to spend it on other than a couple scenarios where you need fodder), but by the middle I've got >1500 more than I'll ever need.




