### PR TITLE
Keep the old id to preserve compatibility with old saves

### DIFF
--- a/_main.cfg
+++ b/_main.cfg
@@ -122,7 +122,7 @@ Legend of the Invincibles, Part II: Into the Light"
     {LOTI_EXTRA_ADVANCEMENT_LINES}
 [/campaign]
 [campaign]
-    id="Legend_of_the_Invincibles_II"
+    id="Legend_of_the_Invincibles_VI"
     name= _ "Legend of the Invincibles"+ "
 " +_"Part II:  Into the Light"
     define=CAMPAIGN_LEGEND_OF_THE_INVINCIBLES_PART_II


### PR DESCRIPTION
The recent change of the second campaign's id breaks the compatibility with older saves: they load but players can no longer change difficulty mid-campaign. I myself had to change difficulty when I played LotI first time, so keeping that working is necessary in my opinion. IDs aren't seen by players anyway (except when in debug mode, which is not the mod in which most players play anyway), and being able to change difficulty is more important