### PR TITLE
fix missing XP

### DIFF
--- a/scenarios8/09_Gladiatrix-The_Path_to_Glory.cfg
+++ b/scenarios8/09_Gladiatrix-The_Path_to_Glory.cfg
@@ -907,6 +907,7 @@
                             speaker=moderator
                             message= _ "Oh yes, the hellhounds were defeated by our brave heroes. Do you know what awaits them next?"
                         [/message]
+                        {HEAL_VRITRA}
                         [message]
                             speaker=Vritra
                             message= _ "Some bloody fun on your face?"

--- a/scenarios8/09_Gladiatrix-The_Path_to_Glory.cfg
+++ b/scenarios8/09_Gladiatrix-The_Path_to_Glory.cfg
@@ -726,6 +726,7 @@
                             speaker=moderator
                             message= _ "Defeated the dracolich, I have never seen such power! We lost ten mages while trying to capture it... We will need to imagine something really bad next time."
                         [/message]
+<<<<<<< Updated upstream
 
                         # We're going to store/unstore the units with kill, and we're inside a die event.  Have to give XP manually.
                         {IF_VAR unit.id not_equals $second_unit.id(
@@ -752,6 +753,52 @@
                             [/then]
                         )}
 
+||||||| constructed merge base
+=======
+
+                        # We're going to store/unstore the units with kill, and we're inside a die event.  Have to give XP manually.
+                        [store_unit]  # In case unit was killed by incineration
+                            [filter]
+                                id=$unit.id
+                                status=incinerated
+                            [/filter]
+                            variable=charcoal
+                            kill=no
+                        [/store_unit]
+                        [foreach]  # There will only be one, if any, but this avoids indexing null value
+                            array=charcoal
+                            [do]
+                                {VARIABLE second_unit.id $this_unit.variables.incinerator}
+                            [/do]
+                        [/foreach]
+                        {CLEAR_VARIABLE charcoal}
+
+                        {IF_VAR unit.id not_equals $second_unit.id (
+                            # Ignore death by secondary effect of things like shockwave
+                            [then]
+                                [store_unit]
+                                    [filter]
+                                        id=$second_unit.id
+                                    [/filter]
+                                    variable=killer
+                                    kill=yes
+                                [/store_unit]
+                                {VARIABLE exp 4}
+                                {IF_VAR unit.level greater_than 0 (
+                                    [then]
+                                        {VARIABLE exp "$($unit.level * 8)"}
+                                    [/then]
+                                )}
+                                {VARIABLE_OP killer.experience add $exp}
+                                [unstore_unit]
+                                    variable=killer
+                                    find_vacant=no
+                                [/unstore_unit]
+                                {CLEAR_VARIABLE exp,killer}
+                            [/then]
+                        )}
+
+>>>>>>> Stashed changes
                         {MOVE_UNIT side=1 24 5}
                         {HEAL_PARTY}
                         {VARIABLE progress 6}
@@ -907,7 +954,6 @@
                             speaker=moderator
                             message= _ "Oh yes, the hellhounds were defeated by our brave heroes. Do you know what awaits them next?"
                         [/message]
-                        {HEAL_VRITRA}
                         [message]
                             speaker=Vritra
                             message= _ "Some bloody fun on your face?"

--- a/scenarios8/09_Gladiatrix-The_Path_to_Glory.cfg
+++ b/scenarios8/09_Gladiatrix-The_Path_to_Glory.cfg
@@ -726,35 +726,6 @@
                             speaker=moderator
                             message= _ "Defeated the dracolich, I have never seen such power! We lost ten mages while trying to capture it... We will need to imagine something really bad next time."
                         [/message]
-<<<<<<< Updated upstream
-
-                        # We're going to store/unstore the units with kill, and we're inside a die event.  Have to give XP manually.
-                        {IF_VAR unit.id not_equals $second_unit.id(
-                            [then]
-                                [store_unit]
-                                    [filter]
-                                        id=$second_unit.id
-                                    [/filter]
-                                    variable=killer
-                                    kill=yes
-                                [/store_unit]
-                                {VARIABLE exp 4}
-                                {IF_VAR unit.level greater_than 0 (
-                                    [then]
-                                        {VARIABLE exp "$($unit.level * 8)"}
-                                    [/then]
-                                )}
-                                {VARIABLE_OP killer.experience add $exp}
-                                [unstore_unit]
-                                    variable=killer
-                                    find_vacant=no
-                                [/unstore_unit]
-                                {CLEAR_VARIABLE exp,killer}
-                            [/then]
-                        )}
-
-||||||| constructed merge base
-=======
 
                         # We're going to store/unstore the units with kill, and we're inside a die event.  Have to give XP manually.
                         [store_unit]  # In case unit was killed by incineration
@@ -797,8 +768,7 @@
                                 {CLEAR_VARIABLE exp,killer}
                             [/then]
                         )}
-
->>>>>>> Stashed changes
+                        
                         {MOVE_UNIT side=1 24 5}
                         {HEAL_PARTY}
                         {VARIABLE progress 6}
@@ -954,6 +924,7 @@
                             speaker=moderator
                             message= _ "Oh yes, the hellhounds were defeated by our brave heroes. Do you know what awaits them next?"
                         [/message]
+                        {HEAL_VRITRA}
                         [message]
                             speaker=Vritra
                             message= _ "Some bloody fun on your face?"

--- a/scenarios8/09_Gladiatrix-The_Path_to_Glory.cfg
+++ b/scenarios8/09_Gladiatrix-The_Path_to_Glory.cfg
@@ -964,6 +964,22 @@
                             message= _ "They are strong, great, we will prepare greater challenges for them next time."
                         [/message]
                         # We're going to store/unstore the units with kill, and we're inside a die event.  Have to give XP manually.
+                       [store_unit]  # In case unit was killed by incineration
+                            [filter]
+                                id=$unit.id
+                                status=incinerated
+                            [/filter]
+                            variable=charcoal
+                            kill=no
+                        [/store_unit]
+                        [foreach]  # There will only be one, if any, but this avoids indexing null value
+                            array=charcoal
+                            [do]
+                                {VARIABLE second_unit.id $this_unit.variables.incinerator}
+                            [/do]
+                        [/foreach]
+                        {CLEAR_VARIABLE charcoal}
+
                         {IF_VAR unit.id not_equals $second_unit.id(
                             [then]
                                 [store_unit]

--- a/scenarios8/09_Gladiatrix-The_Path_to_Glory.cfg
+++ b/scenarios8/09_Gladiatrix-The_Path_to_Glory.cfg
@@ -632,6 +632,12 @@
         first_time_only=no
         [fire_event]
             name=enemy_check
+            [primary_unit]
+                id=$unit.id
+            [/primary_unit]
+            [secondary_unit]
+                id=$second_unit.id
+            [/secondary_unit]
         [/fire_event]
     [/event]
     [event]
@@ -720,6 +726,32 @@
                             speaker=moderator
                             message= _ "Defeated the dracolich, I have never seen such power! We lost ten mages while trying to capture it... We will need to imagine something really bad next time."
                         [/message]
+
+                        # We're going to store/unstore the units with kill, and we're inside a die event.  Have to give XP manually.
+                        {IF_VAR unit.id not_equals $second_unit.id(
+                            [then]
+                                [store_unit]
+                                    [filter]
+                                        id=$second_unit.id
+                                    [/filter]
+                                    variable=killer
+                                    kill=yes
+                                [/store_unit]
+                                {VARIABLE exp 4}
+                                {IF_VAR unit.level greater_than 0 (
+                                    [then]
+                                        {VARIABLE exp "$($unit.level * 8)"}
+                                    [/then]
+                                )}
+                                {VARIABLE_OP killer.experience add $exp}
+                                [unstore_unit]
+                                    variable=killer
+                                    find_vacant=no
+                                [/unstore_unit]
+                                {CLEAR_VARIABLE exp,killer}
+                            [/then]
+                        )}
+
                         {MOVE_UNIT side=1 24 5}
                         {HEAL_PARTY}
                         {VARIABLE progress 6}
@@ -875,7 +907,6 @@
                             speaker=moderator
                             message= _ "Oh yes, the hellhounds were defeated by our brave heroes. Do you know what awaits them next?"
                         [/message]
-                        {HEAL_VRITRA}
                         [message]
                             speaker=Vritra
                             message= _ "Some bloody fun on your face?"
@@ -914,6 +945,31 @@
                             speaker=moderator
                             message= _ "They are strong, great, we will prepare greater challenges for them next time."
                         [/message]
+                        # We're going to store/unstore the units with kill, and we're inside a die event.  Have to give XP manually.
+                        {IF_VAR unit.id not_equals $second_unit.id(
+                            [then]
+                                [store_unit]
+                                    [filter]
+                                        id=$second_unit.id
+                                    [/filter]
+                                    variable=killer
+                                    kill=yes
+                                [/store_unit]
+                                {VARIABLE exp 4}
+                                {IF_VAR unit.level greater_than 0 (
+                                    [then]
+                                        {VARIABLE exp "$($unit.level * 8)"}
+                                    [/then]
+                                )}
+                                {VARIABLE_OP killer.experience add $exp}
+                                [unstore_unit]
+                                    variable=killer
+                                    find_vacant=no
+                                [/unstore_unit]
+                                {CLEAR_VARIABLE exp,killer}
+                            [/then]
+                        )}
+
                         {MOVE_UNIT side=1 24 5}
                         {HEAL_PARTY}
                         {VARIABLE progress 3}


### PR DESCRIPTION
In Path to Glory, I never got XP for killing the dracolich.  This fixes that case, and another I hadn't noticed.

In each round, when the last unit of side 2 is killed a die event calls enemy_check, which might store side 1 with kill.  If it does so, since the die event has not completed, the XP for the kill goes to the dead instance of the killer.  At least, I'm pretty sure that's what was happening.  So I give them the XP manually.

If a unit dies from a secondary effect, like explosive attacks, no XP is given.

XP now given if a unit dies from incinerate.

enemy_check is also called from new turn "#For the case of something went wrong".  In that case, there's no unit/second, so no one gets XP.

Tested on 1.16.9.  Tested incinerate kill, kill w/o advancement, kill with one or more advancements, and just for laughs kill from incinerate but incinerator has died.
