### PR TITLE
Move halos to abilities(wesnoth 1.18 and later)

### DIFF
--- a/lua/stats.lua
+++ b/lua/stats.lua
@@ -645,18 +645,6 @@ function wesnoth.update_stats(original)
 	if sorts_owned.amulet or sorts_owned.ring or sorts_owned.cloak or sorts_owned.limited then
 		table.insert(new_overlays, "misc/orb-overlay.png")
 	end
-	local has_leadership_item = false
-	for _, eff in loti.unit.effects(remade) do
-		if eff.apply_to == "new_ability" then
-			local abilities = wml.get_child(eff, "abilities")
-			if abilities and wml.get_child(abilities, "leadership") then
-				has_leadership_item = true
-			end
-		end
-	end
-	if has_leadership_item then
-		table.insert(new_overlays, "misc/fist-overlay.png")
-	end
 	local overlays_object = { "object", { visual_provider = true, { "effect", { apply_to = "overlay", add = table.concat(new_overlays, ",")}}}}
 	table.insert(visible_modifications, overlays_object)
 

--- a/lua/stats.lua
+++ b/lua/stats.lua
@@ -630,23 +630,6 @@ function wesnoth.update_stats(original)
 			elseif ability.value < 0 then
 				remade.halo = "halo/darkens-aura.png"
 			end
-		elseif name == "berserk" and ability.id == "berserk_leadership" then
-			remade.halo = "misc/berserk-1.png:100,misc/berserk-2.png:100,misc/berserk-3.png:100,misc/berserk-2.png:100"
-		elseif name == "damage" and ability.id == "charge_leadership" then
-			remade.halo = "misc/charge-1.png:100,misc/charge-2.png:100,misc/charge-3.png:100,misc/charge-2.png:100"
-		elseif name == "poison" and ability.id == "poison_leadership" then
-			remade.halo = "misc/poison-1.png:200,misc/poison-2.png:200,misc/poison-3.png:200,misc/poison-2.png:200"
-		elseif name == "firststrike" and ability.id == "firststrike_leadership" then
-			remade.halo = "misc/firststrike-1.png:100,misc/firststrike-2.png:100,misc/firststrike-3.png:100"
-		elseif name == "damage" and ability.id == "backstab_leadership" then
-			remade.halo = "misc/backstab-1.png:200,misc/backstab-2.png:200,misc/backstab-3.png:200,misc/backstab-2.png:200"
-		elseif name == "chance_to_hit" and ability.id == "marksman_leadership" then
-			remade.halo = "misc/marksman-1.png:100,misc/marksman-2.png:100,misc/marksman-3.png:100,misc/marksman-2.png:100"
-		elseif name == "drains" and ability.id == "drain_leadership" then
-			remade.halo = "misc/drain-1.png:200,misc/drain-2.png:200,misc/drain-3.png:200,misc/drain-2.png:200"
-		elseif name == "dummy" and ability.id == "northfrost aura" then
-			remade.halo = "halo/blizzard-1.png~O(40%):100,halo/blizzard-2.png~O(40%):100,halo/blizzard-3.png~O(40%):100"
-
 		end
 	end
 

--- a/lua/stats.lua
+++ b/lua/stats.lua
@@ -620,19 +620,6 @@ function wesnoth.update_stats(original)
 		table.insert(visible_modifications, { "object", visual_obj})
 	end
 
-	-- Make some abilities have a visual effect
-	for i = 1,#remade_abilities do
-		local ability = remade_abilities[i][2]
-		local name = remade_abilities[i][1]
-		if name == "illuminates" then
-			if ability.value > 0 then
-				remade.halo = "halo/illuminates-aura.png"
-			elseif ability.value < 0 then
-				remade.halo = "halo/darkens-aura.png"
-			end
-		end
-	end
-
 	local new_overlays = {}
 	if is_loyal then
 		table.insert(new_overlays, "misc/loyal-icon.png")

--- a/scenarios4/13_The_Way_of_Assassins.cfg
+++ b/scenarios4/13_The_Way_of_Assassins.cfg
@@ -271,7 +271,7 @@ A good plan. Let us go."
                     [effect]
                         apply_to=new_ability
                         [abilities]
-                            {ABILITY_ILLUMINATES}
+                            {ABILITY_ILLUMINATES_LOTI}
                         [/abilities]
                     [/effect]
                 [/advancement]

--- a/scenarios5/05_We_Walk_in_the_Shadows.cfg
+++ b/scenarios5/05_We_Walk_in_the_Shadows.cfg
@@ -26,7 +26,7 @@
                 [effect]
                     apply_to=new_ability
                     [abilities]
-                        {ABILITY_ILLUMINATES}
+                        {ABILITY_ILLUMINATES_LOTI}
                     [/abilities]
                 [/effect]
             [/object]

--- a/spinoffs/The_Beautiful_Child/units/Bringer_of_Light.cfg
+++ b/spinoffs/The_Beautiful_Child/units/Bringer_of_Light.cfg
@@ -6,7 +6,6 @@
     gender=male
     image="units/humans/celestial.png"
     profile="portraits/humans/mage-light.png"
-    halo=halo/illuminates-aura.png
     hitpoints=500
     {QUANTITY hitpoints 300 500 700}
     movement_type=smallfoot
@@ -62,7 +61,7 @@
             description= _ "Spell Casting: At the beginning of this unit's turn, a spell is cast. It can be holy fire that ignites ground under him, it can be a call to arms that brings new soldiers to him or a burst of blinding light that limits the chance to hit of nearby enemies."
 #endif
         [/dummy]
-        {ABILITY_ILLUMINATES}
+        {ABILITY_ILLUMINATES_LOTI}
         {ABILITY_CURES}
         {ABILITY_REGENERATES_OTHER 40}
     [/abilities]

--- a/spinoffs/The_Beautiful_Child/units/Bringer_of_Light2.cfg
+++ b/spinoffs/The_Beautiful_Child/units/Bringer_of_Light2.cfg
@@ -6,7 +6,6 @@
     gender=male
     image="units/humans/celestial.png"
     profile="portraits/humans/mage-light.png"
-    halo=halo/illuminates-aura.png
     hitpoints=400
     {QUANTITY hitpoints 250 400 600}
     movement_type=smallfoot
@@ -64,7 +63,7 @@
             description= _ "Spell Casting: At the beginning of this unit's turn, a spell is cast. It can be teleportation that moves him somewhere nearby, it can be a call beyond death that causes fallen warriors to return to help him or a burst of blinding light that limits the chance to hit of nearby enemies."
 #endif
         [/dummy]
-        {ABILITY_ILLUMINATES}
+        {ABILITY_ILLUMINATES_LOTI}
         {ABILITY_CURES}
         {ABILITY_REGENERATES_OTHER 32}
     [/abilities]

--- a/spinoffs/The_Beautiful_Child/units/Bringer_of_Light3.cfg
+++ b/spinoffs/The_Beautiful_Child/units/Bringer_of_Light3.cfg
@@ -67,7 +67,6 @@
     gender=male
     image="units/humans/celestial.png"
     profile="portraits/humans/mage-light.png"
-    halo=halo/illuminates-aura.png
     hitpoints=400
     {QUANTITY hitpoints 250 400 600}
     movement_type=smallfoot
@@ -125,7 +124,7 @@
             description= _ "Spell Casting: At the beginning of this unit's turn, a spell is cast. It can be an acid rain that creates areas that poison and damage all units inside, it can be a healing spell that allows him to recover a lot of hitpoints or burden of sin that causes nearby units to break through the floor and fall."
 #endif
         [/dummy]
-        {ABILITY_ILLUMINATES}
+        {ABILITY_ILLUMINATES_LOTI}
         {ABILITY_CURES}
         {ABILITY_REGENERATES_OTHER 32}
     [/abilities]

--- a/units/Argan_lich.cfg
+++ b/units/Argan_lich.cfg
@@ -109,7 +109,7 @@ Advancements with crossbow add great precision."
         image="portraits/humans/marshal.png"
     [/portrait]
     [abilities]
-        {ABILITY_LEADERSHIP}
+        {ABILITY_LEADERSHIP_LOTI}
         {ABILITY_SOUL_EATER}
         {ABILITY_REGENERATES}
         {ABILITY_SUBMERGE}

--- a/units/Celestial_Messenger.cfg
+++ b/units/Celestial_Messenger.cfg
@@ -6,7 +6,6 @@
     gender=male,female
     image="units/humans/celestial.png"
     profile="portraits/humans/mage-light.png"
-    halo=halo/illuminates-aura.png
     hitpoints=61
     movement_type=smallfly
     movement=6
@@ -67,7 +66,7 @@ Thanks to the feathered wings on their backs, they can travel much faster throug
         image="portraits/humans/mage-light.png"
     [/portrait]
     [abilities]
-        {ABILITY_ILLUMINATES}
+        {ABILITY_ILLUMINATES_LOTI}
         {ABILITY_CURES}
     [/abilities]
     [resistance]
@@ -723,7 +722,7 @@ Thanks to the feathered wings on their backs, they can travel much faster throug
             [effect]
                 apply_to=remove_ability
                 [abilities]
-                    {ABILITY_ILLUMINATES}
+                    {ABILITY_ILLUMINATES_LOTI}
                 [/abilities]
             [/effect]
             [effect]

--- a/units/Duke.cfg
+++ b/units/Duke.cfg
@@ -39,7 +39,7 @@
         impact=75
     [/resistance]
     [abilities]
-        {ABILITY_LEADERSHIP}
+        {ABILITY_LEADERSHIP_LOTI}
         {ABILITY_CHARGE_LEADERSHIP}
     [/abilities]
     [attack]
@@ -237,7 +237,7 @@
             [effect]
                 apply_to=remove_ability
                 [abilities]
-                    {ABILITY_LEADERSHIP}
+                    {ABILITY_LEADERSHIP_LOTI}
                 [/abilities]
             [/effect]
             [effect]

--- a/units/Elvish_Warlord.cfg
+++ b/units/Elvish_Warlord.cfg
@@ -38,7 +38,7 @@
         image="portraits/elves/captain.png"
     [/portrait]
     [abilities]
-        {ABILITY_LEADERSHIP}
+        {ABILITY_LEADERSHIP_LOTI}
         {ABILITY_MARKSMAN_LEADERSHIP}
     [/abilities]
     [attack]
@@ -318,7 +318,7 @@
             [effect]
                 apply_to=remove_ability
                 [abilities]
-                    {ABILITY_LEADERSHIP}
+                    {ABILITY_LEADERSHIP_LOTI}
                 [/abilities]
             [/effect]
             [effect]

--- a/units/Fire_Dragon.cfg
+++ b/units/Fire_Dragon.cfg
@@ -8,7 +8,7 @@
     image="units/enemies/fire-dragon.png"
     {DEFENSE_ANIM_RANGE "units/monsters/fire-dragon.png" "units/monsters/fire-dragon.png" {SOUND_LIST:DRAKE_HIT} melee}
     [abilities]
-        {ABILITY_LEADERSHIP}
+        {ABILITY_LEADERSHIP_LOTI}
     [/abilities]
     hitpoints=101
     movement_type=drakefly

--- a/units/Goblin_Warbaner.cfg
+++ b/units/Goblin_Warbaner.cfg
@@ -20,7 +20,7 @@
     die_sound={SOUND_LIST:GOBLIN_DIE}
     {DEFENSE_ANIM "units/orcs/goblinwarbanner.png" "units/orcs/goblinwarbanner.png" {SOUND_LIST:GOBLIN_HIT} }
     [abilities]
-        {ABILITY_LEADERSHIP}
+        {ABILITY_LEADERSHIP_LOTI}
     [/abilities]
     [portrait]
         size=400
@@ -323,7 +323,7 @@
             [effect]
                 apply_to=remove_ability
                 [abilities]
-                    {ABILITY_LEADERSHIP}
+                    {ABILITY_LEADERSHIP_LOTI}
                 [/abilities]
             [/effect]
             [effect]

--- a/units/Infernal_Knight.cfg
+++ b/units/Infernal_Knight.cfg
@@ -23,7 +23,7 @@
     description= _ "Tales are told of the mightiest warriors and generals, who, cursed with hate and stung by betrayal, have experimented with demonic magic and returned back to this world as Infernal Knights. Wielding the same weapons as in life, they command both fire and the Undead in their quest for revenge."
     die_sound=lich-die.ogg
     [abilities]
-        {ABILITY_LEADERSHIP}
+        {ABILITY_LEADERSHIP_LOTI}
         {ABILITY_SUBMERGE}
     [/abilities]
     [portrait]
@@ -300,7 +300,7 @@
             [effect]
                 apply_to=remove_ability
                 [abilities]
-                    {ABILITY_LEADERSHIP}
+                    {ABILITY_LEADERSHIP_LOTI}
                 [/abilities]
             [/effect]
             [effect]

--- a/units/Lich_King.cfg
+++ b/units/Lich_King.cfg
@@ -19,7 +19,7 @@
     description= _ "Lich Kings are powerful undead warriors with free will and magic powers. Unlike other undead, they are not obeying a master, they are raising and controlling their minions, and unlike liches, they are leading their minions into battles."
     die_sound=lich-die.ogg
     [abilities]
-        {ABILITY_LEADERSHIP}
+        {ABILITY_LEADERSHIP_LOTI}
         {ABILITY_SUBMERGE}
     [/abilities]
     [portrait]
@@ -387,7 +387,7 @@
             [effect]
                 apply_to=remove_ability
                 [abilities]
-                    {ABILITY_LEADERSHIP}
+                    {ABILITY_LEADERSHIP_LOTI}
                 [/abilities]
             [/effect]
             [effect]

--- a/units/Prophet.cfg
+++ b/units/Prophet.cfg
@@ -6,7 +6,6 @@
     gender=male,female
     image="units/humans/prophet.png"
     profile="portraits/humans/mage-light.png"
-    halo=halo/illuminates-aura.png
     hitpoints=85
     movement_type=mounted
     movement=8
@@ -36,7 +35,7 @@
         arcane=40
     [/resistance]
     [abilities]
-        {ABILITY_ILLUMINATES}
+        {ABILITY_ILLUMINATES_LOTI}
         {ABILITY_CURES}
     [/abilities]
     [healing_anim]

--- a/units/Stormrider.cfg
+++ b/units/Stormrider.cfg
@@ -668,7 +668,7 @@
             [effect]
                 apply_to=new_ability
                 [abilities]
-                    {ABILITY_ILLUMINATES}
+                    {ABILITY_ILLUMINATES_LOTI}
                 [/abilities]
             [/effect]
             {GREATER_AMLA_DEFAULT_BONUSES}
@@ -684,7 +684,7 @@
             [effect]
                 apply_to=remove_ability
                 [abilities]
-                    {ABILITY_ILLUMINATES}
+                    {ABILITY_ILLUMINATES_LOTI}
                 [/abilities]
             [/effect]
             [effect]

--- a/units/The_Prince.cfg
+++ b/units/The_Prince.cfg
@@ -45,7 +45,7 @@
         arcane=60
     [/resistance]
     [abilities]
-        {ABILITY_LEADERSHIP}
+        {ABILITY_LEADERSHIP_LOTI}
     [/abilities]
 #textdomain wesnoth-units
     [attack]

--- a/units/corruption.cfg
+++ b/units/corruption.cfg
@@ -784,7 +784,7 @@
     [/portrait]
     {DEFENSE_ANIM "units/elves-wood/captain-defend.png" "units/elves-wood/captain.png" {SOUND_LIST:ELF_HIT}}
     [abilities]
-        {ABILITY_LEADERSHIP}
+        {ABILITY_LEADERSHIP_LOTI}
     [/abilities]
     [attack]
         name=sword

--- a/units/demon_infiltrators.cfg
+++ b/units/demon_infiltrators.cfg
@@ -830,7 +830,6 @@ Following a strict code of piety and honor, these men and women work tirelessly 
     gender=male,female
     image="units/humans/celestial.png"
     profile="portraits/humans/mage-light.png"
-    halo=halo/illuminates-aura.png
     hitpoints=211
     movement_type=smallfoot
     movement=6
@@ -870,7 +869,7 @@ Following a strict code of piety and honor, these men and women work tirelessly 
         image="portraits/humans/mage-light.png"
     [/portrait]
     [abilities]
-        {ABILITY_ILLUMINATES}
+        {ABILITY_ILLUMINATES_LOTI}
         {ABILITY_CURES}
     [/abilities]
     [resistance]
@@ -1309,7 +1308,6 @@ Following a strict code of piety and honor, these men and women work tirelessly 
     gender=male,female
     image="units/humans/prophet.png"
     profile="portraits/humans/mage-light.png"
-    halo=halo/illuminates-aura.png
     hitpoints=235
     movement_type=mounted
     movement=8
@@ -1341,7 +1339,7 @@ Following a strict code of piety and honor, these men and women work tirelessly 
         arcane=30
     [/resistance]
     [abilities]
-        {ABILITY_ILLUMINATES}
+        {ABILITY_ILLUMINATES_LOTI}
         {ABILITY_CURES}
     [/abilities]
     [healing_anim]

--- a/utils/abilities.cfg
+++ b/utils/abilities.cfg
@@ -314,6 +314,7 @@
         max_value=25
         cumulative=no
         affect_self=yes
+        halo_image="halo/darkens-aura.png"
         name= _ "darkens"
         female_name= _ "female^darkens"
         description= _ "This unit darkens the surrounding area, making chaotic units fight better, and lawful units fight worse.
@@ -330,6 +331,7 @@ Any units adjacent to this unit will fight as if it were dusk when it is day, as
         female_name=_"female^darkens badly"
         name= _ "darkens badly"
         id=darkens
+        halo_image="halo/darkens-aura.png"
         value=-25
         min_value=-50
         max_value=25
@@ -346,6 +348,7 @@ Any units adjacent to this unit will fight almost as if it were night when it is
         female_name=_"female^darkens severely"
         id=darkens
         name= _ "darkens severely"
+        halo_image="halo/darkens-aura.png"
         value=-40
         min_value=-50
         max_value=25
@@ -365,7 +368,11 @@ Any units adjacent to this unit will fight almost as if it were night when it is
 
 Any units adjacent to this unit will fight as if it were dusk when it is night, as if it were day when it is dusk, and even better during the day (worse if they are chaotic or liminal)."
         affect_self=yes
+        halo_image="halo/illuminates-aura.png"
     [/illuminates]
+#enddef
+#define ABILITY_ILLUMINATES_LOTI
+    {ABILITY_ILLUMINATES HALO="halo/illuminates-aura.png"}
 #enddef
 #define ABILITY_ILLUMINATES_GREAT
     [illuminates]
@@ -379,6 +386,7 @@ Any units adjacent to this unit will fight as if it were dusk when it is night, 
 
 Any units adjacent to this unit will fight as if it were almost day when it is night, better than if it were day when it is dusk, and far better during the day (worse if they are chaotic or liminal)."
         affect_self=yes
+        halo_image="halo/illuminates-aura.png"
     [/illuminates]
 #enddef
 #define WEAPON_SPECIAL_CHARGING_BACKSTAB

--- a/utils/abilities.cfg
+++ b/utils/abilities.cfg
@@ -1,3 +1,27 @@
+#textdomain wesnoth-help
+
+#define ABILITY_LEADERSHIP_LOTI
+    # same what mainline but with overlay_image_self attribute
+    [leadership]
+        id=leadership
+        value="(25 * (level - other.level))"
+        cumulative=no
+        name= _ "leadership"
+        female_name= _ "female^leadership"
+        description= _ "This unit can lead other troops in battle.
+
+All adjacent lower-level units from the same side deal 25% more damage for each difference in level."
+        special_note={INTERNAL:SPECIAL_NOTES_LEADERSHIP}
+        affect_self=no
+        overlay_image_self="misc/fist-overlay.png"
+        [affect_adjacent]
+            [filter]
+                formula="level < other.level"
+            [/filter]
+        [/affect_adjacent]
+    [/leadership]
+#enddef
+
 #textdomain wesnoth-loti
 #define WEAPON_SPECIAL_PLAGUE_TYPE_LOTI TYPE LANGUAGE_TYPE
     [plague]
@@ -561,6 +585,7 @@ Enemy units cannot see this unit during dawn or dusk, except if they have units 
         female_name={NAME}+_" ("+{INTENSITY}+_")"
         description= _ "Adjacent allies will do "+{INTENSITY}+_"% more damage."
         affect_self=no
+        overlay_image_self="misc/fist-overlay.png"
         [affect_adjacent]
             adjacent=n,ne,se,s,sw,nw
         [/affect_adjacent]
@@ -599,6 +624,7 @@ Enemy units cannot see this unit during dawn or dusk, except if they have units 
         description= _ "This unit can lead your own units that are next to it, making them fight better.  Adjacent own units of lower level will do more damage in battle. When a unit adjacent to, of a lower level than, and on the same side as a unit with Leadership engages in combat, its attacks do 25% more damage times the difference in their levels."
         special_note = _"The leadership of this unit enables adjacent units of the same side to deal more damage in combat, though this only applies to units of lower level."
         affect_self=no
+        overlay_image_self="misc/fist-overlay.png"
         [affect_adjacent]
             [filter]
                 formula="level < " + {LEVEL}

--- a/utils/abilities.cfg
+++ b/utils/abilities.cfg
@@ -1660,6 +1660,7 @@ Enemy units cannot see this unit during dawn or dusk, except if they have units 
         name= _ "northfrost aura"
         female_name= _ "female^northfrost aura"
         description= _ "All enemies in the range of two hexes from this unit will be slowed at the beginning of their turn."
+        halo_image_self="halo/blizzard-1.png~O(40%):100,halo/blizzard-2.png~O(40%):100,halo/blizzard-3.png~O(40%):100"
     [/dummy]
 #enddef
 #define ABILITY_SPELL_EATER
@@ -1689,6 +1690,7 @@ Enemy units cannot see this unit during dawn or dusk, except if they have units 
         female_name= _ "female^radiating insanity"
         description= _ "All nearby allies fight with a bloodlust equal to the dwarvish berserk on melee attacks."
         value=30
+        halo_image_self="misc/berserk-1.png:100,misc/berserk-2.png:100,misc/berserk-3.png:100,misc/berserk-2.png:100"
         [filter_student]
             [filter_weapon]
                 range=melee
@@ -1708,6 +1710,7 @@ Enemy units cannot see this unit during dawn or dusk, except if they have units 
         female_name= _ "female^warlord's rule"
         description= _ "All nearby allies deal and take 50% more melee damage."
         special_note=_" This unit can fanaticise all units adjacent to him into a frenzy, making them deal and take double melee damage, but only offensively."
+        halo_image_self="misc/charge-1.png:100,misc/charge-2.png:100,misc/charge-3.png:100,misc/charge-2.png:100"
         [filter_student]
             [filter_weapon]
                 range=melee
@@ -1731,6 +1734,7 @@ Enemy units cannot see this unit during dawn or dusk, except if they have units 
         description= _ "All nearby allies get poisonous attacks."
         affect_self=no
         affect_allies=yes
+        halo_image_self="misc/poison-1.png:200,misc/poison-2.png:200,misc/poison-3.png:200,misc/poison-2.png:200"
         [affect_adjacent]
         [/affect_adjacent]
     [/poison]
@@ -1743,6 +1747,7 @@ Enemy units cannot see this unit during dawn or dusk, except if they have units 
         description= _ "All nearby allies get firststrike."
         affect_self=no
         affect_allies=yes
+        halo_image_self="misc/firststrike-1.png:100,misc/firststrike-2.png:100,misc/firststrike-3.png:100"
         [affect_adjacent]
         [/affect_adjacent]
     [/firststrike]
@@ -1758,6 +1763,7 @@ Enemy units cannot see this unit during dawn or dusk, except if they have units 
         active_on=offense
         affect_self=no
         affect_allies=yes
+        halo_image_self="misc/backstab-1.png:200,misc/backstab-2.png:200,misc/backstab-3.png:200,misc/backstab-2.png:200"
         [filter_student]
             [filter_weapon]
                 range=melee
@@ -1792,6 +1798,7 @@ Enemy units cannot see this unit during dawn or dusk, except if they have units 
         value=60
         cumulative=yes
         active_on=offense
+        halo_image_self="misc/marksman-1.png:100,misc/marksman-2.png:100,misc/marksman-3.png:100,misc/marksman-2.png:100"
         [filter_student]
             [filter_weapon]
                 range=ranged
@@ -1811,6 +1818,7 @@ Enemy units cannot see this unit during dawn or dusk, except if they have units 
         description= _ "All adjacent allies gain melee drain that drains 25% of the damage dealt (instead of the usual 50%)."
         value=25
         cumulative=no
+        halo_image_self="misc/marksman-1.png:100,misc/marksman-2.png:100,misc/marksman-3.png:100,misc/marksman-2.png:100"
         [filter_student]
             [filter_weapon]
                 range=melee

--- a/utils/amla.cfg
+++ b/utils/amla.cfg
@@ -3297,7 +3297,7 @@ Adjacent own units will do 25% more damage and will have 20% better resistances.
         [effect]
             apply_to=new_ability
             [abilities]
-                {ABILITY_ILLUMINATES}
+                {ABILITY_ILLUMINATES_LOTI}
             [/abilities]
         [/effect]
         {AMLA_DEFAULT_BONUSES}
@@ -3325,7 +3325,7 @@ Adjacent own units will do 25% more damage and will have 20% better resistances.
         [effect]
             apply_to=remove_ability
             [abilities]
-                {ABILITY_ILLUMINATES}
+                {ABILITY_ILLUMINATES_LOTI}
             [/abilities]
         [/effect]
         [effect]

--- a/utils/item_list.cfg
+++ b/utils/item_list.cfg
@@ -452,7 +452,7 @@ Stand up and see the sky turn bright"
         [effect]
             apply_to=new_ability
             [abilities]
-                {ABILITY_ILLUMINATES}
+                {ABILITY_ILLUMINATES_LOTI}
                 {ABILITY_UNHOLYBANE 12}
             [/abilities]
         [/effect]
@@ -1053,7 +1053,7 @@ Stand up and see the sky turn bright"
         [effect]
             apply_to=new_ability
             [abilities]
-                {ABILITY_ILLUMINATES}
+                {ABILITY_ILLUMINATES_LOTI}
             [/abilities]
         [/effect]
         flavour=_"Let the light show you the way into the darkness that you can enlighten."
@@ -1296,7 +1296,7 @@ Adjacent own units will do 30% more damage and will have 20% better resistances.
         [effect]
             apply_to=new_ability
             [abilities]
-                {ABILITY_ILLUMINATES}
+                {ABILITY_ILLUMINATES_LOTI}
             [/abilities]
         [/effect]
         arcane_resist=10

--- a/utils/item_list.cfg
+++ b/utils/item_list.cfg
@@ -1079,6 +1079,7 @@ Stand up and see the sky turn bright"
 
 Adjacent own units will do 30% more damage and will have 20% better resistances."
                     affect_self=no
+                    overlay_image_self="misc/fist-overlay.png"
                     [affect_adjacent]
                         adjacent=n,ne,se,s,sw,nw
                     [/affect_adjacent]
@@ -1404,6 +1405,7 @@ Adjacent own units will do 30% more damage and will have 20% better resistances.
 
 Adjacent own units will do 20% more damage and will have 10% better resistances."
                     affect_self=no
+                    overlay_image_self="misc/fist-overlay.png"
                     [affect_adjacent]
                         adjacent=n,ne,se,s,sw,nw
                     [/affect_adjacent]


### PR DESCRIPTION

after https://github.com/wesnoth/wesnoth/commit/a17369597c4869938d0a44a70bd9708452c0fd6b, it is possible what abilities
support directly halos image_halo atttribute is usded for give halo to units under influence of abilities when active,
halo_image_self give halo to owner of abilites when active(filter and attribute specific of abilities used like specials wasn't concerned)