### PR TITLE
more castle tiles for the ally

### DIFF
--- a/spinoffs/Affably_Evil/scenarios/01_Incarcerating.cfg
+++ b/spinoffs/Affably_Evil/scenarios/01_Incarcerating.cfg
@@ -478,6 +478,11 @@
             x,y=33-35,12
             terrain=Ce
         [/terrain]
+        [terrain]
+            x=33,35
+            y=11,11
+            terrain=Ce
+        [/terrain]
         [redraw]
         [/redraw]
         [message]


### PR DESCRIPTION
Even with the incarceration limits nudged upward, this one is still stupid hard.  As in I'd be surprised if anyone makes it to the second scenario without giving up.  The enemy is much stronger, with backstab, has ridiculous income, and can sit back and recruit while you really can't.  Your only real chance is to get pretty lucky with the gear and hope the middle leader runs out into traffic at just the right time.

Your ally has a decent income, but he can't recruit fast enough to use the gold (or make up for his losses in battle).  Giving him a couple extra tiles he can recruit from helps, but I still didn't bother to play it through to the end.  Probably need to hardcode some of the initial gear, and definitely lower enemy income (maybe moving some of it to lower base / higher gold/village so your worthless leaders can at least contribute by cutting off some of his income).  And maybe lose some villages in the middle, the enemy just parks on them and heals as much damage as you and your ally can do.

Oh yeah, AE looks ready for a 1.18 build whenever the penetration issue is fixed (if anyone has old saves that is).