### PR TITLE
Don't unstore Uria when she's dead

### DIFF
--- a/scenarios9/33_Pandemonium.cfg
+++ b/scenarios9/33_Pandemonium.cfg
@@ -368,6 +368,11 @@
                     name=turn refresh
                     first_time_only=no
                     id=uria immortality occasional
+                    [filter_side]
+                        [has_unit]
+                            id=Uria
+                        [/has_unit]
+                    [/filter_side]
                     [store_unit]
                         [filter]
                             id=Uria


### PR DESCRIPTION
`error wml: [unstore_unit]: variable 'uria_store' doesn't contain unit data
`

Perhaps it would be better to remove the event when you kill her, but I hate testing wml and this works.