### PR TITLE
improve recall old units

### DIFF
--- a/lua/main.lua
+++ b/lua/main.lua
@@ -15,6 +15,7 @@ wesnoth.dofile("~add-ons/Legend_of_the_Invincibles/lua/unitdata.lua")
 wesnoth.dofile("~add-ons/Legend_of_the_Invincibles/lua/crafting.lua")
 wesnoth.dofile("~add-ons/Legend_of_the_Invincibles/lua/titles.lua")
 wesnoth.dofile("~add-ons/Legend_of_the_Invincibles/lua/redeem.lua")
+wesnoth.dofile("~add-ons/Legend_of_the_Invincibles/lua/recall.lua")
 wesnoth.dofile("~add-ons/Legend_of_the_Invincibles/lua/stats.lua")
 
 --! #textdomain "wesnoth-loti"

--- a/lua/recall.lua
+++ b/lua/recall.lua
@@ -1,0 +1,113 @@
+--! #textdomain "wesnoth-loti"
+
+local _ = wesnoth.textdomain "wesnoth-loti"
+
+local T = wml.tag
+
+function wesnoth.wml_actions.recall_from_variable(cfg)
+	local from_array = cfg.from or wml.error("[recall_from_variable]: missing required from= ")
+	local to_var = cfg.to or wml.error("[recall_from_variable]: missing required to= ")
+	local unit_list = wml.array_access.get(from_array) or wml.error(string.format("[recall_from_variable]: failed to fetch wml array %s",from_array))
+
+	local listboxItem = T.grid {
+		T.row {
+			T.column {
+				T.label { id = "available_unit",
+					linked_group = "available_unit"
+				}
+			}
+		}
+	}
+
+	local listbox_id = "available_units"
+	local listboxDefinition = T.listbox { id = listbox_id,
+		T.list_definition {
+			T.row {
+				T.column {
+					T.toggle_panel { listboxItem }
+				}
+			}
+		}
+	}
+
+	local dialogDefinition = {
+		T.tooltip { id = "tooltip" },
+		T.helptip { id = "tooltip" },
+		T.linked_group { id = "available_unit", fixed_width = true },
+		T.grid {
+			T.row {  -- header
+				T.column {
+					T.grid {
+						T.row {
+							T.column {
+								border = "bottom",
+								border_size = 10,
+								T.label {
+									use_markup = true,
+									label = "<span size='large' color='yellow' weight='bold'>"
+										.. _"Select unit to recall" .. "</span>"
+									}
+							}
+						}
+					}
+				}
+			},
+			T.row {  -- Body
+				T.column {
+					T.grid {
+						T.row {
+							T.column {
+								border = "right",
+								border_size = 40,
+								listboxDefinition
+							},
+							T.column {
+								T.unit_preview_pane { id = "unit_preview" }
+							}
+						}
+					}
+				}
+			},
+			T.row {  -- Footer
+				T.column {
+					T.grid {
+						T.row {
+							T.column {
+								T.spacer { width = 400 }
+							},
+							T.column {
+								border = "top,right",
+								border_size = 10,
+								T.button { id = "ok",
+									label = _"OK"
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	local picked = 1
+
+	local function preshow(dialog)
+		local listbox = dialog[listbox_id]
+		for i,unit in ipairs(unit_list) do
+			listbox[i].available_unit.label = unit.name .. "(" .. unit.language_name .. ")"
+		end
+		local function draw_unit()
+			wesnoth.units.to_recall(unit_list[listbox.selected_index])
+			local tmp = wesnoth.units.find_on_recall{ id = unit_list[listbox.selected_index].id }[1]
+			dialog.unit_preview.unit = tmp
+			wesnoth.units.extract(tmp)
+			picked = listbox.selected_index
+		end
+		draw_unit()
+		listbox.on_modified = draw_unit
+	end
+
+	gui.show_dialog(dialogDefinition,preshow)
+
+	wml.variables[to_var] = picked - 1
+end

--- a/utils/utils.cfg
+++ b/utils/utils.cfg
@@ -1596,57 +1596,19 @@ $item_info.description"
             greater_than_equal_to=1
         [/variable]
         [then]
-            {VARIABLE question.speaker narrator}
-            {VARIABLE question.message _"Choose a unit"}
-            {VARIABLE question.image "wesnoth-icon.png"}
             [sort_unit_list]
                 unit_list={VAR}
             [/sort_unit_list]
-            [foreach]
-                array={VAR}
-                [do]
-                    [if]
-                        [variable]
-                            name=this_item.name
-                            equals=""
-                        [/variable]
-                        [then]
-                            [set_variable]
-                                name=name
-                                value=$this_item.language_name
-                            [/set_variable]
-                        [/then]
-                        [else]
-                            [set_variable]
-                                name=name
-                                value=$this_item.name + _" (" + $this_item.language_name + _")"
-                            [/set_variable]
-                        [/else]
-                    [/if]
-                    [set_variables]
-                        name=question.option[$i]
-                        mode=replace
-                        delayed_variable_substitution=no
-                        [value]
-                            message=$name
-                            [command]
-                                {VARIABLE chose $i}
-                            [/command]
-                        [/value]
-                    [/set_variables]
-                [/do]
-            [/foreach]
-
-            [insert_tag]
-                name=message
-                variable=question
-            [/insert_tag]
+            [recall_from_variable]
+                from={VAR}
+                to=chose
+            [/recall_from_variable]
             [unstore_unit]
                 variable={VAR}[$chose]
                 x,y={X},{Y}
                 find_vacant=yes
             [/unstore_unit]
-            {CLEAR_VARIABLE {VAR}[$chose],question,chose,name}
+            {CLEAR_VARIABLE {VAR}[$chose],chose}
         [/then]
         [else]
             [message]


### PR DESCRIPTION
When you recall units from the past (Invasion, Bloodbath, etc) you only get a list of name/type.  It's hard to remember which is which unless you named them just right.  This adds a unit_preview_pane so you can see a lot more info about the units you are considering.

I gave it it's own recall.lua.  I have more recall gui related features in progress, so this isn't (won't be) just a one-off.

tested on 1.19-dev