### PR TITLE
AE

### DIFF
--- a/spinoffs/Affably_Evil/scenarios/01_Incarcerating.cfg
+++ b/spinoffs/Affably_Evil/scenarios/01_Incarcerating.cfg
@@ -12,9 +12,9 @@
     [side]
         type=Krux_father
         id=Krux
-    name=_"Krux"
+        name=_"Krux"
         canrecruit=yes
-    unrenamable=yes
+        unrenamable=yes
         side=1
         controller=human
         recruit=Spearman,Bowman,Heavy Infantryman
@@ -24,212 +24,212 @@
         user_team_name=_"House de Rais"
         shroud=yes
         fog=no
-    [modifications]
-        [trait]
-        id=affable
-        male_name= _ "affable"
-        female_name= _ "female^affable"
-            description= _ "Nearby allies deal 10% more damage"
-        [effect]
-            apply_to=new_ability
-            [abilities]
-                {ABILITY_EXTRA_DAMAGE_AURA _"affability" 10}
-            [/abilities]
-        [/effect]
-        [/trait]
-        [trait]
-        id=evil
-        male_name= _ "evil"
-        female_name= _ "female^evil"
-            description= _ "Does 25% more damage at night"
-        [effect]
-            apply_to=attack
-            [set_specials]
-                mode=append
-                [damage]
+        [modifications]
+            [trait]
+                id=affable
+                male_name= _ "affable"
+                female_name= _ "female^affable"
+                description= _ "Nearby allies deal 10% more damage"
+                [effect]
+                    apply_to=new_ability
+                    [abilities]
+                        {ABILITY_EXTRA_DAMAGE_AURA _"affability" 10}
+                    [/abilities]
+                [/effect]
+            [/trait]
+            [trait]
                 id=evil
-                name= _ "evil"
-                description= _ "This attack is 25% better at night."
-                multiply=1.25
-                [filter_self]
-                    [filter_location]
-                    time_of_day=chaotic
-                    [/filter_location]
-                [/filter_self]
-                [/damage]
-            [/set_specials]
-        [/effect]
-        [/trait]
-        [advancement]
-        id=awareness
-        [/advancement]
-        [advancement]
-        id=disabled_legacy
-        [/advancement]
-    [/modifications]
-    [variables]
-        hero=yes
-        player=yes
-    [/variables]
-    [unit]
-        id=Acanthamoeba
-        type=Acanthamoeba
-        name=_"Acantha"
-        unrenamable=yes
-        x,y=38,4
-        canrecruit=yes
-        [modifications]
-            [trait]
-            id=sly
-            male_name= _ "sly"
-            female_name= _ "female^sly"
-            [effect]
-                apply_to=max_experience
-                increase=-10%
-            [/effect]
+                male_name= _ "evil"
+                female_name= _ "female^evil"
+                description= _ "Does 25% more damage at night"
+                [effect]
+                    apply_to=attack
+                    [set_specials]
+                        mode=append
+                        [damage]
+                            id=evil
+                            name= _ "evil"
+                            description= _ "This attack is 25% better at night."
+                            multiply=1.25
+                            [filter_self]
+                                [filter_location]
+                                    time_of_day=chaotic
+                                [/filter_location]
+                            [/filter_self]
+                        [/damage]
+                    [/set_specials]
+                [/effect]
             [/trait]
-            [trait]
-            id=healthy
-            male_name= _ "lazy"
-            female_name= _ "female^lazy"
-                description= _ "Always rest heals"
-                generate_description=false
-            [/trait]
+            [advancement]
+                id=awareness
+            [/advancement]
+            [advancement]
+                id=disabled_legacy
+            [/advancement]
         [/modifications]
         [variables]
             hero=yes
+            player=yes
         [/variables]
-    [/unit]
-    [unit]
-        id=Antipos
-        type=White Mage
-        name=_"Antipater the Empyrean"
-        unrenamable=yes
-        x,y=36,4
-        canrecruit=yes
-        [modifications]
-            [trait]
-            id=greedy
-            male_name= _ "greedy"
-            female_name= _ "female^greedy"
-                description= _ "Has a chance to steal some gold when attacking"
-                generate_description=false
-            [effect]
-                apply_to=new_ability
-                [abilities]
-                {ABILITY_STEALS}
-                [/abilities]
-            [/effect]
-            [/trait]
-            {TRAIT_INTELLIGENT}
-            [object]
-            [effect]
-                [filter]
-                    [not]
-                        type=Abomination
-                    [/not]
-                [/filter]
-                apply_to=profile
-                portrait=portraits/Antipater.png
-            [/effect]
-            [/object]
-        [/modifications]
-        [variables]
-            hero=yes
-        [/variables]
-    [/unit]
-    [unit]
-        id=Judas
-        type=Swordsman
-        name=_"Judas the Mole"
-        unrenamable=yes
-        x,y=37,5
-        canrecruit=yes
-        [modifications]
-            {TRAIT_LOYAL}
-            [trait]
-            id=suspicious
-            male_name= _ "suspicious"
-            female_name= _ "female^suspicious"
-                description= _ "Heals, moves faster in caves"
-                generate_description=false
-            [effect]
-                apply_to=new_ability
-                [abilities]
-                {ABILITY_CURES}
-                [/abilities]
-            [/effect]
-            [effect]
-                apply_to=movement_costs
-                replace=true
-                [movement_costs]
-                cave=1
-                fungus=1
-                [/movement_costs]
-            [/effect]
-            [/trait]
-            [object]
-            [effect]
-                apply_to=profile
-                portrait=portraits/humans/transparent/swordsman-3.png
-            [/effect]
-            [/object]
-        [/modifications]
-        [variables]
-            hero=yes
-        [/variables]
-    [/unit]
+        [unit]
+            id=Acanthamoeba
+            type=Acanthamoeba
+            name=_"Acantha"
+            unrenamable=yes
+            x,y=38,4
+            canrecruit=yes
+            [modifications]
+                [trait]
+                    id=sly
+                    male_name= _ "sly"
+                    female_name= _ "female^sly"
+                    [effect]
+                        apply_to=max_experience
+                        increase=-10%
+                    [/effect]
+                [/trait]
+                [trait]
+                    id=healthy
+                    male_name= _ "lazy"
+                    female_name= _ "female^lazy"
+                    description= _ "Always rest heals"
+                    generate_description=false
+                [/trait]
+            [/modifications]
+            [variables]
+                hero=yes
+            [/variables]
+        [/unit]
+        [unit]
+            id=Antipos
+            type=White Mage
+            name=_"Antipater the Empyrean"
+            unrenamable=yes
+            x,y=36,4
+            canrecruit=yes
+            [modifications]
+                [trait]
+                    id=greedy
+                    male_name= _ "greedy"
+                    female_name= _ "female^greedy"
+                    description= _ "Has a chance to steal some gold when attacking"
+                    generate_description=false
+                    [effect]
+                        apply_to=new_ability
+                        [abilities]
+                            {ABILITY_STEALS}
+                        [/abilities]
+                    [/effect]
+                [/trait]
+                {TRAIT_INTELLIGENT}
+                [object]
+                    [effect]
+                        [filter]
+                            [not]
+                                type=Abomination
+                            [/not]
+                        [/filter]
+                        apply_to=profile
+                        portrait=portraits/Antipater.png
+                    [/effect]
+                [/object]
+            [/modifications]
+            [variables]
+                hero=yes
+            [/variables]
+        [/unit]
+        [unit]
+            id=Judas
+            type=Swordsman
+            name=_"Judas the Mole"
+            unrenamable=yes
+            x,y=37,5
+            canrecruit=yes
+            [modifications]
+                {TRAIT_LOYAL}
+                [trait]
+                    id=suspicious
+                    male_name= _ "suspicious"
+                    female_name= _ "female^suspicious"
+                    description= _ "Heals, moves faster in caves"
+                    generate_description=false
+                    [effect]
+                        apply_to=new_ability
+                        [abilities]
+                            {ABILITY_CURES}
+                        [/abilities]
+                    [/effect]
+                    [effect]
+                        apply_to=movement_costs
+                        replace=true
+                        [movement_costs]
+                            cave=1
+                            fungus=1
+                        [/movement_costs]
+                    [/effect]
+                [/trait]
+                [object]
+                    [effect]
+                        apply_to=profile
+                        portrait=portraits/humans/transparent/swordsman-3.png
+                    [/effect]
+                [/object]
+            [/modifications]
+            [variables]
+                hero=yes
+            [/variables]
+        [/unit]
     [/side]
     [side]
         type=Peasant
-    id=ally
-    canrecruit=yes
-    generate_name=yes
+        id=ally
+        canrecruit=yes
+        generate_name=yes
         side=2
         team_name=house_de_rais
         user_team_name=_"House de Rais"
-    {GOLD 30 45 55}
-    income=15
-    village_gold=3
-    recruit=Peasant,Woodsman
+        {GOLD 30 45 55}
+        income=15
+        village_gold=3
+        recruit=Peasant,Woodsman
     [/side]
     [side]
         type=Bandit
-    id=enemy
-    canrecruit=yes
-    generate_name=yes
+        id=enemy
+        canrecruit=yes
+        generate_name=yes
         side=3
         team_name=anarchy
         user_team_name=_"Anarchy"
-    {GOLD 20 25 35}
-    village_gold=3
-    recruit=Thug,Poacher,Thief,Footpad
+        {GOLD 20 25 35}
+        village_gold=3
+        recruit=Thug,Poacher,Thief,Footpad
     [/side]
     [side]
         type=Rogue
-    id=enemy2
-    canrecruit=yes
-    generate_name=yes
+        id=enemy2
+        canrecruit=yes
+        generate_name=yes
         side=4
         team_name=anarchy
         user_team_name=_"Anarchy"
-    gold=0
-    {INCOME 15 20 25}
-    village_gold=3
-    recruit=Thug,Poacher,Thief,Footpad
+        gold=0
+        {INCOME 15 20 25}
+        village_gold=3
+        recruit=Thug,Poacher,Thief,Footpad
     [/side]
     [side]
         type=Highwayman
-    id=enemy3
-    canrecruit=yes
-    generate_name=yes
+        id=enemy3
+        canrecruit=yes
+        generate_name=yes
         side=5
         team_name=anarchy
         user_team_name=_"Anarchy"
-    gold=0
-    {INCOME 15 20 25}
-    village_gold=3
-    recruit=Thug,Poacher,Thief,Footpad
+        gold=0
+        {INCOME 15 20 25}
+        village_gold=3
+        recruit=Thug,Poacher,Thief,Footpad
     [/side]
 
     [event]
@@ -244,18 +244,26 @@
                 description= _ "Death of Krux, Acanthamoeba or Antipater"
                 condition=lose
             [/objective]
-        note=_"If an enemy has 4 health or less, he can be locked in prison by selecting the right-click option, earning 10 gold."
+#ifdef EASY
+            note=_"If an enemy has 4 health or less, he can be locked in prison by selecting the right-click option, earning 10 gold."
+#endif
+#ifdef NORMAL
+            note=_"If an enemy has 6 health or less, he can be locked in prison by selecting the right-click option, earning 10 gold."
+#endif
+#ifdef HARD
+            note=_"If an enemy has 8 health or less, he can be locked in prison by selecting the right-click option, earning 10 gold."
+#endif
         [/objectives]
-    {VARIABLE cash 100}
+        {VARIABLE cash 100}
     [/event]
 
     [event]
         name=start
         {CAPTURE_VILLAGES 2 20 17 15}
-    [remove_shroud]
-        side=1
-        x,y=18-45,0-19
-    [/remove_shroud]
+        [remove_shroud]
+            side=1
+            x,y=18-45,0-19
+        [/remove_shroud]
         [message]
             speaker=Krux
             message=_"We are here, my friends. It is time to save this beautiful village from bandits."
@@ -279,72 +287,72 @@
         [repeating_message]
             speaker=Antipos
             first=_"Do you see a way to get more money from it?"
-        message=_"Any other ideas?"
-        [option]
-        message=_"We might hire them as mercenaries."
-        [command]
-            [message]
-                speaker=Antipos
-                message=_"I fear that their hatred towards your family is too strong for that. Would you mind being hired by somebody who ruined your life before, Judas?"
-            [/message]
-            [message]
-                speaker=Judas
-                message=_"No, but as far as I know, most mercenaries would."
-            [/message]
-        [/command]
-        [/option]
-        [option]
-        message=_"How about paying a necromancer to slaughter them?"
-        [command]
-            [message]
-                speaker=Antipos
-                message=_"That would connect us with necromancy. Rumours about necromantic overlords would spread and that is not quite what you want."
-            [/message]
-        [/command]
-        [/option]
-        [option]
-        message=_"We might have my sister marry their leader and redirect them against our other enemies or subvert them."
-        [command]
-            [message]
-                speaker=Acanthamoeba
-                message=_"No! I am getting convinced that you are <i>mocking</i> me with suggestions like this."
-            [/message]
-            [message]
-                speaker=Krux
-                message=_"Living as a spy and outlaw at the same time has so much romance in it, so much adventure. I would like living like that, but, unfortunately, it is very rare that a bandit leader is a woman. And even more rare that it is a pretty one. So I can only envy you."
-            [/message]
-            [message]
-                speaker=Acanthamoeba
-                message=_"I do not see it like you."
-            [/message]
-            [message]
-                speaker=Krux
-                message=_"Fine, fine. It is my moral obligation not to go against your will."
-            [/message]
-        [/command]
-        [/option]
-        [option]
-        message=_"No."
-        [command]
-            [message]
-                speaker=Antipos
-                message=_"That is a pity."
-            [/message]
-            [break]
-            [/break]
-        [/command]
-        [/option]
+            message=_"Any other ideas?"
+            [option]
+                message=_"We might hire them as mercenaries."
+                [command]
+                    [message]
+                        speaker=Antipos
+                        message=_"I fear that their hatred towards your family is too strong for that. Would you mind being hired by somebody who ruined your life before, Judas?"
+                    [/message]
+                    [message]
+                        speaker=Judas
+                        message=_"No, but as far as I know, most mercenaries would."
+                    [/message]
+                [/command]
+            [/option]
+            [option]
+                message=_"How about paying a necromancer to slaughter them?"
+                [command]
+                    [message]
+                        speaker=Antipos
+                        message=_"That would connect us with necromancy. Rumours about necromantic overlords would spread and that is not quite what you want."
+                    [/message]
+                [/command]
+            [/option]
+            [option]
+                message=_"We might have my sister marry their leader and redirect them against our other enemies or subvert them."
+                [command]
+                    [message]
+                        speaker=Acanthamoeba
+                        message=_"No! I am getting convinced that you are <i>mocking</i> me with suggestions like this."
+                    [/message]
+                    [message]
+                        speaker=Krux
+                        message=_"Living as a spy and outlaw at the same time has so much romance in it, so much adventure. I would like living like that, but, unfortunately, it is very rare that a bandit leader is a woman. And even more rare that it is a pretty one. So I can only envy you."
+                    [/message]
+                    [message]
+                        speaker=Acanthamoeba
+                        message=_"I do not see it like you."
+                    [/message]
+                    [message]
+                        speaker=Krux
+                        message=_"Fine, fine. It is my moral obligation not to go against your will."
+                    [/message]
+                [/command]
+            [/option]
+            [option]
+                message=_"No."
+                [command]
+                    [message]
+                        speaker=Antipos
+                        message=_"That is a pity."
+                    [/message]
+                    [break]
+                    [/break]
+                [/command]
+            [/option]
         [/repeating_message]
         [message]
             speaker=Krux
             message=_"It is time to say hello to our new friends."
         [/message]
-    [move_unit]
-        id=ally
-        to_x=36
-        to_y=7
-        fire_event=no
-    [/move_unit]
+        [move_unit]
+            id=ally
+            to_x=36
+            to_y=7
+            fire_event=no
+        [/move_unit]
         [message]
             speaker=ally
             message=_"Oh, are you Krux de Rais or are my eyes getting old?"
@@ -365,103 +373,103 @@
             speaker=Krux
             message=_"My dear Judas, I am asking you to stop calling good, working and loyal people with ugly words just because their fighting skill is inferior to yours. You are not talking to a goblin. Now, good man, I would like to reassure you that we are here to deal with the bandits, not to take any taxes by force."
         [/message]
-    [message]
-        speaker=Antipos
-        message=_"I am bored. Let us proceed to the main thing. What can you tell us about these bandits?"
-    [/message]
+        [message]
+            speaker=Antipos
+            message=_"I am bored. Let us proceed to the main thing. What can you tell us about these bandits?"
+        [/message]
         [repeating_message]
             speaker=ally
             first=_"What would you like to know?"
-        message=_"Anything else?"
-        [option]
-        message=_"Where are these bandits?"
-        [command]
-            [message]
-                speaker=ally
-                message=_"Everywhere around. You have probably defeated those who were northeast from here, they surely tried to ambush you. So most of them should be southwest from here now."
-            [/message]
-            [message]
-                speaker=Antipos
-                message=_"They might be hiding in the village, preparing to ambush us. Do you really trust that man?"
-            [/message]
-            [message]
-                speaker=Krux
-                message=_"I profoundly hate to say that, but I trust no one. Except my parents, sister and maybe you. I always count with the possibility that somebody lied. However, it is still better to listen to a <i>possible lie</i> than nothing at all."
-            [/message]
-            [message]
-                speaker=Acanthamoeba
-                message=_"Nice to hear from you that I am on your brief list of trustful people."
-            [/message]
-            [message]
-                speaker=Krux
-                message=_"Am I on yours?"
-            [/message]
-            [message]
-                speaker=Acanthamoeba
-                message=_"I will not tell."
-            [/message]
-        [/command]
-        [/option]
-        [option]
-        message=_"What are these bandits doing?"
-        [command]
-            [message]
-                speaker=ally
-                message=_"They are mostly slacking. They earn for living by stealing from us and ambushing travellers. Many of our men joined them thanks to their honeyed words. They call themselves rebels. They speak about a noble plan to dethrone you and spread all kinds of ill words about your family to paint you as the villain."
-            [/message]
-            [message]
-                speaker=Krux
-                message=_"I always thought that our reputation is so bad that it cannot become worse. It is incredible how many people see me as a villain. <i>Me. Villain.</i>"
-            [/message]
-            [message]
-                speaker=ally
-                message=_"They say that you are wearing a friendly façade to seduce women. They say that you are working hard to increase the quantity of the tyrants' kin. Rumours tell that you have fathered a thousand children already and hundreds more are going to be born."
-            [/message]
-            [message]
-                speaker=Acanthamoeba
-                message=_"Do you believe that there were rumours about me having summoned a demon and being pregnant with him?"
-            [/message]
-            [message]
-                speaker=Krux
-                message=_"False rumours have always been a good tool to manipulate people. Somebody tells that I slaughter newborns with a two handed sword, mash their insides into a bloody goo that I pour over the fields and there will be people believing it. Completely missing the problem that even if I was <i>so</i> evil, I would have no reason to do that. It would be completely useless, just decreasing the quantity of tax payers and making new enemies. Rumours are the serpent's way of fighting. A tool to portray somebody as a foul villain."
-            [/message]
-            [message]
-                speaker=ally
-                message=_"Your words are true, mylord. Most of their claims cannot be proven and I fail to understand why would you do that even if you were totally evil. They have gone so far that they renamed our village to Libreborough, so that it would seem that we are free. But we are not, instead of paying taxes, we are robbed, beaten and our property is taken without any order."
-            [/message]
-            [message]
-                speaker=Krux
-                message=_"I see that you understand why we demand taxes. We need to control banditry, and banditry would certainly occur without our care. Here, it seems to have gone too far and we should have reacted earlier."
-            [/message]
-        [/command]
-        [/option]
-        [option]
-        message=_"Will you help us?"
-        [command]
-            [message]
-                speaker=ally
-                message=_"Yes, but not much. We cannot help much. They are better at fighting, they occasionally practice."
-            [/message]
-            [message]
-                speaker=Krux
-                message=_"Thank you even for the little help you can offer."
-            [/message]
-        [/command]
-        [/option]
-        [option]
-        message=_"Thanks. That is all that I wanted to know."
-        [command]
-            [break]
-            [/break]
-        [/command]
-        [/option]
+            message=_"Anything else?"
+            [option]
+                message=_"Where are these bandits?"
+                [command]
+                    [message]
+                        speaker=ally
+                        message=_"Everywhere around. You have probably defeated those who were northeast from here, they surely tried to ambush you. So most of them should be southwest from here now."
+                    [/message]
+                    [message]
+                        speaker=Antipos
+                        message=_"They might be hiding in the village, preparing to ambush us. Do you really trust that man?"
+                    [/message]
+                    [message]
+                        speaker=Krux
+                        message=_"I profoundly hate to say that, but I trust no one. Except my parents, sister and maybe you. I always count with the possibility that somebody lied. However, it is still better to listen to a <i>possible lie</i> than nothing at all."
+                    [/message]
+                    [message]
+                        speaker=Acanthamoeba
+                        message=_"Nice to hear from you that I am on your brief list of trustful people."
+                    [/message]
+                    [message]
+                        speaker=Krux
+                        message=_"Am I on yours?"
+                    [/message]
+                    [message]
+                        speaker=Acanthamoeba
+                        message=_"I will not tell."
+                    [/message]
+                [/command]
+            [/option]
+            [option]
+                message=_"What are these bandits doing?"
+                [command]
+                    [message]
+                        speaker=ally
+                        message=_"They are mostly slacking. They earn for living by stealing from us and ambushing travellers. Many of our men joined them thanks to their honeyed words. They call themselves rebels. They speak about a noble plan to dethrone you and spread all kinds of ill words about your family to paint you as the villain."
+                    [/message]
+                    [message]
+                        speaker=Krux
+                        message=_"I always thought that our reputation is so bad that it cannot become worse. It is incredible how many people see me as a villain. <i>Me. Villain.</i>"
+                    [/message]
+                    [message]
+                        speaker=ally
+                        message=_"They say that you are wearing a friendly façade to seduce women. They say that you are working hard to increase the quantity of the tyrants' kin. Rumours tell that you have fathered a thousand children already and hundreds more are going to be born."
+                    [/message]
+                    [message]
+                        speaker=Acanthamoeba
+                        message=_"Do you believe that there were rumours about me having summoned a demon and being pregnant with him?"
+                    [/message]
+                    [message]
+                        speaker=Krux
+                        message=_"False rumours have always been a good tool to manipulate people. Somebody tells that I slaughter newborns with a two handed sword, mash their insides into a bloody goo that I pour over the fields and there will be people believing it. Completely missing the problem that even if I was <i>so</i> evil, I would have no reason to do that. It would be completely useless, just decreasing the quantity of tax payers and making new enemies. Rumours are the serpent's way of fighting. A tool to portray somebody as a foul villain."
+                    [/message]
+                    [message]
+                        speaker=ally
+                        message=_"Your words are true, mylord. Most of their claims cannot be proven and I fail to understand why would you do that even if you were totally evil. They have gone so far that they renamed our village to Libreborough, so that it would seem that we are free. But we are not, instead of paying taxes, we are robbed, beaten and our property is taken without any order."
+                    [/message]
+                    [message]
+                        speaker=Krux
+                        message=_"I see that you understand why we demand taxes. We need to control banditry, and banditry would certainly occur without our care. Here, it seems to have gone too far and we should have reacted earlier."
+                    [/message]
+                [/command]
+            [/option]
+            [option]
+                message=_"Will you help us?"
+                [command]
+                    [message]
+                        speaker=ally
+                        message=_"Yes, but not much. We cannot help much. They are better at fighting, they occasionally practice."
+                    [/message]
+                    [message]
+                        speaker=Krux
+                        message=_"Thank you even for the little help you can offer."
+                    [/message]
+                [/command]
+            [/option]
+            [option]
+                message=_"Thanks. That is all that I wanted to know."
+                [command]
+                    [break]
+                    [/break]
+                [/command]
+            [/option]
         [/repeating_message]
-    [move_unit]
-        id=ally
-        to_x=34
-        to_y=11
-        fire_event=no
-    [/move_unit]
+        [move_unit]
+            id=ally
+            to_x=34
+            to_y=11
+            fire_event=no
+        [/move_unit]
         [terrain]
             x,y=34,11
             terrain=Ke
@@ -503,99 +511,99 @@
         [repeating_message]
             speaker=enemy
             first=_"<i>You</i> are creating undead. What else would you need the bodies for? I suppose that all of you have heard of the occasional undead incursions."
-        message=_"You have not convinced me, tyrants!"
-        [option]
-        message=_"If we needed bodies, we would take them from graveyards."
-        [command]
-            [message]
-                speaker=Acanthamoeba
-                message=_"There are many abandoned burial grounds around. Many villages were burned and never rebuilt during wars with orcs and other invaders. Their dead are still buried there and if we wanted bodies, we might take those, without bringing any suspicion on us."
-            [/message]
-            [message]
-                speaker=Krux
-                message=_"I can assure you that imprisoning people is a very unwise way to collect bodies for necromancy."
-            [/message]
-            [message]
-                speaker=enemy
-                message=_"You know too much about necromancy somehow!"
-            [/message]
-            [message]
-                speaker=Antipos
-                message=_"Do you think that there is a way to reason with this man?"
-            [/message]
-        [/command]
-        [/option]
-        [option]
-        message=_"You are bandits, you plunder and kill. Is there a reason why should we not execute you? We can save many good people by killing you."
-        [command]
-            [message]
-                speaker=enemy
-                message=_"We are not mere bandits, we are an uprising to dethrone the tyrants and bring liberty to the people!"
-            [/message]
-            [message]
-                speaker=Acanthamoeba
-                message=_"Why do you assert that we are tyrants? Why do you think that it would be good to dethrone us? The villagers know what you do to the people that are under <i>your</i> control."
-            [/message]
-            [message]
-                speaker=enemy
-                message=_"You imprison people! You execute them!"
-            [/message]
-            [message]
-                speaker=Krux
-                message=_"Why should we not do that to evil people? We need to maintain order and sometimes punishments are necessary."
-            [/message]
-            [message]
-                speaker=enemy
-                message=_"You are not keeping order, you are brutally maintaining your tyranny! We are killed for resisting your cruel rule!"
-            [/message]
-            [message]
-                speaker=Acanthamoeba
-                message=_"You are assuming that our rule is cruel because we are fighting those who want to get rid of us. From your words, I judge that you would not consider us evil if we did not fight you. So why did you <i>start</i> fighting us? We became what you consider evil when we begun to fight back. It was you who made us retaliate."
-            [/message]
-            [message]
-                speaker=enemy
-                message=_"I will not succumb to your cunning lies. You are necromancers, you were evil right from the start!"
-            [/message]
-            [message]
-                speaker=Judas
-                message=_"Reasoning with this worm is as effective as trying to burn a dragon."
-            [/message]
-        [/command]
-        [/option]
-        [option]
-        message=_"He is only seeking to justify his villainy, he does not care if he is right or wrong. Unfortunately, we will have to fight."
-        [command]
-            [message]
-                speaker=Judas
-                message=_"That is how I like it!"
-            [/message]
-            [break]
-            [/break]
-        [/command]
-        [/option]
+            message=_"You have not convinced me, tyrants!"
+            [option]
+                message=_"If we needed bodies, we would take them from graveyards."
+                [command]
+                    [message]
+                        speaker=Acanthamoeba
+                        message=_"There are many abandoned burial grounds around. Many villages were burned and never rebuilt during wars with orcs and other invaders. Their dead are still buried there and if we wanted bodies, we might take those, without bringing any suspicion on us."
+                    [/message]
+                    [message]
+                        speaker=Krux
+                        message=_"I can assure you that imprisoning people is a very unwise way to collect bodies for necromancy."
+                    [/message]
+                    [message]
+                        speaker=enemy
+                        message=_"You know too much about necromancy somehow!"
+                    [/message]
+                    [message]
+                        speaker=Antipos
+                        message=_"Do you think that there is a way to reason with this man?"
+                    [/message]
+                [/command]
+            [/option]
+            [option]
+                message=_"You are bandits, you plunder and kill. Is there a reason why should we not execute you? We can save many good people by killing you."
+                [command]
+                    [message]
+                        speaker=enemy
+                        message=_"We are not mere bandits, we are an uprising to dethrone the tyrants and bring liberty to the people!"
+                    [/message]
+                    [message]
+                        speaker=Acanthamoeba
+                        message=_"Why do you assert that we are tyrants? Why do you think that it would be good to dethrone us? The villagers know what you do to the people that are under <i>your</i> control."
+                    [/message]
+                    [message]
+                        speaker=enemy
+                        message=_"You imprison people! You execute them!"
+                    [/message]
+                    [message]
+                        speaker=Krux
+                        message=_"Why should we not do that to evil people? We need to maintain order and sometimes punishments are necessary."
+                    [/message]
+                    [message]
+                        speaker=enemy
+                        message=_"You are not keeping order, you are brutally maintaining your tyranny! We are killed for resisting your cruel rule!"
+                    [/message]
+                    [message]
+                        speaker=Acanthamoeba
+                        message=_"You are assuming that our rule is cruel because we are fighting those who want to get rid of us. From your words, I judge that you would not consider us evil if we did not fight you. So why did you <i>start</i> fighting us? We became what you consider evil when we begun to fight back. It was you who made us retaliate."
+                    [/message]
+                    [message]
+                        speaker=enemy
+                        message=_"I will not succumb to your cunning lies. You are necromancers, you were evil right from the start!"
+                    [/message]
+                    [message]
+                        speaker=Judas
+                        message=_"Reasoning with this worm is as effective as trying to burn a dragon."
+                    [/message]
+                [/command]
+            [/option]
+            [option]
+                message=_"He is only seeking to justify his villainy, he does not care if he is right or wrong. Unfortunately, we will have to fight."
+                [command]
+                    [message]
+                        speaker=Judas
+                        message=_"That is how I like it!"
+                    [/message]
+                    [break]
+                    [/break]
+                [/command]
+            [/option]
         [/repeating_message]
         [message]
             speaker=enemy
             message=_"You see? They have come to kill us and make skeletons from us! That witch wants to use us in her evil ritual to summon more demons to copulate with!"
         [/message]
-    {GENERIC_UNIT 3 "Thug" 21 16}
-    {GENERIC_UNIT 3 "Poacher" 21 17}
-    {GENERIC_UNIT 3 "Thief" 21 18}
-    {GENERIC_UNIT 3 "Thug" 20 16}
-    {GENERIC_UNIT 3 "Poacher" 22 17}
+        {GENERIC_UNIT 3 "Thug" 21 16}
+        {GENERIC_UNIT 3 "Poacher" 21 17}
+        {GENERIC_UNIT 3 "Thief" 21 18}
+        {GENERIC_UNIT 3 "Thug" 20 16}
+        {GENERIC_UNIT 3 "Poacher" 22 17}
         [message]
             speaker=Krux
             message=_"We should minimalise the number of people killed. I am willing to spend 10 gold more for every enemy we imprison instead of killing."
         [/message]
-    [message]
-        speaker=Judas
-        message=_"Prices on their heads? I hate when the heads have to be attached to bodies!"
-    [/message]
-    {VARIABLE party_members[$party_members.length].id Krux}
-    {VARIABLE party_members[$party_members.length].id Acanthamoeba}
-    {VARIABLE party_members[$party_members.length].id Antipos}
-    {VARIABLE party_members[$party_members.length].id Judas}
-    {CHOOSE_VILLAIN_NAME}
+        [message]
+            speaker=Judas
+            message=_"Prices on their heads? I hate when the heads have to be attached to bodies!"
+        [/message]
+        {VARIABLE party_members[$party_members.length].id Krux}
+        {VARIABLE party_members[$party_members.length].id Acanthamoeba}
+        {VARIABLE party_members[$party_members.length].id Antipos}
+        {VARIABLE party_members[$party_members.length].id Judas}
+        {CHOOSE_VILLAIN_NAME}
         [set_menu_item]
             id=zz_incarcerate
             description= _ "Incarcerate"
@@ -603,27 +611,27 @@
                 [have_unit]
                     x,y=$x1,$y1
                     [filter_side]
-            [enemy_of]
-                side=$side_number
-            [/enemy_of]
-            [/filter_side]
-            [filter_wml]
-            [variables]
-                can_incarcerate=yes
-            [/variables]
-            [/filter_wml]
+                        [enemy_of]
+                            side=$side_number
+                        [/enemy_of]
+                    [/filter_side]
+                    [filter_wml]
+                        [variables]
+                            can_incarcerate=yes
+                        [/variables]
+                    [/filter_wml]
                 [/have_unit]
             [/show_if]
             [command]
                 [kill]
-            x,y=$x1,$y1
-            fire_event=yes
-            animate=no
-        [/kill]
-        [gold]
-            side=1
-            amount=10
-        [/gold]
+                    x,y=$x1,$y1
+                    fire_event=yes
+                    animate=no
+                [/kill]
+                [gold]
+                    side=1
+                    amount=10
+                [/gold]
                 [floating_text]
                     text=_ "Locked in prison!"
                     x,y=$x1,$y1
@@ -640,7 +648,7 @@
     {INCARCERATION}
 
     [event]
-    name=turn refresh
+        name=turn refresh
 #define RANDOM_ITEM X Y
     [random_item]
         group=expanded_drop
@@ -665,20 +673,20 @@
     [/event]
 
     [event]
-    name=last breath
-    [filter]
-        id=enemy
-    [/filter]
-    [filter_condition]
-        [have_unit]
-            id=enemy2
-        [/have_unit]
-        [or]
+        name=last breath
+        [filter]
+            id=enemy
+        [/filter]
+        [filter_condition]
             [have_unit]
-                id=enemy3
+                id=enemy2
             [/have_unit]
-        [/or]
-    [/filter_condition]
+            [or]
+                [have_unit]
+                    id=enemy3
+                [/have_unit]
+            [/or]
+        [/filter_condition]
         [message]
             speaker=enemy
             message=_"My fight ends, but I promise you here that the tyrants will fall very soon!"
@@ -691,18 +699,18 @@
             speaker=Krux
             message=_"Let his tantrum rage and exhaust itself, just stop listening to his meaningless words. We have defeated the one who was controlling this town, but there are more bandit groups operating nearby. Some of those we have encountered were not his underlings. And his defeat will enrage them and help them muster more forces, I fear."
         [/message]
-    [gold]
-        side=4
-        {QUANTITY amount 20 40 60}
-    [/gold]
-    [gold]
-        side=5
-        {QUANTITY amount 20 40 60}
-    [/gold]
+        [gold]
+            side=4
+            {QUANTITY amount 20 40 60}
+        [/gold]
+        [gold]
+            side=5
+            {QUANTITY amount 20 40 60}
+        [/gold]
     [/event]
 
     [event]
-    name=enemies defeated
+        name=enemies defeated
         [message]
             speaker=Judas
             message=_"We have shown these maggots what happens to those who dare to oppose us!"
@@ -710,59 +718,59 @@
         [message]
             speaker=Acanthamoeba
             message=_"Do you really think that we have won this war?"
-        [option]
-        message=_"Honestly, no. They were severely weakened, we have retaken control of this village, but there will be scattered parties ambushing us..."
-        [command]
-            [message]
-                speaker=Judas
-                message=_"You are right. But it means only that we will return and bring them more hell!"
-            [/message]
-            [message]
-                speaker=Antipos
-                message=_"When our troops are placed here, it will take them long until their activity becomes as strong as it was, but there are still more bandits around here than around other villages. I agree with you, Krux."
-            [/message]
-        [/command]
-        [/option]
-        [option]
-        message=_"Does it even matter? I am not the ruler. We were sent here with clear orders. We have done what we had to. What happens now is not our problem."
-        [command]
-            [message]
-                speaker=Judas
-                message=_"You want to leave while our fight is not finished? Coward!"
-            [/message]
-            [message]
-                speaker=Acanthamoeba
-                message=_"Catching all those bandits would take too much time and we might be needed elsewhere. I agree with you, Krux."
-            [/message]
-        [/command]
-        [/option]
-        [option]
-        message=_"I have a suspicion that the main goal of our mission was to take prisoners. We have enough prisoners. We would hardly be able to return with more."
-        [command]
-            [message]
-                speaker=Antipos
-                message=_"Why do we need these prisoners anyway?"
-            [/message]
-            [message]
-                speaker=Acanthamoeba
-                message=_"To show the people that we are dealing with those who harm them. Many of them were saying that they were paying us taxes and we were not protecting them. Parading these prisoners around villages and allowing the peasants to spit them into face helps our reputation a lot."
-            [/message]
-            [message]
-                speaker=Judas
-                message=_"You are lying, I can feel that in my guts. But if you do not want to tell it, I can stop asking."
-            [/message]
-        [/command]
-        [/option]
+            [option]
+                message=_"Honestly, no. They were severely weakened, we have retaken control of this village, but there will be scattered parties ambushing us..."
+                [command]
+                    [message]
+                        speaker=Judas
+                        message=_"You are right. But it means only that we will return and bring them more hell!"
+                    [/message]
+                    [message]
+                        speaker=Antipos
+                        message=_"When our troops are placed here, it will take them long until their activity becomes as strong as it was, but there are still more bandits around here than around other villages. I agree with you, Krux."
+                    [/message]
+                [/command]
+            [/option]
+            [option]
+                message=_"Does it even matter? I am not the ruler. We were sent here with clear orders. We have done what we had to. What happens now is not our problem."
+                [command]
+                    [message]
+                        speaker=Judas
+                        message=_"You want to leave while our fight is not finished? Coward!"
+                    [/message]
+                    [message]
+                        speaker=Acanthamoeba
+                        message=_"Catching all those bandits would take too much time and we might be needed elsewhere. I agree with you, Krux."
+                    [/message]
+                [/command]
+            [/option]
+            [option]
+                message=_"I have a suspicion that the main goal of our mission was to take prisoners. We have enough prisoners. We would hardly be able to return with more."
+                [command]
+                    [message]
+                        speaker=Antipos
+                        message=_"Why do we need these prisoners anyway?"
+                    [/message]
+                    [message]
+                        speaker=Acanthamoeba
+                        message=_"To show the people that we are dealing with those who harm them. Many of them were saying that they were paying us taxes and we were not protecting them. Parading these prisoners around villages and allowing the peasants to spit them into face helps our reputation a lot."
+                    [/message]
+                    [message]
+                        speaker=Judas
+                        message=_"You are lying, I can feel that in my guts. But if you do not want to tell it, I can stop asking."
+                    [/message]
+                [/command]
+            [/option]
         [/message]
         [message]
             speaker=Krux
             message=_"We should discuss this in privacy. Come on, it is time to return home and report about our victory."
         [/message]
-    [disallow_recruit]
-        side=1
-        type=Spearman,Bowman,Heavy Infantryman
-    [/disallow_recruit]
-    {VARIABLE previous_scenario incarcerating}
+        [disallow_recruit]
+            side=1
+            type=Spearman,Bowman,Heavy Infantryman
+        [/disallow_recruit]
+        {VARIABLE previous_scenario incarcerating}
         [endlevel]
             result=victory
             bonus=yes

--- a/spinoffs/Affably_Evil/scenarios/02_Marilyn.cfg
+++ b/spinoffs/Affably_Evil/scenarios/02_Marilyn.cfg
@@ -126,7 +126,15 @@
                 description= _ "Death of Krux, Acanthamoeba or Antipater"
                 condition=lose
             [/objective]
+#ifdef EASY
             note=_"If an enemy has 4 health or less, he can be locked in prison by selecting the right-click option, earning 10 gold."
+#endif
+#ifdef NORMAL
+            note=_"If an enemy has 6 health or less, he can be locked in prison by selecting the right-click option, earning 10 gold."
+#endif
+#ifdef HARD
+            note=_"If an enemy has 8 health or less, he can be locked in prison by selecting the right-click option, earning 10 gold."
+#endif
         [/objectives]
         {AE_RECALL_ALL 23 4}
         [unit]
@@ -644,6 +652,7 @@
             message=_"I fear that we might need to retreat a bit. I doubt they will follow us into our outpost, they do not want to be lured away."
         [/message]
         {VARIABLE phase 2}
+        [show_objectives][/show_objectives]
     [/event]
 
     [event]
@@ -772,6 +781,7 @@
         {GUARDIAN_UNIT 2 "Heavy Infantryman" 33 16}
 
         {VARIABLE phase 3}
+        [show_objectives][/show_objectives]
     [/event]
 
     [event]

--- a/spinoffs/Affably_Evil/scenarios/02_Marilyn.cfg
+++ b/spinoffs/Affably_Evil/scenarios/02_Marilyn.cfg
@@ -12,9 +12,9 @@
     [side]
         type=Krux_father
         id=Krux
-    name=_"Krux"
+        name=_"Krux"
         canrecruit=yes
-    unrenamable=yes
+        unrenamable=yes
         side=1
         controller=human
         recruit=Spearman,Bowman,Heavy Infantryman,Cavalryman,Fencer
@@ -33,49 +33,49 @@
     [/side]
     [side]
         type=Destroyer
-    id=Marilyn
-    name=_"Marilyn"
-    canrecruit=yes
-    gender=male
+        id=Marilyn
+        name=_"Marilyn"
+        canrecruit=yes
+        gender=male
         side=3
         team_name=house_mansion
         user_team_name=_"House Mansion"
-    {GOLD 60 75 95}
-    {INCOME 0 10 20}
-    village_gold=3
-    recruit=Spearman,Bowman,Mage,Heavy Infantryman,Cavalryman,Fencer,Young Ogre
-    [modifications]
-        [object]
-        [effect]
-            apply_to=profile
-            portrait=portraits/humans/transparent/bandit.png
-        [/effect]
-        [/object]
-        {TRAIT_RESILIENT}
-        {TRAIT_RESILIENT}
-    [/modifications]
-    [avoid]
-        y=1-12
-    [/avoid]
+        {GOLD 60 75 95}
+        {INCOME 0 10 20}
+        village_gold=3
+        recruit=Spearman,Bowman,Mage,Heavy Infantryman,Cavalryman,Fencer,Young Ogre
+        [modifications]
+            [object]
+                [effect]
+                    apply_to=profile
+                    portrait=portraits/humans/transparent/bandit.png
+                [/effect]
+            [/object]
+            {TRAIT_RESILIENT}
+            {TRAIT_RESILIENT}
+        [/modifications]
+        [avoid]
+            y=1-12
+        [/avoid]
     [/side]
     [side]
         no_leader=yes
         side=4
         team_name=house_de_rais	# Secretly helpful force
         user_team_name=_"???"
-    [ai]
-        [aspect]
-        id=attacks
-        [facet]
-            invalidate_on_gamestate_change=yes
-            [filter_enemy]
-            [not]
-                    side=1
-            [/not]
-            [/filter_enemy]
-        [/facet]
-        [/aspect]
-    [/ai]
+        [ai]
+            [aspect]
+                id=attacks
+                [facet]
+                    invalidate_on_gamestate_change=yes
+                    [filter_enemy]
+                        [not]
+                            side=1
+                        [/not]
+                    [/filter_enemy]
+                [/facet]
+            [/aspect]
+        [/ai]
     [/side]
 
     [event]
@@ -85,97 +85,97 @@
             [objective]
                 description= _ "Come close to Marilyn"
                 condition=win
-        [show_if]
-            [variable]
-                name=phase
-                equals=1
-            [/variable]
-        [/show_if]
+                [show_if]
+                    [variable]
+                        name=phase
+                        equals=1
+                    [/variable]
+                [/show_if]
             [/objective]
             [objective]
                 description= _ "Retreat (get all units near the keep)"
                 condition=win
-        [show_if]
-            [variable]
-                name=phase
-                equals=2
-            [/variable]
-        [/show_if]
+                [show_if]
+                    [variable]
+                        name=phase
+                        equals=2
+                    [/variable]
+                [/show_if]
             [/objective]
             [objective]
                 description= _ "Take over the outpost and defeat Marilyn"
                 condition=win
-        [show_if]
-            [variable]
-                name=phase
-                equals=3
-            [/variable]
-        [/show_if]
+                [show_if]
+                    [variable]
+                        name=phase
+                        equals=3
+                    [/variable]
+                [/show_if]
             [/objective]
             [objective]
                 description= _ "Bonus objective: defeat Marilyn"
                 condition=win
-        [show_if]
-            [variable]
-                name=phase
-                less_than=3
-            [/variable]
-        [/show_if]
+                [show_if]
+                    [variable]
+                        name=phase
+                        less_than=3
+                    [/variable]
+                [/show_if]
             [/objective]
             [objective]
                 description= _ "Death of Krux, Acanthamoeba or Antipater"
                 condition=lose
             [/objective]
-        #note=_"If an enemy has 4 health or less, he can be locked in prison by selecting the right-click option, earning 10 gold."
+            note=_"If an enemy has 4 health or less, he can be locked in prison by selecting the right-click option, earning 10 gold."
         [/objectives]
-    {AE_RECALL_ALL 23 4}
-    [unit]
-        id=Xalzaxx
-        type=Longbowman
-        name=_"Xalzaxx the Personal Space Invader"
-        unrenamable=yes
-        x,y=17,4
-        canrecruit=yes
-        [modifications]
-            {TRAIT_DEXTROUS}
-            [trait]
-            id=nosy
-            male_name= _ "nosy"
-            female_name= _ "female^nosy"
-                description= _ "Regenerates 16 hp per turn when standing next to Krux"
-                generate_description=false
-            [effect]
-                apply_to=new_ability
-                [abilities]
-                    [regenerate]
-                    value=16
+        {AE_RECALL_ALL 23 4}
+        [unit]
+            id=Xalzaxx
+            type=Longbowman
+            name=_"Xalzaxx the Personal Space Invader"
+            unrenamable=yes
+            x,y=17,4
+            canrecruit=yes
+            [modifications]
+                {TRAIT_DEXTROUS}
+                [trait]
                     id=nosy
-                    name= _ "nosy"
-                    female_name= _ "nosy"
-                    description= _ "The unit will heal itself 16 HP per turn if standing next to Krux. If it is poisoned, it will remove the poison instead of healing."
-                    affect_self=yes
-                    poison=cured
-                    [filter_self]
-                        [filter_adjacent]
-                            id=Krux
-                        [/filter_adjacent]
-                    [/filter_self]
-                    [/regenerate]
-                [/abilities]
-            [/effect]
-            [/trait]
-            [object]
-            [effect]
-                apply_to=profile
-                portrait=portraits/humans/transparent/bowman.png
-            [/effect]
-            [/object]
-        [/modifications]
-        [variables]
-            hero=yes
-        [/variables]
-    [/unit]
-    {VARIABLE party_members[$party_members.length].id Xalzaxx}
+                    male_name= _ "nosy"
+                    female_name= _ "female^nosy"
+                    description= _ "Regenerates 16 hp per turn when standing next to Krux"
+                    generate_description=false
+                    [effect]
+                        apply_to=new_ability
+                        [abilities]
+                            [regenerate]
+                                value=16
+                                id=nosy
+                                name= _ "nosy"
+                                female_name= _ "nosy"
+                                description= _ "The unit will heal itself 16 HP per turn if standing next to Krux. If it is poisoned, it will remove the poison instead of healing."
+                                affect_self=yes
+                                poison=cured
+                                [filter_self]
+                                    [filter_adjacent]
+                                        id=Krux
+                                    [/filter_adjacent]
+                                [/filter_self]
+                            [/regenerate]
+                        [/abilities]
+                    [/effect]
+                [/trait]
+                [object]
+                    [effect]
+                        apply_to=profile
+                        portrait=portraits/humans/transparent/bowman.png
+                    [/effect]
+                [/object]
+            [/modifications]
+            [variables]
+                hero=yes
+            [/variables]
+        [/unit]
+        {VARIABLE party_members[$party_members.length].id Xalzaxx}
     [/event]
 
     [event]
@@ -194,34 +194,34 @@
             speaker=Krux
             message=_"You are welcome. Now, it is time for diplomacy."
         [/message]
-    [if]
-        [have_unit]
-            id=Hare
-        [/have_unit]
-        [then]
-            [message]
-                speaker=Hare
-                message=_"That might work, they have a reputation of being the good guys."
-            [/message]
-            [message]
-                speaker=Krux
-                message=_"Their reputation has little in common with their behaviour. They are honest and just, but they are also very bold and prone to attack for little reason."
-            [/message]
-        [/then]
-    [/if]
+        [if]
+            [have_unit]
+                id=Hare
+            [/have_unit]
+            [then]
+                [message]
+                    speaker=Hare
+                    message=_"That might work, they have a reputation of being the good guys."
+                [/message]
+                [message]
+                    speaker=Krux
+                    message=_"Their reputation has little in common with their behaviour. They are honest and just, but they are also very bold and prone to attack for little reason."
+                [/message]
+            [/then]
+        [/if]
         [message]
             speaker=Acanthamoeba
             message=_"Good luck with persuading that Marilyn."
         [/message]
-    {GENERIC_UNIT 2 Swordsman 29 10}
-    {MOVE_UNIT x,y=29,10 26 5}
-    {GENERIC_UNIT 2 Bowman 28 10}
-    {MOVE_UNIT x,y=28,10 23 7}
-    {GENERIC_UNIT 2 "Shock Trooper" 29 11}
-    [+unit]
-        id=enemy_talker
-    [/unit]
-    {MOVE_UNIT x,y=29,11 22 6}
+        {GENERIC_UNIT 2 Swordsman 29 10}
+        {MOVE_UNIT x,y=29,10 26 5}
+        {GENERIC_UNIT 2 Bowman 28 10}
+        {MOVE_UNIT x,y=28,10 23 7}
+        {GENERIC_UNIT 2 "Shock Trooper" 29 11}
+        [+unit]
+            id=enemy_talker
+        [/unit]
+        {MOVE_UNIT x,y=29,11 22 6}
         [message]
             speaker=enemy_talker
             message=_"Our precious Marilyn wants you to sod off. This town is now his."
@@ -257,166 +257,166 @@
         [repeating_message]
             speaker=enemy_talker
             first=_"I am warning you, sod off or face the consequences."
-        message=_"I will not give you another warning, sod off!"
-        [option]
-        message=_"Can you please arrange a meeting between Marilyn and our representative?"
-        [command]
-            [message]
-                speaker=enemy_talker
-                message=_"No. You want to assassinate him!"
-            [/message]
-            [message]
-                speaker=Krux
-                message=_"I will send my sister. Do you think that a young maiden like her can cause harm to a strong and seasoned veteran like Marilyn?"
-            [/message]
-            [message]
-                speaker=enemy_talker
-                message=_"If you give her some poison, she can."
-            [/message]
-            [message]
-                speaker=Acanthamoeba
-                message=_"You may check that I have no poison."
-            [/message]
-            [message]
-                speaker=Hare
-                message=_"Whoa, you are not protesting?"
-            [/message]
-            [message]
-                speaker=enemy_talker
-                message=_"Even if she was naked, there would be a chance that she has some poison under her nails or in her saliva. Or that she knows some wicked magic."
-            [/message]
-            [message]
-                speaker=Krux
-                message=_"I resent the possibility that she would be naked. The weather is not warm enough, she might get cold. She may be in chains, with her mouth covered to prevent her from spitting."
-            [/message]
-            [message]
-                speaker=Acanthamoeba
-                message=_"I resent being in chains."
-            [/message]
-            [message]
-                speaker=Krux
-                message=_"If you are surrounded by a load of soldiers who are not very fond of you, chains mean only discomfort."
-            [/message]
-            [message]
-                speaker=enemy_talker
-                message=_"You are plotting something. You have some tricks prepared, I am sure of that."
-            [/message]
-            [message]
-                speaker=Acanthamoeba
-                message=_"Yes, I have a venomous breath."
-            [/message]
-        [/command]
-        [/option]
-        [option]
-        message=_"I want to sign a treaty with Marilyn that any lands beyond Boonies are ours, allowing him to keep Boonies."
-        [command]
-            [message]
-                speaker=Xalzaxx
-                message=_"Giving Boonies up? I wonder what led you to that decision, mylord."
-            [/message]
-            [message]
-                speaker=Krux
-                message=_"If that can prevent a massive war, we can let them have this town."
-            [/message]
-            [message]
-                speaker=enemy_talker
-                message=_"You are planning some nasty deception! You have just shown me that you are cowards, and cowards have to rely on deception."
-            [/message]
-            [message]
-                speaker=Acanthamoeba
-                message=_"What is so bad about being a coward? Too much risk may cause you to die for little gain. Avoiding risk is the key to long life and amassement of small successes."
-            [/message]
-            [message]
-                speaker=enemy_talker
-                message=_"So you admit that you are cowards that rely on deception?"
-            [/message]
-            [message]
-                speaker=Acanthamoeba
-                message=_"Only under the wrong assumption that all cowards ally on deception. We do not decieve, we minimalise the risk."
-            [/message]
-            [message]
-                speaker=enemy_talker
-                message=_"Stop fooling my head! You are preparing some evil tricks!"
-            [/message]
-            [message]
-                speaker=Antipos
-                message=_"This man is a paranoiac..."
-            [/message]
-        [/command]
-        [/option]
-        [option]
-        message=_"Let us spare the lives of our good soldiers. I want a duel with Marilyn."
-        [command]
-            [message]
-                speaker=Xalzaxx
-                message=_"Let me be your champion!"
-            [/message]
-            [message]
-                speaker=Krux
-                message=_"Wait, we do not even know if there will be a duel."
-            [/message]
-            [message]
-                speaker=enemy_talker
-                message=_"I know how you duel. Strong poison over everything, using spears, knives and arrows to prevent even approaching your opponent! I will not let you kill him like that."
-            [/message]
-            [message]
-                speaker=Krux
-                message=_"It appears that this suggestion will not work. Why was I mixing that poison? I will have to dump it into a river... so much work wasted."
-            [/message]
-            [message]
-                speaker=enemy_talker
-                message=_"So you admit that you had prepared poison?"
-            [/message]
-            [message]
-                speaker=Acanthamoeba
-                message=_"It was a joke, you dimwit!"
-            [/message]
-        [/command]
-        [/option]
-        [option]
-        message=_"Sister, would you mind marrying him? It might be worth it."
-        [command]
-            [message]
-                speaker=Acanthamoeba
-                message=_"I do not know him. It depends. I would like to have a chat before him first and decide later."
-            [/message]
-            [message]
-                speaker=Hare
-                message=_"No!"
-            [/message]
-            [message]
-                speaker=Krux
-                message=_"What a sudden change of reply."
-            [/message]
-            [message]
-                speaker=enemy_talker
-                message=_"She would seduce him and kill him or even possess him."
-            [/message]
-            [message]
-                speaker=Krux
-                message=_"If we had such powers, we would have had him destroyed already."
-            [/message]
-            [message]
-                speaker=enemy_talker
-                message=_"You are doing that only to conceal your powers, you need the element of surprise!"
-            [/message]
-            [message]
-                speaker=Acanthamoeba
-                message=_"Is there something that can persuade this man?"
-            [/message]
-        [/command]
-        [/option]
-        [option]
-        message=_"I will not go back! If Marilyn wants a war, he can have it. There is no way to reason with you anyway!"
-        [command]
-            [message]
-                speaker=Antipos
-                message=_"Yes, crush them for irrationality!"
-            [/message]
-            [break]
-            [/break]
-        [/command]
-        [/option]
+            message=_"I will not give you another warning, sod off!"
+            [option]
+                message=_"Can you please arrange a meeting between Marilyn and our representative?"
+                [command]
+                    [message]
+                        speaker=enemy_talker
+                        message=_"No. You want to assassinate him!"
+                    [/message]
+                    [message]
+                        speaker=Krux
+                        message=_"I will send my sister. Do you think that a young maiden like her can cause harm to a strong and seasoned veteran like Marilyn?"
+                    [/message]
+                    [message]
+                        speaker=enemy_talker
+                        message=_"If you give her some poison, she can."
+                    [/message]
+                    [message]
+                        speaker=Acanthamoeba
+                        message=_"You may check that I have no poison."
+                    [/message]
+                    [message]
+                        speaker=Hare
+                        message=_"Whoa, you are not protesting?"
+                    [/message]
+                    [message]
+                        speaker=enemy_talker
+                        message=_"Even if she was naked, there would be a chance that she has some poison under her nails or in her saliva. Or that she knows some wicked magic."
+                    [/message]
+                    [message]
+                        speaker=Krux
+                        message=_"I resent the possibility that she would be naked. The weather is not warm enough, she might get cold. She may be in chains, with her mouth covered to prevent her from spitting."
+                    [/message]
+                    [message]
+                        speaker=Acanthamoeba
+                        message=_"I resent being in chains."
+                    [/message]
+                    [message]
+                        speaker=Krux
+                        message=_"If you are surrounded by a load of soldiers who are not very fond of you, chains mean only discomfort."
+                    [/message]
+                    [message]
+                        speaker=enemy_talker
+                        message=_"You are plotting something. You have some tricks prepared, I am sure of that."
+                    [/message]
+                    [message]
+                        speaker=Acanthamoeba
+                        message=_"Yes, I have a venomous breath."
+                    [/message]
+                [/command]
+            [/option]
+            [option]
+                message=_"I want to sign a treaty with Marilyn that any lands beyond Boonies are ours, allowing him to keep Boonies."
+                [command]
+                    [message]
+                        speaker=Xalzaxx
+                        message=_"Giving Boonies up? I wonder what led you to that decision, mylord."
+                    [/message]
+                    [message]
+                        speaker=Krux
+                        message=_"If that can prevent a massive war, we can let them have this town."
+                    [/message]
+                    [message]
+                        speaker=enemy_talker
+                        message=_"You are planning some nasty deception! You have just shown me that you are cowards, and cowards have to rely on deception."
+                    [/message]
+                    [message]
+                        speaker=Acanthamoeba
+                        message=_"What is so bad about being a coward? Too much risk may cause you to die for little gain. Avoiding risk is the key to long life and amassement of small successes."
+                    [/message]
+                    [message]
+                        speaker=enemy_talker
+                        message=_"So you admit that you are cowards that rely on deception?"
+                    [/message]
+                    [message]
+                        speaker=Acanthamoeba
+                        message=_"Only under the wrong assumption that all cowards ally on deception. We do not decieve, we minimalise the risk."
+                    [/message]
+                    [message]
+                        speaker=enemy_talker
+                        message=_"Stop fooling my head! You are preparing some evil tricks!"
+                    [/message]
+                    [message]
+                        speaker=Antipos
+                        message=_"This man is a paranoiac..."
+                    [/message]
+                [/command]
+            [/option]
+            [option]
+                message=_"Let us spare the lives of our good soldiers. I want a duel with Marilyn."
+                [command]
+                    [message]
+                        speaker=Xalzaxx
+                        message=_"Let me be your champion!"
+                    [/message]
+                    [message]
+                        speaker=Krux
+                        message=_"Wait, we do not even know if there will be a duel."
+                    [/message]
+                    [message]
+                        speaker=enemy_talker
+                        message=_"I know how you duel. Strong poison over everything, using spears, knives and arrows to prevent even approaching your opponent! I will not let you kill him like that."
+                    [/message]
+                    [message]
+                        speaker=Krux
+                        message=_"It appears that this suggestion will not work. Why was I mixing that poison? I will have to dump it into a river... so much work wasted."
+                    [/message]
+                    [message]
+                        speaker=enemy_talker
+                        message=_"So you admit that you had prepared poison?"
+                    [/message]
+                    [message]
+                        speaker=Acanthamoeba
+                        message=_"It was a joke, you dimwit!"
+                    [/message]
+                [/command]
+            [/option]
+            [option]
+                message=_"Sister, would you mind marrying him? It might be worth it."
+                [command]
+                    [message]
+                        speaker=Acanthamoeba
+                        message=_"I do not know him. It depends. I would like to have a chat before him first and decide later."
+                    [/message]
+                    [message]
+                        speaker=Hare
+                        message=_"No!"
+                    [/message]
+                    [message]
+                        speaker=Krux
+                        message=_"What a sudden change of reply."
+                    [/message]
+                    [message]
+                        speaker=enemy_talker
+                        message=_"She would seduce him and kill him or even possess him."
+                    [/message]
+                    [message]
+                        speaker=Krux
+                        message=_"If we had such powers, we would have had him destroyed already."
+                    [/message]
+                    [message]
+                        speaker=enemy_talker
+                        message=_"You are doing that only to conceal your powers, you need the element of surprise!"
+                    [/message]
+                    [message]
+                        speaker=Acanthamoeba
+                        message=_"Is there something that can persuade this man?"
+                    [/message]
+                [/command]
+            [/option]
+            [option]
+                message=_"I will not go back! If Marilyn wants a war, he can have it. There is no way to reason with you anyway!"
+                [command]
+                    [message]
+                        speaker=Antipos
+                        message=_"Yes, crush them for irrationality!"
+                    [/message]
+                    [break]
+                    [/break]
+                [/command]
+            [/option]
         [/repeating_message]
         [message]
             speaker=enemy_talker
@@ -430,63 +430,63 @@
             speaker=Krux
             message=_"This should not become an overly large slaughter. Please try to take prisoners. Some of them might be eventually converted into our soldiers, so larger expensies will be more acceptable if we take enough prisoners. I am willing to spend ten more gold for every soldier we capture."
         [/message]
-    {GENERIC_UNIT 2 "Javelineer" 32 13}
-    {GENERIC_UNIT 2 "Bowman" 33 13}
-    {GENERIC_UNIT 2 "Pikeman" 33 14}
-    {GENERIC_UNIT 2 "Dragoon" 32 14}
-    {GENERIC_UNIT 2 "Spearman" 34 13}
-    {GENERIC_UNIT 2 "Fencer" 34 14}
-    {GENERIC_UNIT 2 "Shock Trooper" 35 13}
-    {GENERIC_UNIT 2 "Longbowman" 35 14}
-    {SCENARIO_DURATION_VARIABLE phase 1}
+        {GENERIC_UNIT 2 "Javelineer" 32 13}
+        {GENERIC_UNIT 2 "Bowman" 33 13}
+        {GENERIC_UNIT 2 "Pikeman" 33 14}
+        {GENERIC_UNIT 2 "Dragoon" 32 14}
+        {GENERIC_UNIT 2 "Spearman" 34 13}
+        {GENERIC_UNIT 2 "Fencer" 34 14}
+        {GENERIC_UNIT 2 "Shock Trooper" 35 13}
+        {GENERIC_UNIT 2 "Longbowman" 35 14}
+        {SCENARIO_DURATION_VARIABLE phase 1}
     [/event]
 
     {INCARCERATION}
 
     [event]
-    name=last breath
-    [filter]
-        id=enemy_talker
-    [/filter]
+        name=last breath
+        [filter]
+            id=enemy_talker
+        [/filter]
         [message]
             speaker=second_unit
             message=_"Take that, bedbug."
         [/message]
-    [gold]
-        side=3
-        {QUANTITY amount 20 40 60}
-    [/gold]
+        [gold]
+            side=3
+            {QUANTITY amount 20 40 60}
+        [/gold]
     [/event]
 
     [event]
-    name=moveto
-    [filter]
-        side=1
-        x,y=17-42,20-34
-    [/filter]
-    [store_unit]
+        name=moveto
         [filter]
-            id=Krux
+            side=1
+            x,y=17-42,20-34
         [/filter]
-        variable=krux_store
-        kill=no
-    [/store_unit]
-    [store_unit]
-        [filter]
-            id=Acanthamoeba
-        [/filter]
-        variable=acanthamoeba_store
-        kill=no
-    [/store_unit]
-    [store_unit]
-        [filter]
-            id=Marilyn
-        [/filter]
-        variable=marilyn_store
-        kill=no
-    [/store_unit]
-    {MOVE_UNIT id=Krux "$($unit.x-1)" "$unit.y"}
-    {MOVE_UNIT id=Acanthamoeba "$($unit.x-2)" "$unit.y"}
+        [store_unit]
+            [filter]
+                id=Krux
+            [/filter]
+            variable=krux_store
+            kill=no
+        [/store_unit]
+        [store_unit]
+            [filter]
+                id=Acanthamoeba
+            [/filter]
+            variable=acanthamoeba_store
+            kill=no
+        [/store_unit]
+        [store_unit]
+            [filter]
+                id=Marilyn
+            [/filter]
+            variable=marilyn_store
+            kill=no
+        [/store_unit]
+        {MOVE_UNIT id=Krux "$($unit.x-1)" "$unit.y"}
+        {MOVE_UNIT id=Acanthamoeba "$($unit.x-2)" "$unit.y"}
         [message]
             speaker=Krux
             message=_"Look to south from Boonies, he has reaved everything on his way into Boonies. Definitely not something we want to be happening. It is now time to talk."
@@ -499,7 +499,7 @@
             speaker=Marilyn
             message=_"I am willing to talk to you when you have come this far. I will come closer, there is no need to shout from such a distance."
         [/message]
-    {MOVE_UNIT id=Marilyn "$(1+$unit.x)" "$(1+$unit.y)"}
+        {MOVE_UNIT id=Marilyn "$(1+$unit.x)" "$(1+$unit.y)"}
         [message]
             speaker=Krux
             message=_"Greetings. My name is Krux de Rais and this is my sister, Acanthamoeba de Rais, or Acantha for short."
@@ -620,139 +620,139 @@
             speaker=Marilyn
             message=_"Now when we see that these swindlers are a large threat, gather all warriors and give them hell!"
         [/message]
-    {MOVE_UNIT id=Krux $krux_store.x $krux_store.y}
-    {MOVE_UNIT id=Acanthamoeba $acanthamoeba_store.x $acanthamoeba_store.y}
-    {MOVE_UNIT id=Marilyn $marilyn_store.x $marilyn_store.y}
-    {CLEAR_VARIABLE krux_store,acanthamoeba_store,marilyn_store}
-    [gold]
-        side=3
-        {QUANTITY amount 400 550 600}
-    [/gold]
-    [if]
-        [have_unit]
-            id=Hare
-        [/have_unit]
-        [then]
-            [message]
-                speaker=Acanthamoeba
-                message=_"Good news, Hare, I am not going to marry that bull-header jackass."
-            [/message]
-        [/then]
-    [/if]
+        {MOVE_UNIT id=Krux $krux_store.x $krux_store.y}
+        {MOVE_UNIT id=Acanthamoeba $acanthamoeba_store.x $acanthamoeba_store.y}
+        {MOVE_UNIT id=Marilyn $marilyn_store.x $marilyn_store.y}
+        {CLEAR_VARIABLE krux_store,acanthamoeba_store,marilyn_store}
+        [gold]
+            side=3
+            {QUANTITY amount 400 550 600}
+        [/gold]
+        [if]
+            [have_unit]
+                id=Hare
+            [/have_unit]
+            [then]
+                [message]
+                    speaker=Acanthamoeba
+                    message=_"Good news, Hare, I am not going to marry that bull-header jackass."
+                [/message]
+            [/then]
+        [/if]
         [message]
             speaker=Krux
             message=_"I fear that we might need to retreat a bit. I doubt they will follow us into our outpost, they do not want to be lured away."
         [/message]
-    {VARIABLE phase 2}
+        {VARIABLE phase 2}
     [/event]
 
     [event]
-    name=new turn
-    [filter_condition]
-        [variable]
-            name=phase
-            equals=2
-        [/variable]
-        [not]
-            [have_unit]
-                side=1
-                y=11-33
-            [/have_unit]
-        [/not]
-    [/filter_condition]
+        name=new turn
+        [filter_condition]
+            [variable]
+                name=phase
+                equals=2
+            [/variable]
+            [not]
+                [have_unit]
+                    side=1
+                    y=11-33
+                [/have_unit]
+            [/not]
+        [/filter_condition]
         [message]
             speaker=Krux
             message=_"We should be safe now. They will most likely try to fortify their positions."
         [/message]
-    [message]
-        speaker=Acanthamoeba
-        message=_"How do you plan to regain the town? He holds it and he is only becoming stronger and stronger."
-    [/message]
+        [message]
+            speaker=Acanthamoeba
+            message=_"How do you plan to regain the town? He holds it and he is only becoming stronger and stronger."
+        [/message]
         [message]
             speaker=Krux
             message=_"He might weaken himself by sending at us groups of soldiers he does not necessarily need to keep the town. But that is not the beauty of the plan. Remember what we saw near all the undead?"
         [/message]
-    [message]
-        speaker=Antipos
-        message=_"Stench? Bodies?"
-    [/message]
+        [message]
+            speaker=Antipos
+            message=_"Stench? Bodies?"
+        [/message]
         [message]
             speaker=Acanthamoeba
             message=_"Swamps. Flooded areas. You want to send some unarmed soldiers dressed up as peasants to block the river and cause a flood. The undead will come."
         [/message]
-    [message]
-        speaker=Antipos
-        message=_"Why are you so certain the undead will come? We still do not know if the undead are not making the swamps themselves."
-    [/message]
+        [message]
+            speaker=Antipos
+            message=_"Why are you so certain the undead will come? We still do not know if the undead are not making the swamps themselves."
+        [/message]
         [message]
             speaker=Krux
             message=_"There is a plenty of undead north from here. If we plant some of them into the swamp, they will know what to do."
         [/message]
-    [message]
-        speaker=Antipos
-        message=_"I think that you do not need to bother with that. I am a White Mage and I can feel the presence of unholy. The undead are already there. It is only a matter of time when they awaken and attack."
-    [/message]
+        [message]
+            speaker=Antipos
+            message=_"I think that you do not need to bother with that. I am a White Mage and I can feel the presence of unholy. The undead are already there. It is only a matter of time when they awaken and attack."
+        [/message]
         [message]
             speaker=Krux
             message=_"Maybe we could find a place where they are vulnerable and inflict some damage."
-    [/message]
-    [event]
-        name=new turn
-        [message]
-            speaker=Antipos
-            message=_"The undead have awakeneed. Our foes shall have more targets to handle."
         [/message]
-        {VARIABLE quests.marilyn_undead_exploit yes}
         [event]
-        name=new turn
-        first_time_only=no
-        [store_time_of_day]
-        [/store_time_of_day]
-        [if]
-            [variable]
-                name=time_of_day.lawful_bonus
-                less_than=0
-            [/variable]
-            [then]
-                {VARIABLE count 0}
-                [while]
+            name=new turn
+            [message]
+                speaker=Antipos
+                message=_"The undead have awakeneed. Our foes shall have more targets to handle."
+            [/message]
+            {VARIABLE quests.marilyn_undead_exploit yes}
+            [event]
+                name=new turn
+                first_time_only=no
+                [store_time_of_day]
+                [/store_time_of_day]
+                [if]
                     [variable]
-                        name=count
-                        less_than=5
+                        name=time_of_day.lawful_bonus
+                        less_than=0
                     [/variable]
-                    [do]
-                        {VARIABLE_OP rand_x rand 1..44}
-                        {VARIABLE_OP rand_y rand 12..33}
-                        {GENERIC_UNIT 4 "Ghost" $rand_x $rand_y}
-                        [+unit]
-                            [variables]
-                                night_menace=yes
-                            [/variables]
-                        [/unit]
-                        {VARIABLE_OP count add 1}
-                    [/do]
-                [/while]
-                {CLEAR_VARIABLE rand_x,rand_y,count}
-                {GENERIC_UNIT 4 Ghoul 5 24}
-                {GENERIC_UNIT 4 "Walking Corpse" 16 21}
-                {GENERIC_UNIT 4 Ghoul 6 13}
-                {GENERIC_UNIT 4 "Walking Corpse" 15 15}
-            [/then]
-            [else]
-                [kill]
-                    [filter_wml]
-                        [variables]
-                            night_menace=yes
-                        [/variables]
-                    [/filter_wml]
-                    animate=no
-                    fire_event=no
-                [/kill]
-            [/else]
-        [/if]
-        {CLEAR_VARIABLE time_of_day}
+                    [then]
+                        {VARIABLE count 0}
+                        [while]
+                            [variable]
+                                name=count
+                                less_than=5
+                            [/variable]
+                            [do]
+                                {VARIABLE_OP rand_x rand 1..44}
+                                {VARIABLE_OP rand_y rand 12..33}
+                                {GENERIC_UNIT 4 "Ghost" $rand_x $rand_y}
+                                [+unit]
+                                    [variables]
+                                        night_menace=yes
+                                    [/variables]
+                                [/unit]
+                                {VARIABLE_OP count add 1}
+                            [/do]
+                        [/while]
+                        {CLEAR_VARIABLE rand_x,rand_y,count}
+                        {GENERIC_UNIT 4 Ghoul 5 24}
+                        {GENERIC_UNIT 4 "Walking Corpse" 16 21}
+                        {GENERIC_UNIT 4 Ghoul 6 13}
+                        {GENERIC_UNIT 4 "Walking Corpse" 15 15}
+                    [/then]
+                    [else]
+                        [kill]
+                            [filter_wml]
+                                [variables]
+                                    night_menace=yes
+                                [/variables]
+                            [/filter_wml]
+                            animate=no
+                            fire_event=no
+                        [/kill]
+                    [/else]
+                [/if]
+                {CLEAR_VARIABLE time_of_day}
+            [/event]
         [/event]
-    [/event]
         [terrain]
             x,y=31,17
             terrain=Ke
@@ -765,20 +765,20 @@
             x,y=32,17
             terrain=Ce
         [/terrain]
-    {GUARDIAN_UNIT 2 "Lieutenant" 31 17}
-    {GUARDIAN_UNIT 2 "Heavy Infantryman" 31 16}
-    {GUARDIAN_UNIT 2 "Longbowman" 32 17}
-    {GUARDIAN_UNIT 2 "Swordsman" 32 16}
-    {GUARDIAN_UNIT 2 "Heavy Infantryman" 33 16}
-        
-    {VARIABLE phase 3}
+        {GUARDIAN_UNIT 2 "Lieutenant" 31 17}
+        {GUARDIAN_UNIT 2 "Heavy Infantryman" 31 16}
+        {GUARDIAN_UNIT 2 "Longbowman" 32 17}
+        {GUARDIAN_UNIT 2 "Swordsman" 32 16}
+        {GUARDIAN_UNIT 2 "Heavy Infantryman" 33 16}
+
+        {VARIABLE phase 3}
     [/event]
 
     [event]
-    name=last breath
-    [filter]
-        id=Marilyn
-    [/filter]
+        name=last breath
+        [filter]
+            id=Marilyn
+        [/filter]
         [message]
             speaker=Marilyn
             message=_"Impressive. You have defeated me. This village is rightfully yours."
@@ -791,12 +791,12 @@
             speaker=Marilyn
             message=_"In fact, you would have stood no chance against me if those necromancers were not attacking us. We have spent way too much resources on fighting them and now we are too weak. All our attempts to find the necromancers are unsuccessful."
         [/message]
-    {MOVE_UNIT id=Marilyn 35 33}
-    [kill]
-        id=Marilyn
-        animate=no
-        fire_event=no
-    [/kill]
+        {MOVE_UNIT id=Marilyn 35 33}
+        [kill]
+            id=Marilyn
+            animate=no
+            fire_event=no
+        [/kill]
         [message]
             speaker=Acanthamoeba
             message=_"Good luck explaining it to your father. See you later my love."
@@ -809,11 +809,11 @@
             speaker=Krux
             message=_"This was a dangerous fight. It is time to announce this glorious victory to my father."
         [/message]
-    {VARIABLE previous_scenario marilyn}
-    [disallow_recruit]
-        side=1
-        type=Spearman,Bowman,Heavy Infantryman,Cavalryman,Fencer
-    [/disallow_recruit]
+        {VARIABLE previous_scenario marilyn}
+        [disallow_recruit]
+            side=1
+            type=Spearman,Bowman,Heavy Infantryman,Cavalryman,Fencer
+        [/disallow_recruit]
         [endlevel]
             result=victory
             bonus=yes

--- a/spinoffs/Affably_Evil/utils/utils.cfg
+++ b/spinoffs/Affably_Evil/utils/utils.cfg
@@ -301,7 +301,15 @@
                 [if]
                     [variable]
                         name=possibly[$i].hitpoints
+#ifdef EASY
+                        less_than_equal_to=8
+#endif
+#ifdef NORMAL
+                        less_than_equal_to=6
+#endif
+#ifdef HARD
                         less_than_equal_to=4
+#endif
                     [/variable]
                     [then]
                         {VARIABLE possibly[$i].variables.can_incarcerate yes}
@@ -335,6 +343,15 @@
                 [if]
                     [variable]
                         name=incarceratables[$i].hitpoints
+#ifdef EASY
+                        greater_than=8
+#endif
+#ifdef NORMAL
+                        greater_than=6
+#endif
+#ifdef HARD
+                        greater_than=4
+#endif
                         greater_than=4
                     [/variable]
                     [then]

--- a/spinoffs/Affably_Evil/utils/utils.cfg
+++ b/spinoffs/Affably_Evil/utils/utils.cfg
@@ -352,7 +352,6 @@
 #ifdef HARD
                         greater_than=4
 #endif
-                        greater_than=4
                     [/variable]
                     [then]
                         {CLEAR_VARIABLE incarceratables[$i].varaibles.can_incarcerate}


### PR DESCRIPTION
Put objective note back in Marilyn.

Added show_objectives when they change, for people like me who skip a lot of dialog.

I'm not the only one who finds the first scenario very difficult.  It probably turns a lot of people off the campaign.  The enemy gold/income is too high (and they're far away) and the only strategy I've found for winning somewhat consistently (assuming decent luck in the initial drop) is not very intuitive.  And then there's the incarceration threshold.  I regularly see enemies with 5-7 HP, but almost never with 4 or less, and any that are low are going to die by my ally or run to a village.  Might help a bit (lot?) if I had poison.  Propose raising the HP threshold for incarceration on easy/normal, both to make the scenario easier and to make incarceration a bigger part of the scenario as I suspect was intended.  This also affects Marilyn, but that one is difficult enough relative to the rest of the scenarios that at worst it won't hurt.
