### PR TITLE
Add level Harder

### DIFF
--- a/_main.cfg
+++ b/_main.cfg
@@ -108,6 +108,12 @@
         label=_"Tyrant"
         description=_"Hard"
     [/difficulty]
+    [difficulty]
+        define=HARDER
+        image=units/human-loyalists/shocktrooper.png~RC(magenta>red)
+        label=_"Trooper"
+        description=_"Harder (Experimental)"
+    [/difficulty]
     description= _ "Sometimes, people don't embrace the tempting powers of darkness because of desires to rule, but merely for survival. Can the dark powers be used to fight against dark schemes with no limits or will they eventually corrupt its users?
 
 (Intermediate level, 90 scenarios separated to five chapters)

--- a/lua/main.lua
+++ b/lua/main.lua
@@ -194,7 +194,7 @@ function wesnoth.wml_actions.harm_unit_loti(cfg)
 						       )
 
 			if unit_to_harm.hitpoints <= damage then
-				if kill then 
+				if kill then
 					damage = unit_to_harm.hitpoints
 				else
 					damage = unit_to_harm.hitpoints - 1

--- a/lua/main.lua
+++ b/lua/main.lua
@@ -3,8 +3,6 @@
 loti = {}
 loti.util = {}
 
---fake change
-
 -- Syntax sugar to make GUI2 dialogs more compact, e.g. T.column, T.row, etc.
 T = wml.tag
 

--- a/lua/main.lua
+++ b/lua/main.lua
@@ -136,6 +136,8 @@ function wesnoth.wml_actions.harm_unit_loti(cfg)
 			local animate = cfg.animate -- attacker and defender are special values
 			local delay = cfg.delay or 500
 			local fire_event = cfg.fire_event
+			local kill = true
+			if cfg.kill ~= nil then kill = cfg.kill end
 			local primary_attack = wml.get_child(cfg, "primary_attack")
 			local secondary_attack = wml.get_child(cfg, "secondary_attack")
 			local harmer_filter = wml.get_child(cfg, "filter_second")
@@ -192,7 +194,11 @@ function wesnoth.wml_actions.harm_unit_loti(cfg)
 						       )
 
 			if unit_to_harm.hitpoints <= damage then
-				damage = unit_to_harm.hitpoints
+				if kill then 
+					damage = unit_to_harm.hitpoints
+				else
+					damage = unit_to_harm.hitpoints - 1
+				end
 			end
 
 			unit_to_harm.hitpoints = unit_to_harm.hitpoints - damage

--- a/lua/main.lua
+++ b/lua/main.lua
@@ -3,6 +3,8 @@
 loti = {}
 loti.util = {}
 
+--fake change
+
 -- Syntax sugar to make GUI2 dialogs more compact, e.g. T.column, T.row, etc.
 T = wml.tag
 

--- a/scenarios1/01_An_Orcish_Assault.cfg
+++ b/scenarios1/01_An_Orcish_Assault.cfg
@@ -6,7 +6,7 @@
     next_scenario="02_The_Assassination"
     experience_modifier=125
     {GLOBAL_EVENTS}
-    {TURNS 16 15 14}
+    {LOTI_TURNS 16 15 14 13}
     {SCENARIO_MUSIC "elvish-theme.ogg"}
 
     {DEFAULT_SCHEDULE}
@@ -19,7 +19,7 @@
         profile=portraits/Efraim.png
         canrecruit=yes
         controller=human
-        gold=150
+        {LOTI_GOLD 150 150 150 120}
         recruit=Fencer,Thief,Spearman,Bowman,Heavy Infantryman,Poacher
         team_name=Loyalists
         user_team_name=_"Loyalists"
@@ -113,8 +113,8 @@
         type=Orcish Warrior
         canrecruit=yes
         recruit=Orcish Grunt,Wolf Rider,Orcish Archer,Troll Whelp
-        {GOLD 175 200 225}
-        {INCOME 1 2 2}
+        {LOTI_GOLD 175 200 225 250}
+        {LOTI_INCOME 1 2 2 3}
         random_traits=yes
         team_name=evil
         user_team_name=_"Evil"

--- a/scenarios1/02_The_Assassination.cfg
+++ b/scenarios1/02_The_Assassination.cfg
@@ -6,7 +6,7 @@
     name=_ "The Assassination"
     map_data="{~add-ons/Legend_of_the_Invincibles/maps/02_Redain_Castle.map}"
     {GLOBAL_EVENTS}
-    {TURNS 20 17 15}
+    {LOTI_TURNS 20 17 15 13}
     victory_when_enemies_defeated=no
 
     {SCENARIO_MUSIC loyalists.ogg}
@@ -32,7 +32,7 @@
         unrenamable=yes
         canrecruit=yes
         recruit=Fencer,Thief
-        {GOLD 60 50 45}
+        {LOTI_GOLD 60 50 45 20}
         income=0
         shroud=yes
         fog=yes
@@ -144,6 +144,22 @@
             canrecruit=no
             random_traits=yes
         [/unit]
+#ifdef HARDER
+        [unit]
+            type=Royal Guard
+            side=2
+            x,y=3,6
+            canrecruit=no
+            random_traits=yes
+        [/unit]
+        [unit]
+            type=Royal Guard
+            side=2
+            x,y=1,6
+            canrecruit=no
+            random_traits=yes
+        [/unit]
+#endif
 #ifdef HARD
         [unit]
             type=Swordsman
@@ -152,8 +168,6 @@
             canrecruit=no
             random_traits=yes
         [/unit]
-#endif
-#ifdef HARD
         [unit]
             type=Swordsman
             side=2

--- a/scenarios1/03_Banished.cfg
+++ b/scenarios1/03_Banished.cfg
@@ -6,7 +6,7 @@
     {GLOBAL_EVENTS}
     {SCENARIO_MUSIC "wanderer.ogg"}
     {EXTRA_SCENARIO_MUSIC "nunc_dimittis.ogg"}
-    {TURNS 35 33 31}
+    {LOTI_TURNS 35 33 31 29}
     victory_when_enemies_defeated=no
 
     {AFTERNOON}
@@ -102,6 +102,9 @@
 #ifdef HARD
         recruit=Orcish Grunt,Orcish Archer,Wolf Rider,Troll Whelp,Troll, Goblin Knight,Orcish Assassin,Orcish Slayer,Orcish Warrior
 #endif
+#ifdef HARDER
+        recruit=Orcish Grunt,Orcish Archer,Wolf Rider,Troll, Goblin Knight,Orcish Slayer,Orcish Warrior
+#endif
 
         gold=0
         income=−2
@@ -112,7 +115,7 @@
                 [effect]
                     apply_to=new_ability
                     [abilities]
-#ifndef HARD
+#ifdef EASY
                         {ABILITY_WEAK_REFLECT}
 #else
                         {ABILITY_REFLECT}
@@ -167,8 +170,8 @@
         [/filter]
         [modify_side]
             side=2
-            {GOLD 200 250 300}
-            income=15
+            {LOTI_GOLD 200 250 300 350}
+            {LOTI_INCOME 15 15 15 20}
         [/modify_side]
         [unit]
             type=Orcish Grunt

--- a/scenarios1/04_Paradise_Lost.cfg
+++ b/scenarios1/04_Paradise_Lost.cfg
@@ -60,7 +60,7 @@
         recruit=Fencer,Thief
         team_name=defenders
         user_team_name=_"Defenders"
-        gold=200
+        {LOTI_GOLD 200 200 200 175}
         controller=human
     [/side]
     [side]
@@ -93,9 +93,12 @@
 #ifdef HARD
         recruit=Orcish Grunt,Orcish Archer,Wolf Rider,Troll Whelp,Troll, Goblin Knight,Orcish Assassin,Orcish Slayer,Orcish Warrior,Orcish Crossbowman,Troll Rocklobber
 #endif
+#ifdef HARDER
+        recruit=Orcish Grunt,Orcish Archer,Wolf Rider,Troll, Goblin Knight,Orcish Slayer,Orcish Warrior,Orcish Crossbowman,Troll Rocklobber
+#endif
 
-        {GOLD 180 250 330}
-        {INCOME 15 22 30}
+        {LOTI_GOLD 180 250 330 350}
+        {LOTI_INCOME 15 22 30 32}
         team_name=evil
         user_team_name=_"Evil"
         [modifications]
@@ -103,10 +106,10 @@
                 [effect]
                     apply_to=new_ability
                     [abilities]
-#ifdef HARD
-                        {ABILITY_GREATER_EVISCERATION}
-#else
+#ifdef EASY
                         {ABILITY_EVISCERATION}
+#else
+                        {ABILITY_GREATER_EVISCERATION}
 #endif
                     [/abilities]
                 [/effect]
@@ -134,9 +137,12 @@
 #ifdef HARD
         recruit=Orcish Grunt,Orcish Archer,Wolf Rider,Troll Whelp,Troll, Goblin Knight,Orcish Assassin,Orcish Slayer,Orcish Warrior,Orcish Crossbowman,Troll Rocklobber,Goblin Impaler
 #endif
+#ifdef HARDER
+        recruit=Orcish Grunt,Orcish Archer,Troll Whelp,Troll,Orcish Assassin,Orcish Slayer,Orcish Warrior,Orcish Crossbowman,Troll Rocklobber
+#endif
 
-        {GOLD 70 150 200}
-        {INCOME 20 25 30}
+        {LOTI_GOLD 70 150 200 200}
+        {LOTI_INCOME 20 25 30 32}
         team_name=evil
         user_team_name=_"Evil"
         [modifications]
@@ -152,7 +158,8 @@
             [/advancement]
         [/modifications]
     [/side]
-    [side]
+    [side]  # No harder on HARDER, since side 1 can't get there to help in time.  May need to lower starting gold (& raise income?) anyway.
+            # May make sense to make Lethalia hard to hit for this scenario so player doesn't lose due to unavoidable circumstances.
         id=Vrongromor
         name= _ "Vrongromor"
         type=Orcish Warlord
@@ -169,9 +176,12 @@
 #ifdef HARD
         recruit=Orcish Grunt,Orcish Archer,Wolf Rider,Troll Whelp,Troll, Goblin Knight,Orcish Assassin,Orcish Slayer,Orcish Warrior,Orcish Crossbowman,Troll Rocklobber,Direwolf Rider
 #endif
+#ifdef HARDER
+        recruit=Orcish Grunt,Orcish Archer,Wolf Rider,Troll Whelp,Troll, Goblin Knight,Orcish Assassin,Orcish Slayer,Orcish Warrior,Orcish Crossbowman,Troll Rocklobber,Direwolf Rider
+#endif
 
-        {GOLD 140 220 300}
-        {INCOME 10 15 20}
+        {LOTI_GOLD 140 220 300 300}
+        {LOTI_INCOME 10 15 20 20}
         team_name=evil
         user_team_name=_"Evil"
         [modifications]

--- a/scenarios1/05_Shatter_the_Defilers.cfg
+++ b/scenarios1/05_Shatter_the_Defilers.cfg
@@ -7,7 +7,7 @@
     {SCENARIO_MUSIC "elvish-theme.ogg"}
     {EXTRA_SCENARIO_MUSIC "elf-land.ogg"}
     {EXTRA_SCENARIO_MUSIC "vengeful.ogg"}
-    {TURNS 40 37 35}
+    {LOTI_TURNS 40 37 35 33}
     victory_when_enemies_defeated=no
 
     {DEFAULT_SCHEDULE}
@@ -83,6 +83,7 @@
             y=5
             side=1
         [/unit]
+#ifndef HARDER
         [unit]
             type=Elvish Shaman
             generate_name=yes
@@ -97,6 +98,7 @@
             y=8
             side=1
         [/unit]
+#endif
         [unit]
             type=Elvish Marksman
             generate_name=yes
@@ -184,9 +186,12 @@
 #ifdef HARD
         recruit=Orcish Grunt,Orcish Archer,Wolf Rider,Troll Whelp,Troll, Goblin Knight,Orcish Assassin,Orcish Slayer,Orcish Warrior,Orcish Crossbowman,Troll Rocklobber,Orcish Warrior
 #endif
+#ifdef HARDER
+        recruit=Orcish Grunt,Orcish Archer,Wolf Rider,Troll, Goblin Knight,Orcish Assassin,Orcish Slayer,Orcish Warrior,Orcish Crossbowman,Troll Rocklobber,Orcish Warrior
+#endif
 
-        {GOLD 150 200 300}
-        income=2
+        {LOTI_GOLD 150 200 300 350}
+        {LOTI_INCOME 2 2 2 8}
         team_name=evil
         user_team_name=_"Evil"
 #ifndef EASY
@@ -221,8 +226,12 @@
 #ifdef HARD
         recruit=Orcish Grunt,Orcish Archer,Wolf Rider,Troll Whelp,Troll, Goblin Knight,Orcish Assassin,Orcish Slayer,Orcish Warrior,Orcish Crossbowman,Troll Rocklobber,Goblin Impaler,Goblin Rouser
 #endif
+#ifdef HARDER
+        recruit=Orcish Grunt,Orcish Archer,Wolf Rider,Troll Whelp,Troll, Goblin Knight,Orcish Assassin,Orcish Slayer,Orcish Warrior,Orcish Crossbowman,Troll Rocklobber
+#endif
 
-        {GOLD 150 200 300}
+        {LOTI_GOLD 150 200 300 350}
+        {LOTI_INCOME 2 2 2 8}
         income=2
         team_name=evil
         user_team_name=_"Evil"
@@ -251,14 +260,17 @@
         recruit=Orcish Grunt,Orcish Archer,Wolf Rider,Troll Whelp,Orcish Assassin,Orcish Crossbowman,Troll Shaman
 #endif
 #ifdef NORMAL
-        recruit=Orcish Grunt,Orcish Archer,Wolf Rider,Troll Whelp,Troll, Goblin Knight,Orcish Assassin,Orcish Crossbowman,Troll Shaman
+        recruit=Orcish Grunt,Orcish Archer,Wolf Rider,Troll Whelp,Troll,Goblin Knight,Orcish Assassin,Orcish Crossbowman,Troll Shaman
 #endif
 #ifdef HARD
-        recruit=Orcish Grunt,Orcish Archer,Wolf Rider,Troll Whelp,Troll, Goblin Knight,Orcish Assassin,Orcish Slayer,Orcish Warrior,Orcish Crossbowman,Troll Rocklobber,Direwolf Rider
+        recruit=Orcish Grunt,Orcish Archer,Wolf Rider,Troll Whelp,Troll,Goblin Knight,Orcish Assassin,Orcish Slayer,Orcish Warrior,Orcish Crossbowman,Troll Rocklobber,Direwolf Rider
+#endif
+#ifdef HARDER
+        recruit=Orcish Grunt,Orcish Archer,Wolf Rider,Troll Whelp,Troll,Goblin Knight,Orcish Assassin,Orcish Slayer,Orcish Warrior,Orcish Crossbowman,Troll Rocklobber,Direwolf Rider
 #endif
 
-        {GOLD 150 200 300}
-        income=2
+        {LOTI_GOLD 150 200 300 350}
+        {LOTI_INCOME 2 2 2 8}
         team_name=evil
         user_team_name=_"Evil"
         [modifications]
@@ -266,10 +278,10 @@
                 [effect]
                     apply_to=new_ability
                     [abilities]
-#ifdef HARD
-                        {ABILITY_ABSORB_4}
-#else
+#ifdef EASY
                         {ABILITY_ABSORB_2}
+#else
+                        {ABILITY_ABSORB_4}
 #endif
                     [/abilities]
                 [/effect]

--- a/scenarios1/06_The_Ruins_of_Lost_Empires.cfg
+++ b/scenarios1/06_The_Ruins_of_Lost_Empires.cfg
@@ -11,7 +11,7 @@
     victory_when_enemies_defeated=no
 
     {DEFAULT_SCHEDULE}
-    turns=100
+    {LOTI_TURNS 100 100 100 60}
     next_scenario=07_The_Return
 
     [event]
@@ -65,6 +65,9 @@
 #endif
 #ifdef HARD
         recruit=Orcish Grunt,Orcish Archer,Wolf Rider,Troll Whelp, Goblin Knight,Orcish Assassin,Orcish Slayer,Orcish Warrior,Orcish Crossbowman,Troll Rocklobber,Orcish Warrior
+#endif
+#ifdef HARDER
+        recruit=Orcish Grunt,Orcish Archer,Goblin Knight,Orcish Assassin,Orcish Slayer,Orcish Warrior,Orcish Crossbowman,Troll Rocklobber,Orcish Warrior
 #endif
 
         gold=0
@@ -131,8 +134,11 @@
 #ifdef HARD
         recruit=Orcish Grunt,Orcish Archer,Wolf Rider,Goblin Knight,Orcish Assassin,Orcish Slayer,Orcish Warrior,Orcish Crossbowman,Goblin Impaler,Goblin Rouser
 #endif
+#ifdef HARDER
+        recruit=Orcish Grunt,Orcish Archer,Wolf Rider,Goblin Knight,Orcish Assassin,Orcish Slayer,Orcish Warrior,Orcish Crossbowman
+#endif
         ai_special=guardian
-        {GOLD 0 0 0}
+        {LOTI_GOLD 0 0 0 0}
         income=−2
         team_name=evil
         user_team_name=_"Evil"
@@ -189,7 +195,7 @@
         profile="portraits/orcs/ruler-2.png"
         random_traits=yes
         side=6
-        {GOLD 0 0 0}
+        {LOTI_GOLD 0 0 0 0}
         income=−2
         ai_special=guardian
         canrecruit=yes
@@ -203,6 +209,9 @@
 #ifdef HARD
         recruit=Orcish Grunt,Orcish Archer,Wolf Rider,Goblin Knight,Orcish Assassin,Orcish Slayer,Orcish Warrior,Orcish Crossbowman,Direwolf Rider
 #endif
+#ifdef HARDER
+        recruit=Orcish Grunt,Orcish Archer,Wolf Rider,Goblin Knight,Orcish Assassin,Orcish Slayer,Orcish Warrior,Orcish Crossbowman,Direwolf Rider
+#endif
         team_name=evil
         user_team_name=_"Evil"
         [modifications]
@@ -210,10 +219,10 @@
                 [effect]
                     apply_to=new_ability
                     [abilities]
-#ifdef HARD
-                        {ABILITY_CONVICTION 50}
-#else
+#ifdef EASY
                         {ABILITY_CONVICTION 30}
+#else
+                        {ABILITY_CONVICTION 50}
 #endif
                     [/abilities]
                 [/effect]
@@ -253,8 +262,11 @@
 #ifdef HARD
         recruit=Orcish Grunt,Orcish Archer,Wolf Rider,Goblin Knight,Orcish Assassin,Orcish Slayer,Orcish Warrior,Orcish Crossbowman,Direwolf Rider
 #endif
+#ifdef HARDER
+        recruit=Orcish Grunt,Orcish Archer,Wolf Rider,Goblin Knight,Orcish Assassin,Orcish Slayer,Orcish Warrior,Orcish Crossbowman,Direwolf Rider
+#endif
 
-        {GOLD 0 0 0}
+        {LOTI_GOLD 0 0 0 0}
         income=−2
         ai_special=guardian
         team_name=evil
@@ -314,8 +326,11 @@
 #ifdef HARD
         recruit=Orcish Grunt,Orcish Archer,Wolf Rider,Goblin Knight,Orcish Assassin,Orcish Slayer,Orcish Warrior,Orcish Crossbowman,Direwolf Rider
 #endif
+#ifdef HARDER
+        recruit=Orcish Grunt,Orcish Archer,Wolf Rider,Goblin Knight,Orcish Assassin,Orcish Slayer,Orcish Warrior,Orcish Crossbowman,Direwolf Rider
+#endif
 
-        {GOLD 0 0 0}
+        {LOTI_GOLD 0 0 0 0}
         income=−2
         ai_special=guardian
         team_name=evil
@@ -368,8 +383,11 @@
 #ifdef HARD
         recruit=Troll Whelp,Troll,Troll Rocklobber,Troll Shaman,Troll Warrior
 #endif
+#ifdef HARDER
+        recruit=Troll,Troll Rocklobber,Troll Shaman,Troll Warrior
+#endif
 
-        {GOLD 0 0 0}
+        {LOTI_GOLD 0 0 0 0}
         income=−2
         ai_special=guardian
         income=2
@@ -518,7 +536,7 @@
         [/message]
         [modify_side]
             side=5
-            {GOLD 350 400 500}
+            {LOTI_GOLD 350 400 500 600}
         [/modify_side]
     [/event]
     [event]
@@ -539,7 +557,7 @@
         [/message]
         [modify_side]
             side=6
-            {GOLD 350 400 500}
+            {LOTI_GOLD 350 400 500 650}
         [/modify_side]
     [/event]
     [event]
@@ -560,7 +578,7 @@
         [/message]
         [modify_side]
             side=7
-            {GOLD 200 250 300}
+            {LOTI_GOLD 200 250 300 350}
         [/modify_side]
     [/event]
     [event]
@@ -581,7 +599,7 @@
         [/message]
         [modify_side]
             side=8
-            {GOLD 300 350 450}
+            {LOTI_GOLD 300 350 450 500}
         [/modify_side]
     [/event]
     [event]
@@ -602,7 +620,7 @@
         [/message]
         [modify_side]
             side=9
-            {GOLD 350 400 500}
+            {LOTI_GOLD 350 400 500 500}
         [/modify_side]
     [/event]
     [event]
@@ -635,31 +653,31 @@
         # To make it easier to orcs defeat other orcs
         [modify_side]
             side=5
-            {GOLD 300 300 400}
+            {LOTI_GOLD 300 300 400 450}
             team_name=northeast_orcs
             user_team_name=_"Northeast Orcs"
         [/modify_side]
         [modify_side]
             side=6
-            {INCOME 15 20 25}
+            {LOTI_INCOME 15 20 25 27}
             team_name=northwest_orcs
             user_team_name=_"Northwest Orcs"
         [/modify_side]
         [modify_side]
             side=7
-            {INCOME 15 20 25}
+            {LOTI_INCOME 15 20 25 30}
             team_name=west_orcs
             user_team_name=_"West Orcs"
         [/modify_side]
         [modify_side]
             side=8
-            {INCOME 15 20 25}
+            {LOTI_INCOME 15 20 25 28}
             team_name=south_orcs
             user_team_name=_"South Orcs"
         [/modify_side]
         [modify_side]
             side=9
-            {INCOME 15 20 25}
+            {LOTI_INCOME 15 20 25 30}
             team_name=trolls
             user_team_name=_"Trolls"
         [/modify_side]
@@ -694,6 +712,7 @@
             side=1
             random_traits=yes
         [/unit]
+#ifndef HARDER
         [unit]
             type=Elvish Druid
             generate_name=yes
@@ -702,6 +721,8 @@
             side=1
             random_traits=yes
         [/unit]
+        {UPDATE_ATTACKS 25 8}
+#endif
         [unit]
             type=Elvish Ranger
             gender=male
@@ -715,7 +736,6 @@
         [/unit]
         {UPDATE_ATTACKS 16 11}
         {UPDATE_ATTACKS 15 8}
-        {UPDATE_ATTACKS 25 8}
         {UPDATE_ATTACKS 22 6}
         [remove_shroud]
             side=1
@@ -739,6 +759,7 @@
             speaker=unit
             message= _ "Hey, I can see some elves in the distance. I hope they will help us."
         [/message]
+#ifndef HARDER
         [unit]
             type=Elvish Marksman
             generate_name=yes
@@ -755,6 +776,9 @@
             side=1
             random_traits=yes
         [/unit]
+        {UPDATE_ATTACKS 49 33}
+        {UPDATE_ATTACKS 55 30}
+#endif
         [unit]
             type=Elvish Druid
             generate_name=yes
@@ -774,8 +798,6 @@
             side=1
             random_traits=yes
         [/unit]
-        {UPDATE_ATTACKS 49 33}
-        {UPDATE_ATTACKS 55 30}
         {UPDATE_ATTACKS 56 25}
         {UPDATE_ATTACKS 56 29}
         [remove_shroud]

--- a/scenarios1/07_The_Return.cfg
+++ b/scenarios1/07_The_Return.cfg
@@ -7,7 +7,7 @@
     {SCENARIO_MUSIC "wanderer.ogg"}
     {EXTRA_SCENARIO_MUSIC "legends_of_the_north.ogg"}
     {EXTRA_SCENARIO_MUSIC "journeys_end.ogg"}
-    {TURNS 18 17 16}
+    {LOTI_TURNS 18 17 16 15}
     victory_when_enemies_defeated=no
 
     {AFTERNOON}
@@ -56,7 +56,7 @@
         recruit=
         team_name=adventurers
         user_team_name=_"Adventurers"
-        gold=150
+        {LOTI_GOLD 150 150 150 100}
         controller=human
     [/side]
     [side]
@@ -91,10 +91,18 @@
             speaker=Efraim_de_Ceise
             message= _ "Wait, do not leave... I will miss you."
         [/message]
+#ifndef HARDER   # should be ifdef EASY
         [message]
             speaker=Delenia
             message= _ "Finally you ceased to show off before your new subject of desire. I will leave soon, so if I am carrying some things you want back, take them back."
         [/message]
+#else
+        [message]
+            speaker=Delenia
+            message= _ "Finally you ceased to show off before your new subject of desire."
+        [/message]
+#endif
+
     [/event]
 
     [event]
@@ -164,6 +172,14 @@
 #ifdef HARD
         [unit]
             type=Thug
+            side=2
+            x,y=20,17
+            random_traits=yes
+        [/unit]
+#endif
+#ifdef HARDER
+        [unit]
+            type=Highwayman
             side=2
             x,y=20,17
             random_traits=yes
@@ -267,6 +283,14 @@
             random_traits=yes
         [/unit]
 #endif
+#ifdef HARDER
+        [unit]
+            type=Highwayman
+            side=2
+            x,y=30,10
+            random_traits=yes
+        [/unit]
+#endif
         [message]
             speaker=Efraim_de_Ceise
             message= _ "I thought I smelled someone in need of a bath..."
@@ -311,6 +335,14 @@
             random_traits=yes
         [/unit]
 #ifdef HARD
+        [unit]
+            type=Highwayman
+            side=2
+            x,y=25,11
+            random_traits=yes
+        [/unit]
+#endif
+#ifdef HARDER
         [unit]
             type=Highwayman
             side=2
@@ -381,6 +413,14 @@
 #ifdef HARD
         [unit]
             type=Thug
+            side=2
+            x,y=30,6
+            random_traits=yes
+        [/unit]
+#endif
+#ifdef HARDER
+        [unit]
+            type=Bandit
             side=2
             x,y=30,6
             random_traits=yes

--- a/scenarios1/08_Where_the_Sun_Does_not_Shine.cfg
+++ b/scenarios1/08_Where_the_Sun_Does_not_Shine.cfg
@@ -3,7 +3,7 @@
     id=08_Where_the_Sun_Does_not_Shine
     name= _ "Where the Sun Does not Shine"
     map_data="{~add-ons/Legend_of_the_Invincibles/maps/08_Cave_of_Lost_Souls.map}"
-    turns=100
+    {LOTI_TURNS 100 100 100 70}
 
     {GLOBAL_EVENTS}
     {INTRO_AND_SCENARIO_MUSIC frantic.ogg the_deep_path.ogg}
@@ -434,8 +434,19 @@
             canrecruit=no
             random_traits=yes
         [/unit]
+#else
+#ifdef HARDER
+        [unit]
+            type=Hurricane Drake
+            generate_name=yes
+            side=3
+            x,y=44,25
+            canrecruit=no
+            random_traits=yes
+        [/unit]
 #endif
-#ifdef NORMAL
+#endif
+#ifndef EASY
         [unit]
             type=Drake Glider
             generate_name=yes
@@ -600,6 +611,14 @@
             y=32
             side=3
         [/unit]
+#ifdef HARDER
+        [unit]
+            type=Sea Serpent
+            x=10
+            y=32
+            side=3
+        [/unit]
+#endif
         [unit]
             type=Tentacle of the Deep
             x=7
@@ -690,13 +709,20 @@
                 {VARIABLE_OP spawn_type rand (Blood Bat,Blood Bat,Blood Bat,Vampire Bat,Dread Bat)}
 #endif
 #ifdef HARD
-                {VARIABLE_OP spawn_type rand (Blood Bat,Vampire Bat,Dread Bat)}
+                {VARIABLE_OP spawn_type rand (Blood Bat,Vampire Bat,Dread Bat)}  # how is this harder than NORMAL?
+#endif
+#ifdef HARDER
+                {VARIABLE_OP spawn_type rand (Blood Bat,Blood Bat,Vampire Bat,Dread Bat,Dread Bat)}
 #endif
                 {GENERIC_UNIT 3 $spawn_type 29 9}
             [/then]
         [/if]
         {CLEAR_VARIABLE spawn_type}
     [/event]
+#ifdef HARDER 
+    {DROPS 3 5 (sword,dagger,knife,xbow,staff,staff) yes 3}
+#else
     {DROPS 4 7 (sword,dagger,knife,xbow,staff,staff) yes 3}
+#endif
     experience_modifier=125
 [/scenario]

--- a/scenarios1/09_Escape_from_Oblivion.cfg
+++ b/scenarios1/09_Escape_from_Oblivion.cfg
@@ -3,7 +3,7 @@
     id=09_Escape_from_Oblivion
     name= _ "Escape from Oblivion"
     map_data="{~add-ons/Legend_of_the_Invincibles/maps/09_Oblivion.map}"
-    turns=100
+    {LOTI_TURNS 100 100 100 80}
 
     {GLOBAL_EVENTS}
     {INTRO_AND_SCENARIO_MUSIC the_dangerous_symphony.ogg the_deep_path.ogg}
@@ -54,7 +54,11 @@
                 condition=lose
             [/objective]
             [gold_carryover]
+#ifdef HARDER
                 carryover_percentage=80
+#else
+                carryover_percentage=40
+#endif
                 bonus=yes
             [/gold_carryover]
         [/objectives]
@@ -88,6 +92,15 @@
 #endif
 #ifdef HARD
         recruit=Skeleton,Skeleton Archer,Ghost,Walking Corpse,Soulless,Wraith,Revenant,Deathblade,Bone Shooter
+#endif
+#ifdef HARDER
+        recruit=Skeleton,Skeleton Archer,Ghost,Soulless,Wraith,Revenant,Deathblade,Bone Shooter,Draug
+        [unit]
+            type=Death Knight
+        [/unit]
+        [unit]
+            type=Death Knight
+        [/unit]
 #endif
         ai_special=guardian
         team_name=evil
@@ -634,8 +647,8 @@
         [/message]
         [modify_side]
             side=2
-            {GOLD 400 500 600}
-            {INCOME 20 30 40}
+            {LOTI_GOLD 400 500 600 700}
+            {LOTI_INCOME 20 30 40 50}
         [/modify_side]
         {VARIABLE progress 1}
         [objectives]
@@ -751,11 +764,43 @@
 #ifdef HARD
                 {VARIABLE_OP spawn_type rand (Blood Bat,Vampire Bat,Dread Bat)}
 #endif
+#ifdef HARDER
+                {VARIABLE_OP spawn_type rand (Blood Bat,Blood Bat,Vampire Bat,Dread Bat,Dread Bat,Dread Bat)}
+#endif
                 {GENERIC_UNIT 2 $spawn_type 32 3}
             [/then]
         [/if]
         {CLEAR_VARIABLE spawn_type}
     [/event]
+#ifdef HARDER
+    [event]
+        name=moveto
+        id=not_very_nice
+        [filter]
+            side=1
+            x,y=34-42,27-33
+        [/filter]
+        [message]
+            speaker=Plutonius
+            message= _"Yes, come closer...  I have been waiting for you..."
+        [/message]
+        [modify_side]
+            side=2
+            gold=300
+            recruit=Deathblade,Revenant,Wraith,Bone Shooter
+        [/modify_side]
+        [transform_unit]
+            side=2
+            canrecruit=no
+        [/transform_unit]
+        [heal_unit]
+            [filter]
+                side=2
+            [/filter]
+        [/heal_unit]
+    [/event]
+#endif
+        
     {DROPS 4 7 (sword,dagger,knife,xbow,staff,staff) no 2,3}
     experience_modifier=125
 [/scenario]

--- a/scenarios1/10_The_Poison.cfg
+++ b/scenarios1/10_The_Poison.cfg
@@ -7,7 +7,7 @@
     map_data="{~add-ons/Legend_of_the_Invincibles/maps/10_The_Den_of_a_Dragon.map}"
     turns=-1
     {GLOBAL_EVENTS}
-    {TURNS 23 21 19}
+    {LOTI_TURNS 23 21 19 17}
     {UNDERGROUND}
     {SCENARIO_MUSIC "vengeful.ogg"}
     {EXTRA_SCENARIO_MUSIC "the_dangerous_symphony.ogg"}
@@ -46,7 +46,7 @@
         recruit=Walking Corpse,Ghost,Skeleton,Skeleton Archer,Chocobone
         team_name=adventurers
         user_team_name=_"Adventurers"
-        {GOLD 400 350 300}
+        {LOTI_GOLD 400 350 300 225}
         controller=human
     [/side]
 
@@ -66,7 +66,10 @@
 #ifdef HARD
         recruit=Drake Burner,Drake Glider,Drake Clasher,Drake Fighter,Drake Flameheart,Drake Blademaster,Drake Enforcer,Fire Drake,Drake Flare,Drake Arbiter,Hurricane Drake,Inferno Drake,Sky Drake,Drake Thrasher,Drake Warden,Drake Warrior,Armageddon Drake
 #endif
-        {GOLD 800 900 1000}
+#ifdef HARDER
+        recruit=Drake Burner,Drake Clasher,Drake Fighter,Drake Flameheart,Drake Blademaster,Drake Enforcer,Fire Drake,Drake Flare,Drake Arbiter,Hurricane Drake,Inferno Drake,Sky Drake,Drake Thrasher,Drake Warden,Drake Warrior,Armageddon Drake
+#endif
+        {LOTI_GOLD 800 900 1000 1100}
         income=30
         team_name=Dragon
         user_team_name=_"Dragon"

--- a/scenarios1/11_Ascension.cfg
+++ b/scenarios1/11_Ascension.cfg
@@ -3,7 +3,7 @@
     id=11_Ascension
     name= _ "Ascension"
     map_data="{~add-ons/Legend_of_the_Invincibles/maps/11_Mind_of_Efraim.map}"
-    {TURNS 13 11 9}
+    {LOTI_TURNS 13 11 9 9}
 
     {INTRO_AND_SCENARIO_MUSIC heroes_rite.ogg the_deep_path.ogg}
     {EXTRA_SCENARIO_MUSIC breaking_the_chains.ogg}

--- a/scenarios1/12_Toxic_Sun.cfg
+++ b/scenarios1/12_Toxic_Sun.cfg
@@ -4,7 +4,7 @@
     name= _ "Toxic Sun"
     map_data="{~add-ons/Legend_of_the_Invincibles/maps/12_Outer_Cave.map}"
     {GLOBAL_EVENTS}
-    {TURNS 34 31 28}
+    {LOTI_TURNS 34 31 28 26}
 
     {INTRO_AND_SCENARIO_MUSIC breaking_the_chains.ogg journeys_end.ogg}
     {EXTRA_SCENARIO_MUSIC underground.ogg}
@@ -127,8 +127,8 @@
         side=2
         canrecruit=yes
         recruit=Dwarvish Thunderguard,Dwarvish Steelclad,Dwarvish Berserker,Dwarvish Stalwart,Dwarvish Fighter
-        {GOLD 350 400 500}
-        income=20
+        {LOTI_GOLD 350 400 500 300}  # He's on our side, LESS gold on HARDER - though dialog will break if he dies REALLY early
+        {LOTI_INCOME 20 20 20 15}
         team_name=Good
         user_team_name=_"Good"
     [/side]
@@ -148,7 +148,10 @@
 #ifdef HARD
         recruit=Ghoul,Ghost,Skeleton Archer,Skeleton,Necrophage,Shadow,Wraith,Deathblade,Bone Shooter
 #endif
-        {GOLD 900 1000 1200}
+#ifdef HARDER
+        recruit=Ghoul,Ghost,Skeleton Archer,Necrophage,Shadow,Wraith,Deathblade,Bone Shooter
+#endif
+        {LOTI_GOLD 900 1000 1200 1300}
         team_name=Undead
         user_team_name=_"Undead"
 #ifndef EASY
@@ -182,7 +185,10 @@
 #ifdef HARD
         recruit=Ghoul,Ghost,Skeleton Archer,Skeleton,Necrophage,Shadow,Wraith,Deathblade,Bone Shooter,Revenant
 #endif
-        {GOLD 900 1000 1100}
+#ifdef HARDER
+        recruit=Ghoul,Skeleton,Necrophage,Shadow,Wraith,Deathblade,Bone Shooter,Revenant
+#endif
+        {LOTI_GOLD 900 1000 1100 1200}
         team_name=Undead
         user_team_name=_"Undead"
         [unit]
@@ -197,7 +203,7 @@
             y=28
             generate_name=yes
         [/unit]
-#ifdef HARD
+#ifndef EASY
         [modifications]
             [advancement]
                 [effect]
@@ -226,7 +232,10 @@
 #ifdef HARD
         recruit=Troll Whelp,Troll,Troll Rocklobber,Troll Shaman,Troll Warrior
 #endif
-        {GOLD 150 180 210}
+#ifdef HARDER
+        recruit=Troll,Troll Rocklobber,Troll Shaman,Troll Warrior
+#endif
+        {LOTI_GOLD 150 180 210 250}
         team_name=Trolls
         user_team_name=_"Trolls"
         [modifications]
@@ -257,7 +266,10 @@
 #ifdef HARD
         recruit=Troll Whelp,Troll,Troll Rocklobber,Troll Shaman
 #endif
-        {GOLD 700 800 900}
+#ifdef HARDER
+        recruit=Troll,Troll Rocklobber,Troll Shaman
+#endif
+        {LOTI_GOLD 700 800 900 1000}
         team_name=Trolls
         user_team_name=_"Trolls"
         [modifications]
@@ -287,7 +299,6 @@
                     [filter]
                         id=$army_store[$i].id
                     [/filter]
-                    amount=999
                 [/heal_unit]
             [/do]
         [/foreach]

--- a/scenarios1/13_Twilight.cfg
+++ b/scenarios1/13_Twilight.cfg
@@ -7,7 +7,7 @@
     victory_when_enemies_defeated=no
     map_data="{~add-ons/Legend_of_the_Invincibles/maps/13_Valley_of_Cold_Harmony.map}"
     {GLOBAL_EVENTS}
-    {TURNS 26 25 24}
+    {LOTI_TURNS 26 25 24 23}
     # We are close to the North Pole
     {DUSK}
     {FIRST_WATCH}
@@ -57,7 +57,7 @@
         recruit=Walking Corpse,Ghost,Skeleton,Skeleton Archer,Chocobone,Wraith,Soulless,Shadow,Bone Shooter,Deathblade,Revenant
         team_name=good
         user_team_name=_"Good"
-        {GOLD 300 250 200}
+        {LOTI_GOLD 300 250 200 160}
         controller=human
     [/side]
 
@@ -69,7 +69,7 @@
         side=2
         canrecruit=yes
         recruit=Heavy Infantryman,Mage,Sergeant,Cavalryman,Bowman
-        {GOLD 500 450 400}
+        {LOTI_GOLD 500 450 400 400}  # No sense making HARDER, Garcyn's team would probably just die to yeti
         team_name=good
         user_team_name=_"Good"
         [ai]
@@ -88,7 +88,8 @@
         side=3
         canrecruit=yes
         recruit=Gryphon
-        {GOLD 50 75 100}
+        {LOTI_GOLD 50 75 100 200}
+        {LOTI_INCOME 0 0 0 12}
         team_name=evil
         user_team_name=_"Evil"
         [ai]
@@ -96,6 +97,13 @@
                 terrain=Ai^Es
             [/avoid]
         [/ai]
+#ifdef HARDER
+        [unit]
+            type=Gryphon
+            x=25
+            y=1
+        [/unit]
+#endif
         [unit]
             type=Gryphon
             x=26
@@ -127,8 +135,8 @@
         side=4
         team_name=evil
         user_team_name=_"Evil"
-        {GOLD 150 200 250}
-        {INCOME 10 20 30}
+        {LOTI_GOLD 150 200 250 250}  # No need to make team 4 any HARDER
+        {LOTI_INCOME 10 20 30 30}
         recruit=Skeleton,Skeleton Archer
         village_gold=2
         [ai]
@@ -372,7 +380,7 @@
         [/terrain]
         [redraw]
         [/redraw]
-#ifdef HARD
+#ifndef EASY
         {EMERGE_ICE_MONSTER Revenant 18,16 18 14}
 #else
         {EMERGE_ICE_MONSTER Skeleton 18,16 18 14}
@@ -427,7 +435,11 @@
 #ifdef HARD
         {EMERGE_ICE_MONSTER Draug 30,14 30 18}
 #else
+#ifdef HARDER
+        {EMERGE_ICE_MONSTER Draug 30,14 30 18}
+#else
         {EMERGE_ICE_MONSTER Revenant 30,14 30 18}
+#endif
 #endif
         [terrain]
             x,y=28,14
@@ -438,7 +450,11 @@
 #ifdef HARD
         {EMERGE_ICE_MONSTER "Banebow" 28,14 25 13}
 #else
+#ifdef HARDER
+        {EMERGE_ICE_MONSTER "Banebow" 28,14 25 13}
+#else
         {EMERGE_ICE_MONSTER "Bone Shooter" 28,14 25 13}
+#endif
 #endif
         [terrain]
             x,y=29,16
@@ -449,7 +465,11 @@
 #ifdef HARD
         {EMERGE_ICE_MONSTER Deathblade 29,16 28 17}
 #else
+#ifdef HARDER
+        {EMERGE_ICE_MONSTER Deathblade 29,16 28 17}
+#else
         {EMERGE_ICE_MONSTER Skeleton 29,16 28 17}
+#endif
 #endif
         [terrain]
             x,y=30,15

--- a/scenarios1/14_Shadow_Empire.cfg
+++ b/scenarios1/14_Shadow_Empire.cfg
@@ -1,4 +1,4 @@
-##textdomain wesnoth-loti
+#textdomain wesnoth-loti
 [scenario]
     id=14_Shadow_Empire
     next_scenario=15_Long_Way_Home
@@ -6,7 +6,7 @@
     victory_when_enemies_defeated=no
     map_data="{~add-ons/Legend_of_the_Invincibles/maps/14_Shadow_Empire.map}"
     {GLOBAL_EVENTS}
-    {TURNS 36 33 30}
+    {LOTI_TURNS 36 33 30 27}
     {FIRST_WATCH}
     {FIRST_WATCH}
     {SECOND_WATCH}
@@ -41,7 +41,9 @@
                 carryover_percentage=40
                 bonus=yes
             [/gold_carryover]
+#ifndef HARDER
             note= _ " Note: Generals will turn to your side after Zorox's fall"
+#endif
         [/objectives]
     [/event]
 
@@ -68,7 +70,7 @@
         recruit=Walking Corpse,Ghost,Skeleton,Skeleton Archer,Chocobone,Wraith,Soulless,Shadow,Bone Shooter,Deathblade,Revenant
         team_name=good
         user_team_name=_"Good"
-        {GOLD 500 400 300}
+        {LOTI_GOLD 500 400 300 275}
         controller=human
     [/side]
 
@@ -80,7 +82,7 @@
         side=2
         canrecruit=yes
         recruit=Spearman,Bowman,Cavalryman,Swordsman,Heavy Infantryman,Javelineer,Pikeman,Shock Trooper,Horseman,Lancer,Knight,Longbowman
-        {GOLD 600 500 400}
+        {LOTI_GOLD 600 500 400 300}
         team_name=good
         user_team_name=_"Good"
     [/side]
@@ -101,7 +103,10 @@
 #ifdef HARD
         recruit=Spearman,Bowman,Cavalryman,Swordsman,Heavy Infantryman,Javelineer,Pikeman,Shock Trooper,Horseman,Lancer,Knight,Revenant,Chocobone,Wraith,Longbowman
 #endif
-        {GOLD 800 900 1000}
+#ifdef HARDER
+        recruit=Swordsman,Heavy Infantryman,Javelineer,Pikeman,Shock Trooper,Horseman,Lancer,Knight,Revenant,Chocobone,Wraith,Longbowman
+#endif
+        {LOTI_GOLD 800 900 1000 1100}
         team_name=evil
         user_team_name=_"Evil"
         [modifications]
@@ -131,8 +136,12 @@
 #ifdef HARD
         recruit=Walking Corpse,Ghost,Skeleton,Skeleton Archer,Chocobone,Wraith,Soulless,Shadow,Bone Shooter,Deathblade,Revenant,Spearman,Bowman,Cavalryman,Swordsman,Heavy Infantryman,Javelineer,Pikeman,Shock Trooper,Horseman,Lancer,Knight,Revenant,Chocobone,Wraith,Dark Adept,Dark Sorcerer
 #endif
+#ifdef HARDER
+        recruit=Ghost,Chocobone,Wraith,Soulless,Shadow,Bone Shooter,Deathblade,Revenant,Swordsman,Heavy Infantryman,Javelineer,Pikeman,Shock Trooper,Horseman,Lancer,Knight,Revenant,Chocobone,Wraith,Dark Adept,Dark Sorcerer
+#endif
 
-        {GOLD 400 525 625}
+        {LOTI_GOLD 400 525 625 750}
+        {LOTI_INCOME 0 0 0 15}  # might go higher on HARDER
         team_name=evil
         user_team_name=_"Evil"
 #ifndef EASY
@@ -166,11 +175,15 @@
 #ifdef HARD
         recruit=Walking Corpse,Ghost,Skeleton,Skeleton Archer,Chocobone,Wraith,Soulless,Shadow,Bone Shooter,Deathblade,Revenant,Spearman,Bowman,Cavalryman,Swordsman,Heavy Infantryman,Javelineer,Pikeman,Shock Trooper,Horseman,Lancer,Knight,Revenant,Chocobone,Wraith,Dark Adept,Dark Sorcerer
 #endif
+#ifdef HARDER
+        recruit=Chocobone,Wraith,Soulless,Shadow,Bone Shooter,Deathblade,Revenant,Swordsman,Heavy Infantryman,Javelineer,Pikeman,Shock Trooper,Horseman,Lancer,Knight,Revenant,Chocobone,Wraith,Dark Adept,Dark Sorcerer
+#endif
 
-        {GOLD 400 525 625}
+        {LOTI_GOLD 400 525 625 750}
+        {LOTI_INCOME 0 0 0 15}  # might go higher on HARDER
         team_name=evil
         user_team_name=_"Evil"
-#ifdef HARD
+#ifndef EASY
         [modifications]
             [advancement]
                 [effect]
@@ -201,7 +214,11 @@
 #ifdef HARD
         recruit=Spearman,Bowman,Cavalryman,Swordsman,Heavy Infantryman,Javelineer,Pikeman,Shock Trooper,Horseman,Lancer,Knight,Longbowman
 #endif
-        {GOLD 250 275 300}
+#ifdef HARDER
+        # Going to be on our side soon, no sense making them MORE powerful on harder levels
+        recruit=Spearman,Bowman,Cavalryman,Swordsman,Heavy Infantryman,Javelineer,Pikeman,Shock Trooper,Horseman,Longbowman
+#endif
+        {LOTI_GOLD 250 275 300 300}
         team_name=evil
         user_team_name=_"Evil"
     [/side]
@@ -219,9 +236,12 @@
         recruit=Spearman,Bowman,Cavalryman,Swordsman,Heavy Infantryman,Javelineer,Pikeman,Shock Trooper,Horseman,Longbowman
 #endif
 #ifdef HARD
+        recruit=Spearman,Bowman,Cavalryman,Swordsman,Heavy Infantryman,Javelineer,Pikeman,Shock Trooper,Horseman,Longbowman
+#endif
+#ifdef HARDER
         recruit=Spearman,Bowman,Cavalryman,Swordsman,Heavy Infantryman,Javelineer,Pikeman,Shock Trooper,Horseman,Lancer,Knight,Longbowman
 #endif
-        {GOLD 250 275 300}
+        {LOTI_GOLD 250 275 300 300}
         team_name=evil
         user_team_name=_"Evil"
     [/side]
@@ -277,6 +297,10 @@
         [/message]
         [message]
             speaker=Efraim
+#ifdef HARDER
+            message= _ "Well.  His arrogance is his greatest weakness.   It shall lead to his downfall on this field."
+        [/message]
+#else
             message= _ "Well. His arrogance is his greatest weakness. And it seems that only the necromancers are loyal to him. I think after his death the two cities to the south will turn to our side."
         [/message]
         [scroll_to_unit]
@@ -291,6 +315,7 @@
         [delay]
             time=500
         [/delay]
+#endif
         [message]
             speaker=Lethalia
             message= _ "And the necromancers will start a succession war like the orcs did."

--- a/scenarios1/15_Long_Way_Home.cfg
+++ b/scenarios1/15_Long_Way_Home.cfg
@@ -4,7 +4,7 @@
     name= _ "Long Way Home"
     map_data="{~add-ons/Legend_of_the_Invincibles/maps/15_The_Path.map}"
     {GLOBAL_EVENTS}
-    {TURNS 45 42 40}
+    {LOTI_TURNS 45 42 40 36}
 
     {INTRO_AND_SCENARIO_MUSIC heroes_rite.ogg transience.ogg}
     {EXTRA_SCENARIO_MUSIC siege_of_laurelmor.ogg}
@@ -92,7 +92,11 @@
 #ifdef HARD
         recruit=Orcish Grunt,Orcish Archer,Wolf Rider,Goblin Knight,Orcish Assassin,Orcish Slayer,Orcish Warrior,Orcish Crossbowman,Orcish Warrior
 #endif
-        {GOLD 350 400 500}
+#ifdef HARDER
+        recruit=Goblin Knight,Orcish Assassin,Orcish Slayer,Orcish Warrior,Orcish Crossbowman,Orcish Warrior
+#endif
+        {LOTI_GOLD 350 400 500 650}
+        {LOTI_INCOME 0 0 0 12}
         team_name=evil
         user_team_name=_"Evil"
 #ifndef EASY
@@ -124,10 +128,13 @@
 #ifdef HARD
         recruit=Troll Whelp,Troll Rocklobber,Troll,Troll Warrior,Troll Shaman
 #endif
-        {GOLD 150 200 250}
+#ifdef HARDER
+        recruit=Troll Rocklobber,Troll,Troll Warrior,Troll Shaman
+#endif
+        {LOTI_GOLD 150 200 250 350}
         team_name=evil
         user_team_name=_"Evil"
-#ifdef HARD
+#ifndef EASY
         [modifications]
             [advancement]
                 [effect]
@@ -158,7 +165,11 @@
 #ifdef HARD
         recruit=Saurian Skirmisher,Saurian Augur,Saurian Soothsayer,Saurian Ambusher,Saurian Oracle
 #endif
-        {GOLD 100 150 200}
+#ifdef HARDER
+        recruit=Saurian Soothsayer,Saurian Ambusher,Saurian Oracle
+#endif
+        {LOTI_GOLD 100 150 200 400}
+        {LOTI_INCOME 0 0 0 8}
         team_name=evil
         user_team_name=_"Evil"
         [modifications]
@@ -307,10 +318,17 @@
             side=1
             type=Walking Corpse,Ghost,Skeleton,Skeleton Archer,Chocobone,Wraith,Soulless,Shadow,Bone Shooter,Deathblade,Revenant
         [/disallow_recruit]
+#ifdef EASY
         [message]
             speaker=Argan
             message= _ "I shall be leaving you very soon, the duties in my valley are waiting for me. If I am borrowing any items you need, take them, I do not want to owe you even more than I already do."
         [/message]
+#else
+        [message]
+            speaker=Argan
+            message= _ "I shall be leaving you very soon, the duties in my valley are waiting for me."
+        [/message]
+#endif
     [/event]
 
     [event]
@@ -380,6 +398,12 @@
             speaker=Efraim
             message= _ "I had nearly lost hope of seeing flowers again."
         [/message]
+#ifdef HARDER
+        [modify_side]  # To make this truly effective, need to protect the saurian leader, perhaps by expanding castle
+            side=4
+            gold=250
+        [/modify_side]
+#endif
     [/event]
     [event]
         name=moveto
@@ -462,10 +486,17 @@
                     speaker=trader
                     message= _ "Hello, I am a trader. I sell items. Look at my stock and tell me what would you like to look at more closely."
                     {SELL_GEMS}
+#ifdef HARDER
+                    {SHOP_ITEM _"The Fencer's Study" 100 26 items/book3.png i1}
+                    {SHOP_ITEM _"Ring of Iced Veins" 175 18 items/ring-silver.png i2}
+                    {SHOP_ITEM _"Ring of Dragon's Bane" 110 35 items/ring-red.png i3}
+                    {SHOP_ITEM _"Claymore" 80 28 items/sword.png i4}
+#else
                     {SHOP_ITEM _"The Fencer's Study" 60 26 items/book3.png i1}
                     {SHOP_ITEM _"Ring of Iced Veins" 80 18 items/ring-silver.png i2}
                     {SHOP_ITEM _"Ring of Dragon's Bane" 30 35 items/ring-red.png i3}
                     {SHOP_ITEM _"Claymore" 50 28 items/sword.png i4}
+#endif
                     [option]
                         label= _ "Nothing"
                         [command]

--- a/scenarios1/16_The_Battle_for_Ogira.cfg
+++ b/scenarios1/16_The_Battle_for_Ogira.cfg
@@ -121,7 +121,11 @@
         unrenamable=yes
         side=1
         canrecruit=yes
+#ifdef HARDER
+        recruit=Spearman,Horseman,Bowman
+#else
         recruit=Spearman,Horseman,Bowman,Longbowman,Swordsman,Pikeman,Javelineer
+#endif
         team_name=good
         user_team_name=_"Good"
         random_traits=yes
@@ -178,7 +182,7 @@
             [/object]
         [/modifications]
         gold=500
-        {INCOME 40 30 20}
+        {LOTI_INCOME 40 30 20 20}
     [/side]
     [side]
         id=Brograr
@@ -197,8 +201,11 @@
 #ifdef HARD
         recruit=Orcish Grunt,Orcish Archer,Wolf Rider,Orcish Assassin,Orcish Crossbowman,Orcish Warrior,Troll Whelp,Troll,Direwolf Rider,Goblin Impaler,Orcish Slurbow,Goblin Rouser,Troll Shaman,Orcish Warlord,Orcish Slayer,Orcish Warlord,Troll Rocklobber,Great Troll,Orcish Slurbow
 #endif
-        {GOLD 700 900 1100}
-        income=5
+#ifdef HARDER
+        recruit=Orcish Grunt,Orcish Archer,Wolf Rider,Orcish Assassin,Orcish Crossbowman,Orcish Warrior,Troll Whelp,Troll,Direwolf Rider,Orcish Slurbow,Troll Shaman,Orcish Warlord,Orcish Slayer,Orcish Warlord,Troll Rocklobber,Great Troll,Orcish Slurbow
+#endif
+        {LOTI_GOLD 700 900 1100 1100}
+        {LOTI_INCOME 5 5 5 15}
         team_name=evil
         user_team_name=_"Evil"
 #ifndef EASY
@@ -231,8 +238,11 @@
 #ifdef HARD
         recruit=Orcish Grunt,Orcish Archer,Wolf Rider,Orcish Assassin,Orcish Crossbowman,Orcish Warrior,Troll Whelp,Troll,Direwolf Rider,Goblin Impaler,Orcish Slurbow,Troll Warrior,Goblin Rouser,Troll Shaman,Orcish Warlord,Orcish Slayer,Orcish Warlord,Orcish Slurbow
 #endif
-        {GOLD 600 700 900}
-        income=5
+#ifdef HARDER
+        recruit=Orcish Grunt,Orcish Archer,Wolf Rider,Orcish Assassin,Orcish Crossbowman,Orcish Warrior,Troll Whelp,Troll,Direwolf Rider,Orcish Slurbow,Troll Warrior,Troll Shaman,Orcish Warlord,Orcish Slayer,Orcish Warlord,Orcish Slurbow
+#endif
+        {LOTI_GOLD 600 700 900 1200}
+        {LOTI_INCOME 5 5 5 15}
         team_name=evil
         user_team_name=_"Evil"
         [modifications]
@@ -265,11 +275,14 @@
 #ifdef HARD
         recruit=Orcish Grunt,Wolf Rider,Orcish Warrior,Troll Whelp,Direwolf Rider,Goblin Impaler,Goblin Rouser,Orcish Warlord,Orcish Warlord
 #endif
-        {GOLD 800 1000 1200}
-        income=5
+#ifdef HARDER
+        recruit=Orcish Grunt,Wolf Rider,Orcish Warrior,Troll Whelp,Direwolf Rider,Goblin Impaler,Goblin Rouser,Orcish Warlord,Orcish Warlord
+#endif
+        {LOTI_GOLD 800 1000 1200 1300}
+        {LOTI_INCOME 5 5 5 24}
         team_name=evil
         user_team_name=_"Evil"
-#ifdef HARD
+#ifndef EASY
         [modifications]
             [advancement]
                 [effect]
@@ -299,8 +312,11 @@
 #ifdef HARD
         recruit=Orcish Grunt,Orcish Archer,Wolf Rider,Orcish Assassin,Orcish Crossbowman,Orcish Warrior,Troll Whelp,Troll,Goblin Impaler
 #endif
-        {GOLD 700 900 1100}
-        income=5
+#ifdef HARDER
+        recruit=Orcish Grunt,Orcish Archer,Wolf Rider,Orcish Assassin,Orcish Crossbowman,Orcish Warrior,Troll Whelp,Troll
+#endif
+        {LOTI_GOLD 700 900 1100 1200}
+        {LOTI_INCOME 5 5 5 24}
         team_name=evil
         user_team_name=_"Evil"
         [modifications]
@@ -331,8 +347,11 @@
 #ifdef HARD
         recruit=Orcish Grunt,Orcish Archer,Wolf Rider,Orcish Assassin,Orcish Crossbowman,Orcish Warrior,Troll Whelp,Troll,Direwolf Rider,Goblin Impaler,Orcish Slurbow,Troll Warrior,Goblin Rouser,Troll Shaman,Orcish Warlord,Orcish Slayer,Orcish Slurbow
 #endif
-        {GOLD 650 800 900}
-        income=5
+#ifdef HARDER
+        recruit=Orcish Grunt,Orcish Archer,Wolf Rider,Orcish Assassin,Orcish Crossbowman,Orcish Warrior,Troll,Direwolf Rider,Goblin Impaler,Orcish Slurbow,Troll Warrior,Troll Shaman,Orcish Warlord,Orcish Slayer,Orcish Slurbow
+#endif
+        {LOTI_GOLD 650 800 900 1000}
+        {LOTI_INCOME 5 5 5 20}
         team_name=evil
         user_team_name=_"Evil"
         [modifications]
@@ -356,8 +375,8 @@
         random_traits=yes
         canrecruit=yes
         recruit=Orcish Grunt,Orcish Archer,Wolf Rider,Orcish Assassin,Troll Whelp
-        {GOLD 600 800 1000}
-        income=5
+        {LOTI_GOLD 600 800 1000 1200}
+        {LOTI_INCOME 5 5 5 15}
         team_name=evil
         user_team_name=_"Evil"
 #ifndef EASY
@@ -387,6 +406,7 @@
             id=Lethalia
             x,y=67,55
         [/recall]
+#ifndef HARDER
         [recall]
             race=elf
             x,y=66,55
@@ -411,6 +431,7 @@
             race=elf
             x,y=69,54
         [/recall]
+#endif
         {OGIRA_GUARD 38 31}
         {OGIRA_GUARD 41 31}
         {OGIRA_GUARD 42 30}
@@ -432,18 +453,22 @@
         {OGIRA_GUARD 31 29}
         {OGIRA_GUARD 34 30}
         {OGIRA_GUARD 38 28}
+#ifndef HARDER
         {OGIRA_GUARD 39 29}
+        {OGIRA_GUARD 39 28}
+#endif
         {OGIRA_GUARD 40 29}
         {OGIRA_GUARD 40 28}
-        {OGIRA_GUARD 39 28}
         {OGIRA_GUARD 41 24}
         {OGIRA_GUARD 35 31}
         {OGIRA_TOWN_GUARD 42 25}
         {OGIRA_TOWN_GUARD 42 26}
         {OGIRA_TOWN_GUARD 42 29}
+#ifndef HARDER
         {OGIRA_TOWN_GUARD 39 24}
         {OGIRA_TOWN_GUARD 39 25}
         {OGIRA_TOWN_GUARD 39 26}
+#endif
         {OGIRA_TOWN_GUARD 38 23}
         {OGIRA_TOWN_GUARD 36 29}
         {OGIRA_TOWN_GUARD 35 23}
@@ -459,10 +484,12 @@
         {OGIRA_RESERVE_GUARD 37 24}
         {OGIRA_RESERVE_GUARD 36 23}
         {OGIRA_RESERVE_GUARD 35 24}
+        {OGIRA_RESERVE_GUARD 35 27}
+#ifndef HARDER
         {OGIRA_RESERVE_GUARD 34 24}
         {OGIRA_RESERVE_GUARD 34 25}
         {OGIRA_RESERVE_GUARD 34 26}
-        {OGIRA_RESERVE_GUARD 35 27}
+#endif
         [message]
             speaker=Efraim
             message= _ "All right. We are near Ogira, but it seems we have arrived at the last minute."
@@ -819,6 +846,47 @@
             next_scenario=01_The_Beginning
         [/endlevel]
     [/event]
+#ifdef HARDER
+    [event]
+        name=victory
+        [message]
+            speaker=Lethalia
+            message=_"Thank you for trying out the experimental 'Harder' difficulty.  Please leave a note or two on the forum thread."
+        [/message]
+        [if]
+            [not]
+                [have_unit]
+                    side=1
+                    id=Mario
+                [/have_unit]
+            [/not]
+            [then]
+                [unit]
+                    id=Marios_ghost
+                    side=1
+                    x,y=69,56
+                    type=Ghoul  # Okay, I lied.  Not a ghost.
+                    name=_"Mario"
+                [/unit]
+                [message]
+                    speaker=Marios_ghost
+                    message=_"And be sure to mention how you let me die.  Thanks for that, by the way."
+                    scroll=no
+                [/message]
+                [kill]
+                    id=Marios_ghost
+                [/kill]
+            [/then]
+        [/if]
+        [message]
+            speaker=Efraim
+            message=_"Your difficulty will now be set to Hard, hopefully.  Saved games will continue to show as Harder, and there may be unforseen side effects.  When the next scenario starts, you should reload the start of scenario save using the Change Difficulty option and select Easy, Medium, or Hard."
+        [/message]
+#undef HARDER
+#define HARD
+#enddef
+    [/event]
+#endif
     {BEELZEBUB_SPAWN_POINT 9 1 24 24 19-29,19-29}
     {FORCE_CHANCE_TO_HIT side=3,4,5,6,7,8 id=undead_Argan 10 ()}
     {DROPS 2 3 (sword,sword,sword,bow,bow,dagger,knife,xbow,axe,axe,staff,staff,spear,spear,mace,mace) yes 3,4,5,6,7,8}

--- a/utils/abilities_events.cfg
+++ b/utils/abilities_events.cfg
@@ -2042,6 +2042,7 @@
         {VARIABLE has_poison no}
         {VARIABLE has_slow no}
         {VARIABLE has_lethargy no}
+#ifndef HARD
         [if]
             [variable]
                 name=weapon.specials.poison.id
@@ -2060,6 +2061,7 @@
                 {VARIABLE has_slow yes}
             [/then]
         [/if]
+#endif
         [foreach]
             array=weapon.specials.dummy
             [do]
@@ -3386,6 +3388,7 @@
         {VARIABLE has_drain 0}
         {VARIABLE has_slow no}
         {VARIABLE has_poison no}
+#ifdef HARD
         [foreach]
             array=weapon.specials.damage
             [do]
@@ -3427,6 +3430,7 @@
                 {VARIABLE has_slow yes}
             [/then]
         [/if]
+#endif
         #{DEBUG "Whirlwind Hit: dmg $damage  leech $has_leech  poison $has_poison  drain $has_drain  slow $has_slow"}
         [if]
             [variable]
@@ -3591,6 +3595,9 @@
             fire_event=yes
             poisoned=$has_poison
             slowed=$has_slow
+#ifdef HARD
+            kill=no
+#endif
         [/harm_unit_loti]
         {CLEAR_VARIABLE has_slow}
         {CLEAR_VARIABLE has_poison}
@@ -6361,7 +6368,6 @@
             [/then]
         [/if]
     [/event]
-
 
     [event]
         name=attack

--- a/utils/abilities_events.cfg
+++ b/utils/abilities_events.cfg
@@ -3388,7 +3388,7 @@
         {VARIABLE has_drain 0}
         {VARIABLE has_slow no}
         {VARIABLE has_poison no}
-#ifdef HARD
+#ifndef HARD
         [foreach]
             array=weapon.specials.damage
             [do]

--- a/utils/utils.cfg
+++ b/utils/utils.cfg
@@ -1934,3 +1934,49 @@ $item_info.description"
         [/do]
     [/for]
 #enddef
+#define LOTI_TURNS A B C D
+#ifdef EASY
+    turns={A}
+#endif
+#ifdef NORMAL
+    turns={B}
+#endif
+#ifdef HARD
+    turns={C}
+#endif
+#ifdef HARDER
+    turns={D}
+#endif
+#enddef
+
+#define LOTI_GOLD A B C D
+#ifdef EASY
+    gold={A}
+#endif
+#ifdef NORMAL
+    gold={B}
+#endif
+#ifdef HARD
+    gold={C}
+#endif
+#ifdef HARDER
+    gold={D}
+#endif
+#enddef
+
+#define LOTI_INCOME A B C D
+#ifdef EASY
+    income={A}
+#endif
+#ifdef NORMAL
+    income={B}
+#endif
+#ifdef HARD
+    income={C}
+#endif
+#ifdef HARDER
+    income={D}
+#endif
+#enddef
+
+


### PR DESCRIPTION
The existing difficulty levels just aren't (aside from a handful of scenarios).  I added a fourth level to experiment with adding some amount of difficulty.  I was just targetting "Normal", but I think I actually came up with something approaching Hard.  It's kind of a tricky question, the scenarios are certainly a bit harder but I've yet to see the longer term effects.  For example, I usually finish ch1 with about 500 saved_turns, testing on Harder I've ended up close to 300.  Also, I've actually lost experience/geared units (though not enough) -- my goal if I see this through is not to end each part with 300-600 unused items and no losses (except Exec Sanct, where I just let senior units die to finish as fast as possible).  So it's tough to say how these effects will play out in chapters to come.

I've played this through a couple times, and most scenarios several times each (all on 1.19) and while it's not quite as hard as I'd like I think it's close enough to put it out there for feedback and to see if there's any interest, both on your part and the players'.  If you're interested, I'm wondering if it's possible (I assume it must be), to create a branch/fork and publish a separate experimental version. 

I tried not to touch the existing levels at all, but there were a couple places where it was just easier to change ifdef HARD to ifndef EASY, for example, and I only did that on scenarios that were really trivial anyway.

BTW, I've never relied much on elves (save gryphon riders), but on my last run I have a Sylph and an Enchantress who are nearly as powerful as Lethalia (at least, they almost always kill any enemy unit in one turn) even with minimal gear.  And Lethalia seems MUCH more powerful than normal.  It's all fairie fire.  I suspect the recent changes to the elves are pretty major.