### PR TITLE
Fix nil error if [damage] special lacks id

### DIFF
--- a/lua/stats.lua
+++ b/lua/stats.lua
@@ -569,7 +569,7 @@ function wesnoth.update_stats(original)
 		local best_backstab_mult = 0
 		local best_backstab
 		for i = #specials,1,-1 do
-			if specials[i][1] == "damage" and string.match(specials[i][2].id, "backstab") then
+			if specials[i][1] == "damage" and specials[i][2].id and string.match(specials[i][2].id, "backstab") then
 				local quality = specials[i][2].multiply
 
 				if quality then


### PR DESCRIPTION
Playing in a custom era, I found some unit being unrecruitable because of a lua error in stats.lua:572. The unit had a ``[damage]`` weapon special without id which caused the code to fail (match receieved nil as the 1st arg)