### PR TITLE
Update 03s_In_the_Magical_Mirror.cfg

### DIFF
--- a/scenarios2/03s_In_the_Magical_Mirror.cfg
+++ b/scenarios2/03s_In_the_Magical_Mirror.cfg
@@ -719,9 +719,7 @@
         [/message]
         [kill]
             side=5
-            [filter]
-                race=elf
-            [/filter]
+            race=elf
             [not]
                 id=Verderber
             [/not]


### PR DESCRIPTION
1.17: The [kill] tag now explicitly no longer accepts [filter].

Scenario aborts in 1.17 if [filter] included.  Works in 1.16.10 and 1.17.25 when removed.  Not sure about anything earlier.

https://forums.wesnoth.org/viewtopic.php?p=686708#p686708