### PR TITLE
In ch8 scenario The Desert, undead no longer spawn on keeps.

### DIFF
--- a/scenarios8/08_The_Desert.cfg
+++ b/scenarios8/08_The_Desert.cfg
@@ -326,7 +326,7 @@
         {CLEAR_VARIABLE spawn_type,spawn_x,spawn_y,spawn_side,spawn_count}
         [kill]
             [filter_location]
-                terrain=Xu,Md^Xm,Ql
+                terrain=Xu,Md^Xm,Ql,K*
             [/filter_location]
             side=6,7,8
         [/kill]


### PR DESCRIPTION
It prevents the leader from recruiting when they do. They can still spawn on castle tiles, which reduces the amount a leader can recruit.