### PR TITLE
placement=map_passable -> use placement=map and passable=yes

### DIFF
--- a/scenarios7/15_Annihilation.cfg
+++ b/scenarios7/15_Annihilation.cfg
@@ -5,7 +5,8 @@
         x,y={X},{Y}
         side=2
         id=bleed_mist
-        placement=map_passable
+        placement=map
+        passable=yes
     [/unit]
     {ADVANCE_UNIT type=Mist "{TYPE}"}
     [store_unit]


### PR DESCRIPTION
> map_passable: If x,y are explicitly given and point to a valid on-map location - try to place unit at this location; if the hex is of an impassable terrain for the unit being placed, or is already occupied by another unit, the new unit will be placed in the nearest vacant hex. ([Version 1.13.8 and later only](https://wiki.wesnoth.org/DevFeature)) Deprecated, use placement=map and passable=yes instead.

