### PR TITLE
fix typo

### DIFF
--- a/scenarios9/48_Execrable_Sanctum.cfg
+++ b/scenarios9/48_Execrable_Sanctum.cfg
@@ -904,7 +904,7 @@
                 [if]
                     [have_unit]
                         side=1
-                        x,y=28-26,15-23
+                        x,y=28-36,15-23
                     [/have_unit]
                     [else]
                         [teleport]


### PR DESCRIPTION
The area search for Uria teleport locations has a typo where a 2 (two) instead of 3 (three) makes the unit location search always fail for one option.