### PR TITLE
Now clearing dazzle on victory.

### DIFF
--- a/utils/abilities_events.cfg
+++ b/utils/abilities_events.cfg
@@ -6715,5 +6715,47 @@
         [/for]
         {CLEAR_VARIABLE undazzle}
     [/event]
+    [event]
+        name=victory
+
+        [store_unit]
+            [filter]
+                status=dazzled
+            [/filter]
+            variable=undazzle
+        [/store_unit]
+        [for]
+            array=undazzle
+            [do]
+                [unstore_unit]
+                    variable=undazzle[$i]
+                [/unstore_unit]
+
+                [object]
+                    silent=yes
+                    sort=potion_like
+                    [filter]
+                        find_in=undazzle[$i]
+                    [/filter]
+                    [effect]
+                        apply_to=status
+                        remove=dazzled
+                    [/effect]
+                    [effect]
+                        apply_to=image_mod
+                        replace="CS(0,0,0)"
+                    [/effect]
+                    [effect]
+                        apply_to=attack
+                        remove_specials=dazzled
+                    [/effect]
+                [/object]
+
+                {CLEAR_VARIABLE undazzle[$i].variables.side_turn_dazzled}
+                {CLEAR_VARIABLE undazzle[$i].variables.turn_dazzled}
+            [/do]
+        [/for]
+        {CLEAR_VARIABLE undazzle}
+    [/event]
 
 #enddef


### PR DESCRIPTION
This happened to me not too long ago.

1. Efraim got dazzled on turn 61, side turn 11.
2. I finished the scenario on turn 62, side turn 1.
3. Turn 62, side turn 11 never ran, so dazzle wasn't removed. It carried over to the next two scenarios before I intervened.