### PR TITLE
Fixes to how incinerate handles kills

### DIFF
--- a/utils/abilities_events.cfg
+++ b/utils/abilities_events.cfg
@@ -3099,35 +3099,6 @@
             [/do]
         [/for]
         {CLEAR_VARIABLE unburn_store}
-
-        [store_unit]
-            [filter]
-                status=incinerated
-                [and]
-                    [filter_side]
-                        side=$side_number
-                    [/filter_side]
-                [/and]
-            [/filter]
-            variable=burn_store
-            kill=no
-        [/store_unit]
-        [for]
-            array=burn_store
-            [do]
-                [harm_unit]
-                    [filter]
-                        id=$burn_store[$i].id
-                    [/filter]
-                    amount=16
-                    damage_type=fire
-                    fire_event=yes
-                    kill=no
-                    animate=no
-                [/harm_unit]
-            [/do]
-        [/for]
-        {CLEAR_VARIABLE burn_store}
         [store_unit]
             [filter]
                 status=incinerated
@@ -3147,23 +3118,61 @@
         [/store_unit]
         [for]
             array=burn_store
+            variable=burnt  # Something in the kill messes with default variable i when it's Lilith that dies
             [do]
+                [award_extra_experience] # Do this before kill, as these may be lost when unit killed (Lilith, at least)
+                    id=$burn_store[$burnt].variables.incinerator
+                    death_of_level=$burn_store[$burnt].level
+                    defer=no
+                [/award_extra_experience]
                 [kill]
-                    id=$burn_store[$i].id
+                    id=$burn_store[$burnt].id
                     [secondary_unit]
-                        id=$burn_store[$i].variables.incinerator
+                        id=$burn_store[$burnt].variables.incinerator
                     [/secondary_unit]
                     animate=yes
                     fire_event=yes
                 [/kill]
-                [award_extra_experience]
-                    id=$burn_store[$i].variables.incinerator
-                    death_of_level=$burn_store[$i].level
-                    defer=no
-                [/award_extra_experience]
             [/do]
         [/for]
         {CLEAR_VARIABLE burn_store}
+        [store_unit]
+            [filter]
+                status=incinerated
+                [and]
+                    [filter_side]
+                        side=$side_number
+                    [/filter_side]
+                [/and]
+            [/filter]
+            variable=burn_store
+            kill=no
+        [/store_unit]
+        [for]
+            array=burn_store
+            [do]
+                {VARIABLE burn_store[$i].resting no}
+                [unstore_unit]
+                    variable=burn_store[$i]
+                [/unstore_unit]
+                [harm_unit]
+                    [filter]
+                        id=$burn_store[$i].id
+                    [/filter]
+                    amount=16
+                    damage_type=fire
+                    fire_event=yes
+                    kill=no
+                    animate=no
+                [/harm_unit]
+            [/do]
+        [/for]
+        {CLEAR_VARIABLE burn_store}
+[wml_message]
+   message="And we're outta here"
+   logger=error
+[/wml_message]
+
     [/event]
     [event]
         name=victory

--- a/utils/abilities_events.cfg
+++ b/utils/abilities_events.cfg
@@ -3064,7 +3064,6 @@
     [event]
         name=turn refresh
         first_time_only=no
-
         [store_unit]
             [filter]
                 status=incinerated
@@ -3168,11 +3167,6 @@
             [/do]
         [/for]
         {CLEAR_VARIABLE burn_store}
-[wml_message]
-   message="And we're outta here"
-   logger=error
-[/wml_message]
-
     [/event]
     [event]
         name=victory


### PR DESCRIPTION
Reordered operations so the only-kill-with-1HP and award experience stuff works properly, disabled resting for incinerated units, and added a loop variable since when Lilith is killed it was deleting the default.

Tested v1.19.0-dev (94b71ac95b2-Clean)

Closes #693 