### PR TITLE
Update 44_Gathering_Alcove.cfg

### DIFF
--- a/scenarios9/44_Gathering_Alcove.cfg
+++ b/scenarios9/44_Gathering_Alcove.cfg
@@ -438,7 +438,7 @@
                         [do]
                             {VARIABLE_OP spawn_type rand (Demon Manowar,Demon Warrior,Demon Overlord)}
                             {GENERIC_UNIT 8 $spawn_type 33 16}
-                            {GENERIC_UNIT 8 $spawn_type 51 17}
+                            {GENERIC_UNIT 8 $spawn_type 45 12}
                             {GENERIC_UNIT 8 $spawn_type 48 33}
                             {VARIABLE_OP spawn_count sub 1}
                         [/do]


### PR DESCRIPTION
One of the spawn points for Romero's ambush is at an exit that can randomly blocked. Half the time, 1/3 of the ambush is trapped and irrelevant. This moves that spawn point slightly north and west so it is outside randomly blocking walls.