### PR TITLE
add set item highlight to item_pick

### DIFF
--- a/lua/item_pick.lua
+++ b/lua/item_pick.lua
@@ -7,8 +7,8 @@ wesnoth.require("inventory/multiplayer_safety")(item_picker)
 
 --- actions:
 --- 0 is equip/use, 1 is to store, 2 is to destroy, 3 is to leave on the ground
-local function show_picking_dialogue(item, sort, replaced_item, cant_equip, count)
-	local description = loti.item.describe_item(item.number, sort)
+local function show_picking_dialogue(item, sort, replaced_item, cant_equip, count, set_items)
+	local description = loti.item.describe_item(item.number, sort, set_items)
 	if item.sort == "potion" then
 		local res = gui.show_narration ({
 			title = item.name,
@@ -86,7 +86,8 @@ function loti.util.item_pick_menu (mpsafety, unit)
 
 			local count = loti.item.storage.list_items(sort)[number] or 0
 
-			local result = show_picking_dialogue(item, sort, replaced_item, why_cant_equip, count)
+			local set_items = loti.unit.list_unit_item_numbers(unit.__cfg)
+			local result = show_picking_dialogue(item, sort, replaced_item, why_cant_equip, count, set_items)
 			if result == 0 then
 				mpsafety:queue({
 					command = "equip_ground",


### PR DESCRIPTION
When you are offerred the option to pick up an item, it doesn't understand that the item is part of a set and do the highlighting like in other places.  Now it does.

Somewhere way down on my list of things to do is a "what if?" option for this menu.  Bring up something like side by side copies of Unit Information that show before and after if you picked this item up (including effect of dropping any necessary item of course).  Probably with highlighting.  Or maybe one Unit Info with "diff-style" changes highlighted.  I don't know.

Actually a number of things I'd like to do with Unit Info.  Like making it available in other places (like where I added that unit_preview_pane).  And making weapon specials into tooltips.  And making tooltips for resistances/penetration that show how the calculation was done to arrive at that number.   I think first I need to learn more about "function scope" in lua -- how, and what the implications are, of exposing that function (or a wrapper?) to other parts of the code.  Not as much fun that way, but probably a good idea not to screw around with things until I understand what I'm doing.