### PR TITLE
improve doppleganger kill

### DIFF
--- a/utils/global_events.cfg
+++ b/utils/global_events.cfg
@@ -643,7 +643,7 @@
     [event]
         name=start
         {VARIABLE bosses "Umbra4,Akula,Achilles,Baal,Shadowlord,Lethalia_evil,Niflheim,Uria,Lilith,Abaddon,Romero,Beelzebub,Delly"} #Some abilities have no effect on bosses, the game needs to know who the bosses are
-        {GENERATE_ITEM_LIST}
+        #        {GENERATE_ITEM_LIST}
 
         [set_menu_item]
             id=3dropping
@@ -1886,10 +1886,23 @@ $soul_eating"
         name=scenario end
         [kill]
             type=Efraim_doppelganger
+            animate=yes
         [/kill]
-        [kill]
-            type=Lethalia_doppelganger
-        [/kill]
+        [if]
+            [have_unit]
+                type=Lethalia_doppelganger
+            [/have_unit]
+            [then]
+                [kill]
+                    type=Lethalia_doppelganger
+                    animate=yes
+                [/kill]
+                [message]
+                    speaker=Lethalia
+                    message=_"What a shame to see such beauty go to waste!"
+                [/message]
+            [/then]
+        [/if]
     [/event]
 #enddef
 


### PR DESCRIPTION
Doppelgangers need better animation when they die.  With a bit of delay so you can see it even if you blink.

Oops, I wasn't ready to include the comment on GENERATE_ITEM_LIST.