### PR TITLE
enemy_sides -> [enemy_of]

### DIFF
--- a/utils/abilities_events.cfg
+++ b/utils/abilities_events.cfg
@@ -1959,7 +1959,7 @@
         [/store_unit]
         [for]
             array=ash_cooldown
-                        variable=h
+            variable=h
             [do]
                 [if]
                     [variable]
@@ -4339,19 +4339,16 @@
         [filter_attack]
             special_id=explosive slow
         [/filter_attack]
-
         [harm_unit]
             [filter]
                 [filter_adjacent]
                     x,y=$x2,$y2
                 [/filter_adjacent]
-                [not]
-                    side=$unit.side
-                [/not]
-                [not]
-                    x,y=$x2,$y2
-                [/not]
-                side=$enemy_sides
+                [filter_side]
+                    [enemy_of]
+                        side=$unit.side
+                    [/enemy_of]
+                [/filter_side]
             [/filter]
             [filter_second]
                 x,y=$x1,$y1


### PR DESCRIPTION
Replace $enemy_sides with [enemy_of].  Fixes explosive slow in scenarios where enemy_sides does not include all enemy sides.

Tested on 1.16.9, Lost in Space (against prince's side).

Closes #634