### PR TITLE
lesser nightstalk forest terrain

### DIFF
--- a/utils/abilities.cfg
+++ b/utils/abilities.cfg
@@ -958,7 +958,7 @@ Does not affect poisoned enemies."
         [filter_self]
             [filter_location]
                 time_of_day=chaotic
-                terrain=*^Fp,*^Fet,*^Ft,*^Fpa,*^Fd*,*^Fm*,*^V*,H*,M*,C*,K*,*^Zf*
+                terrain=*^F*,*^V*,H*,M*,C*,K*,*^Zf*
             [/filter_location]
         [/filter_self]
     [/hides]


### PR DESCRIPTION
Gave Ef nighwalker in Jungle Hell, at night, and it didn't do anything.  It looks like maybe the terrain type is newer than when this ability was created or something?  From the description, it sounds like we should just match all forest tiles?

Worked when I tested it, but all I know about terrain is what I just looked up.