### PR TITLE
wesnoth.get_time_of_day > wesnoth.schedule.get_illumination

### DIFF
--- a/lua/main.lua
+++ b/lua/main.lua
@@ -186,7 +186,7 @@ function wesnoth.wml_actions.harm_unit_loti(cfg)
 
 			local damage = calculate_damage( amount,
 							 ( cfg.alignment or "neutral" ),
-							 wesnoth.get_time_of_day( { unit_to_harm.x, unit_to_harm.y, true } ).lawful_bonus,
+							 wesnoth.schedule.get_illumination( { unit_to_harm.x, unit_to_harm.y } ).lawful_bonus,
 							 100 - wesnoth.units.resistance_against( unit_to_harm, cfg.damage_type or "dummy" ),
 							 resistance_multiplier
 						       )


### PR DESCRIPTION
Tested in 1.16.10 and 1.17.25.

Currently get_time_of_day only triggers a warning in debug mode, but I got tired of looking at it.

https://wiki.wesnoth.org/LuaAPI/UpdatingFrom14