### PR TITLE
New locations for demon soul images

### DIFF
--- a/units/Demon_Soul.cfg
+++ b/units/Demon_Soul.cfg
@@ -1,4 +1,5 @@
 #textdomain wesnoth-loti
+#ifver WESNOTH_VERSION < 1.17.4
 [unit_type]
     id=Demon Soul
     name= _ "Demon Soul"
@@ -152,3 +153,158 @@
         [/frame]
     [/standing_anim]
 [/unit_type]
+#else
+[unit_type]
+    id=Demon Soul
+    name= _ "Demon Soul"
+    race=undead
+    image="units/undead-spirit/shadow-s-2.png~CS(-100,-200,-200)"
+    profile="portraits/undead/shadow.webp~CS(-100,-200,-200)"
+    hitpoints=182
+    movement_type=undeadspirit
+    [resistance]
+        arcane=50
+    [/resistance]
+    movement=5
+    experience=200
+    level=5
+    alignment=chaotic
+    advances_to=null
+    {AMLA_DEFAULT}
+    cost=79
+    usage=scout
+    description= _ "Worship of dark deities can bind a demon in his revered place of rest and force him to guard it. These undead demons are restless, unable to get too far from their grave, but no adventurer who ever visits Inferno is strongly advised not to approach these places."
+    [portrait]
+        size=400
+        side="left"
+        mirror="false"
+        image="portraits/undead/shadow.webp~CS(-100,-200,-200)"
+    [/portrait]
+    [portrait]
+        size=400
+        side="right"
+        mirror="true"
+        image="portraits/undead/shadow.webp~CS(-100,-200,-200)"
+    [/portrait]
+    die_sound=wail-long.wav
+    [abilities]
+        {ABILITY_NIGHTSTALK}
+        {ABILITY_SKIRMISHER}
+    [/abilities]
+    [defend]
+        start_time=-126
+        [if]
+            hits=hit
+            offset=0.0~-0.05:126,-0.05~0.0:126
+            alpha=0.8~0.5:126,0.5~0.8:126
+            hit_sound_start_time=-25
+            [hit_sound_frame]
+                sound=wail-sml.wav
+            [/hit_sound_frame]
+        [/if]
+        [else]
+            hits=kill
+            offset=0.0~-0.05:126,-0.05~0.0:126
+            alpha=0.8~0.5:126,0.5~0.8:126
+        [/else]
+        [else]
+            hits=miss
+            offset=0.0~-0.1:126,-0.1~0.0:126
+            alpha=0.8~0.25:126,0.25~0.8:126
+        [/else]
+        [if]
+            direction=s,se,sw
+            [frame]
+                image=units/undead-spirit/shadow-s-2.png~CS(-100,-200,-200):1,units/undead-spirit/shadow-s-attack-1.png~CS(-100,-200,-200):250,units/undead-spirit/shadow-s-2.png~CS(-100,-200,-200):1
+            [/frame]
+        [/if]
+        [else]
+            direction=n,ne,nw
+            [frame]
+                image=units/undead-spirit/shadow-n-2.png~CS(-100,-200,-200):1,units/undead-spirit/shadow-n-attack-1.png~CS(-100,-200,-200):250,units/undead-spirit/shadow-n-2.png~CS(-100,-200,-200):1
+            [/frame]
+        [/else]
+    [/defend]
+
+    [attack]
+        name=claws
+        description=_"claws"
+        type=blade
+        icon=attacks/claws-undead.png
+        range=melee
+        damage=21
+        number=4
+        [specials]
+            {WEAPON_SPECIAL_BACKSTAB}
+        [/specials]
+    [/attack]
+    [attack_anim]
+        [filter_attack]
+            name=claws
+        [/filter_attack]
+        start_time=-500
+        offset=0.0~1.0:550,0.0:225
+        alpha=0.8~0.7:350,0.7~0.0:200,0.0~0.8:225
+        direction=n,ne,nw
+
+        [if]
+            direction=s,se,sw
+            [frame]
+                image="units/undead-spirit/shadow-s-2.png~CS(-100,-200,-200):25"
+            [/frame]
+            [frame]
+                image="units/undead-spirit/shadow-s-attack-[1~6,2,1].png~CS(-100,-200,-200):[75*2,50*2,75,200,100*2]"
+            [/frame]
+            [frame]
+                image="units/undead-spirit/shadow-s-2.png~CS(-100,-200,-200):25"
+            [/frame]
+        [/if]
+        [else]
+            direction=n,ne,nw
+            [frame]
+                image="units/undead-spirit/shadow-s-2.png~CS(-100,-200,-200):25"
+            [/frame]
+            [frame]
+                image="units/undead-spirit/shadow-s-attack-[1~6,2,1].png~CS(-100,-200,-200):[75*2,50*2,75,200,100*2]"
+            [/frame]
+            [frame]
+                image="units/undead-spirit/shadow-s-2.png~CS(-100,-200,-200):25"
+            [/frame]
+        [/else]
+        attack_sound_start_time=-325
+        [attack_sound_frame]
+            duration=50
+            sound=wail-sml.wav
+        [/attack_sound_frame]
+        [if]
+            hits=yes
+            [attack_sound_frame]
+                sound=claws.ogg
+            [/attack_sound_frame]
+        [/if]
+        [else]
+            hits=no
+            [attack_sound_frame]
+                sound={SOUND_LIST:MISS}
+            [/attack_sound_frame]
+        [/else]
+    [/attack_anim]
+
+    [standing_anim]
+        direction=s,se,sw
+        start_time=0
+        alpha=0.8~0.4:1400,0.4~0.6:600,0.6~0.4:600,0.4~0.8:1400
+        [frame]
+            image="units/undead-spirit/shadow-s-[2,1~3,2,1~3,2,1~3,2,1~3].png~CS(-100,-200,-200):250"
+        [/frame]
+    [/standing_anim]
+    [standing_anim]
+        direction=n,ne,nw
+        start_time=0
+        alpha=0.8~0.4:1400,0.4~0.6:600,0.6~0.4:600,0.4~0.8:1400
+        [frame]
+            image="units/undead-spirit/shadow-n-[2,1~3,2,1~3,2,1~3,2,1~3].png~CS(-100,-200,-200):250"
+        [/frame]
+    [/standing_anim]
+[/unit_type]
+#endif


### PR DESCRIPTION
Tested with 1.16.10 and 1.17.25.

I have no idea if 1.17.4 is the correct version to check, I just copied that from other changes.  I highly doubt it matters since pretty much anyone running 1.17 should be reasonably up to date.

P.S.  Other than some png > webp changes, which I believe are handled automatically (for now?), all of the other images listed in [Compatibility-breaking changes between 1.16 and 1.17/1.18](https://forums.wesnoth.org/viewtopic.php?p=685243#p685243) are up to date.