### PR TITLE
weaken godless on normal/hard

### DIFF
--- a/utils/item_list.cfg
+++ b/utils/item_list.cfg
@@ -8604,9 +8604,12 @@ Showshaunshog proved him wrong by collecting condensed water from smoke."
         sapphires=0
         black_pearls=0
         sort=armourword
-        defence=35
-        fire_resist=25
-        arcane_resist=30
+        defence=20
+        {QUANTITY defence 35 30 20}
+        fire_resist=15
+        {QUANTITY fire_resist 25 20 15}
+        arcane_resist=20
+        {QUANTITY arcane_resist 30 25 20}
         flavour=_"Do not justify your actions with the name of a man made deity."
     [/object]
     [object]	#Been formerly cheaper!


### PR DESCRIPTION
Regardless of any changes I might be working on for hard, this one is just too powerful.

Or it's too cheap to craft, but I like making it weaker instead of more expensive/rare, because it takes up one of a limited number of slots in one unit (particularly E/L)'s inventory.  I wouldn't argue against making it slightly more expensive/rare as well (+1 amythingy or even +1 sapphire?).

I'd even be tempted to give it something like -1MP so you don't just craft 3 or 4 of these and stack them.