### PR TITLE
invalid recruit= entries

### DIFF
--- a/scenarios2/10_Lilith.cfg
+++ b/scenarios2/10_Lilith.cfg
@@ -403,7 +403,6 @@
                     side=3
                     {IS_HERO}
                     canrecruit=yes
-                    recruit=yes
                     [modifications]
                         [object]
                             [effect]
@@ -1346,7 +1345,6 @@
             name=Argan
             x,y=22,15
             canrecruit=yes
-            recruit=
             [modifications]
                 [advancement]
                     id=sword1


### PR DESCRIPTION
Given the context and the scenario, I'm reasonably sure these just shouldn't exist at all.