### PR TITLE
make hard harder (ch1)

### DIFF
--- a/scenarios1/00_Tutorial.cfg
+++ b/scenarios1/00_Tutorial.cfg
@@ -206,7 +206,7 @@
         controller=human
         gold=0
         income=-2
-        recruit=Fencer,Thief,Spearman,Bowman,Heavy Infantryman,Rogue
+        recruit=
         team_name=Loyalists
         user_team_name=_"Loyalists"
         unrenamable=yes

--- a/scenarios1/01_An_Orcish_Assault.cfg
+++ b/scenarios1/01_An_Orcish_Assault.cfg
@@ -77,24 +77,7 @@
         [modifications]
             {TRAIT_LOYAL OVERLAY=""}
             {TRAIT_STRONG}
-            [advancement]
-                [effect]
-                    apply_to=max_experience
-#ifdef EASY
-                    increase=100%
-#endif
-#ifdef NORMAL
-                    increase=200%
-#endif
-#ifdef HARD
-                    increase=300%
-#endif
-                [/effect]
-                [effect]
-                    apply_to=attack
-                    increase_damage=50%
-                [/effect]
-            [/advancement]
+            {TRAIT_PERFECTIONIST}
         [/modifications]
 
         {FLAG_VARIANT loyalist}

--- a/scenarios1/01_An_Orcish_Assault.cfg
+++ b/scenarios1/01_An_Orcish_Assault.cfg
@@ -6,7 +6,7 @@
     next_scenario="02_The_Assassination"
     experience_modifier=125
     {GLOBAL_EVENTS}
-    {TURNS 16 15 14}
+    {TURNS 16 15 13}
     {SCENARIO_MUSIC "elvish-theme.ogg"}
 
     {DEFAULT_SCHEDULE}
@@ -19,8 +19,12 @@
         profile=portraits/Efraim.png
         canrecruit=yes
         controller=human
-        gold=150
+        {GOLD 150 150 120}
+#ifdef HARD
         recruit=Fencer,Thief,Spearman,Bowman,Heavy Infantryman,Poacher
+#else
+        recruit=Fencer,Thief,Spearman,Bowman,Heavy Infantryman,Poacher,Rogue
+#endif
         team_name=Loyalists
         user_team_name=_"Loyalists"
 
@@ -113,8 +117,8 @@
         type=Orcish Warrior
         canrecruit=yes
         recruit=Orcish Grunt,Wolf Rider,Orcish Archer,Troll Whelp
-        {GOLD 175 200 225}
-        {INCOME 1 2 2}
+        {GOLD 175 200 250}
+        {INCOME 1 2 3}
         random_traits=yes
         team_name=evil
         user_team_name=_"Evil"
@@ -149,7 +153,6 @@
 
     [event]
         name=prestart
-
         [modify_side]
             side=3
             controller=null

--- a/scenarios1/01_An_Orcish_Assault.cfg
+++ b/scenarios1/01_An_Orcish_Assault.cfg
@@ -77,6 +77,24 @@
         [modifications]
             {TRAIT_LOYAL OVERLAY=""}
             {TRAIT_STRONG}
+            [advancement]
+                [effect]
+                    apply_to=max_experience
+#ifdef EASY
+                    increase=100%
+#endif
+#ifdef NORMAL
+                    increase=200%
+#endif
+#ifdef HARD
+                    increase=300%
+#endif
+                [/effect]
+                [effect]
+                    apply_to=attack
+                    increase_damage=50%
+                [/effect]
+            [/advancement]
         [/modifications]
 
         {FLAG_VARIANT loyalist}

--- a/scenarios1/01_An_Orcish_Assault.cfg
+++ b/scenarios1/01_An_Orcish_Assault.cfg
@@ -76,7 +76,6 @@
 
         [modifications]
             {TRAIT_LOYAL OVERLAY=""}
-            {TRAIT_STRONG}
             {TRAIT_PERFECTIONIST}
         [/modifications]
 

--- a/scenarios1/02_The_Assassination.cfg
+++ b/scenarios1/02_The_Assassination.cfg
@@ -289,6 +289,9 @@
         [/message]
 
         [endlevel]
+#ifdef HARD
+            carryover_percentage=50
+#endif            
             result=victory
         [/endlevel]
     [/event]

--- a/scenarios1/02_The_Assassination.cfg
+++ b/scenarios1/02_The_Assassination.cfg
@@ -6,7 +6,7 @@
     name=_ "The Assassination"
     map_data="{~add-ons/Legend_of_the_Invincibles/maps/02_Redain_Castle.map}"
     {GLOBAL_EVENTS}
-    {TURNS 20 17 15}
+    {TURNS 20 17 13}
     victory_when_enemies_defeated=no
 
     {SCENARIO_MUSIC loyalists.ogg}
@@ -32,7 +32,7 @@
         unrenamable=yes
         canrecruit=yes
         recruit=Fencer,Thief
-        {GOLD 60 50 45}
+        {GOLD 60 50 20}
         income=0
         shroud=yes
         fog=yes
@@ -83,93 +83,31 @@
                 description=_ "Turns run out"
             [/objective]
             [gold_carryover]
+#ifdef HARD
+                carryover_percentage=50
+#else
                 carryover_percentage=80
+#endif
                 bonus=yes
             [/gold_carryover]
         [/objectives]
 
-        [unit]
-            type=Royal Guard
-            side=2
-            x,y=11,9
-            canrecruit=no
-            random_traits=yes
-        [/unit]
-        [unit]
-            type=Royal Guard
-            side=2
-            x,y=17,9
-            canrecruit=no
-            random_traits=yes
-        [/unit]
-        [unit]
-            type=Halberdier
-            side=2
-            x,y=17,3
-            canrecruit=no
-            random_traits=yes
-        [/unit]
-        [unit]
-            type=Javelineer
-            side=2
-            x,y=21,1
-            canrecruit=no
-            random_traits=yes
-        [/unit]
-        [unit]
-            type=Silver Mage
-            side=2
-            x,y=20,9
-            canrecruit=no
-            random_traits=yes
-        [/unit]
-        [unit]
-            type=Royal Guard
-            side=2
-            x,y=11,1
-            canrecruit=no
-            random_traits=yes
-        [/unit]
-        [unit]
-            type=Javelineer
-            side=2
-            x,y=1,1
-            canrecruit=no
-            random_traits=yes
-        [/unit]
-        [unit]
-            type=Halberdier
-            side=2
-            x,y=11,7
-            canrecruit=no
-            random_traits=yes
-        [/unit]
+        {GENERIC_UNIT 2 "Royal Guard" 11 9}
+        {GENERIC_UNIT 2 "Royal Guard" 17 9}
+        {GENERIC_UNIT 2 "Royal Guard" 11 1}
+        {GENERIC_UNIT 2 Halberdier 11 7}
+        {GENERIC_UNIT 2 Halberdier 17 3}
+        {GENERIC_UNIT 2 Javelineer 1 1}
+        {GENERIC_UNIT 2 Javelineer 21 1}
+        {GENERIC_UNIT 2 "Silver Mage" 20 9}
+
 #ifdef HARD
-        [unit]
-            type=Swordsman
-            side=2
-            x,y=3,6
-            canrecruit=no
-            random_traits=yes
-        [/unit]
-#endif
-#ifdef HARD
-        [unit]
-            type=Swordsman
-            side=2
-            x,y=1,6
-            canrecruit=no
-            random_traits=yes
-        [/unit]
+        {GENERIC_UNIT 2 "Royal Guard" 3 6}
+        {GENERIC_UNIT 2 "Royal Guard" 1 6}
+        {GENERIC_UNIT 2 "Royal Guard" 2 7}
 #endif
 #ifdef NORMAL
-        [unit]
-            type=Royal Guard
-            side=2
-            x,y=1,6
-            canrecruit=no
-            random_traits=yes
-        [/unit]
+        {GENERIC_UNIT 2 "Royal Guard" 1 6}
 #endif
         [recall]
             id=Delenia

--- a/scenarios1/03_Banished.cfg
+++ b/scenarios1/03_Banished.cfg
@@ -80,7 +80,7 @@
         recruit=Fencer,Thief
         team_name=adventurers
         user_team_name=_"Adventurers"
-        gold=140
+        {GOLD 140 140 100}
         controller=human
         shroud=yes
     [/side]

--- a/scenarios1/04_Paradise_Lost.cfg
+++ b/scenarios1/04_Paradise_Lost.cfg
@@ -320,6 +320,71 @@
             y=29
             side=6
         [/unit]
+        {GENERIC_UNIT 2 "Elvish Archer" 12 22}
+    [/event]
+
+    [event]   # Sometimes the elves/woses fall quickly and Lethalia is killed before player can get there to help
+        name=side 6 turn
+        id=woses gone too soon
+        first_time_only=no
+        [if]
+            [variable]
+                name=turn_number
+                less_than=8  # might adjust for difficulty, just not too low 
+            [/variable]
+            [not]
+                [have_unit]
+                    side=6
+                    count=3-99
+                [/have_unit]
+            [/not]
+            [then]
+                {GENERIC_UNIT 6 "Elder Wose" 3 25}
+                {GENERIC_UNIT 6 "Elder Wose" 7 24}
+                {GENERIC_UNIT 6 Wose 11 25}
+                {GENERIC_UNIT 6 Wose 15 25}
+                {GENERIC_UNIT 6 Wose 17 21}
+                [remove_event]
+                    id=woses gone too soon
+                [/remove_event]
+            [/then]
+        [/if]
+    [/event]
+    [event]   # Sometimes the elves/woses fall quickly and Lethalia is killed before player can get there to help, part 2
+        name=side 2 turn
+        id=elves gone too soon
+        first_time_only=no
+        [if]
+            [variable]
+                name=turn_number
+                less_than=8  # might adjust for difficulty, just not too low 
+            [/variable]
+            [not]
+                [have_unit]
+                    side=2
+                    canrecruit=no
+                [/have_unit]
+            [/not]
+            [then]
+                [message]
+                    speaker=Lethalia
+                    message= _"It seems I need to call out the reserves!  I thought <span weight='bold'>someone</span> was coming to help.  Why I trusted the word of a <span font='oblique'>human...</span>"
+                [/message]
+                {GENERIC_UNIT 2 "Elvish Avenger" 11 22}
+                {GENERIC_UNIT 2 "Elvish Avenger" 14 22}
+                {GENERIC_UNIT 2 "Elvish Avenger" 15 24}
+                {GENERIC_UNIT 2 "Elvish Marksman" 12 23}
+                {GENERIC_UNIT 2 "Elvish Hero" 13 22}
+                {GENERIC_UNIT 2 "Elvish Lord" 14 23}
+                [modify_side]
+                    side=2
+                    gold=150
+                [/modify_side]
+                [remove_event]
+                    id=elves gone too soon
+                [/remove_event]
+            [/then]
+        [/if]
     [/event]
 
     [event]

--- a/scenarios1/05_Shatter_the_Defilers.cfg
+++ b/scenarios1/05_Shatter_the_Defilers.cfg
@@ -188,7 +188,7 @@
 #endif
 
         {GOLD 150 200 350}
-        {INCOME 2 2 8}
+        {INCOME 2 4 8}
         team_name=evil
         user_team_name=_"Evil"
 #ifndef EASY

--- a/scenarios1/05_Shatter_the_Defilers.cfg
+++ b/scenarios1/05_Shatter_the_Defilers.cfg
@@ -7,7 +7,7 @@
     {SCENARIO_MUSIC "elvish-theme.ogg"}
     {EXTRA_SCENARIO_MUSIC "elf-land.ogg"}
     {EXTRA_SCENARIO_MUSIC "vengeful.ogg"}
-    {TURNS 40 37 35}
+    {TURNS 40 37 33}
     victory_when_enemies_defeated=no
 
     {DEFAULT_SCHEDULE}
@@ -83,6 +83,7 @@
             y=5
             side=1
         [/unit]
+#ifndef HARD
         [unit]
             type=Elvish Shaman
             generate_name=yes
@@ -97,6 +98,7 @@
             y=8
             side=1
         [/unit]
+#endif
         [unit]
             type=Elvish Marksman
             generate_name=yes
@@ -182,11 +184,11 @@
         recruit=Orcish Grunt,Orcish Archer,Wolf Rider,Troll Whelp,Troll, Goblin Knight,Orcish Assassin,Orcish Crossbowman,Orcish Warrior
 #endif
 #ifdef HARD
-        recruit=Orcish Grunt,Orcish Archer,Wolf Rider,Troll Whelp,Troll, Goblin Knight,Orcish Assassin,Orcish Slayer,Orcish Warrior,Orcish Crossbowman,Troll Rocklobber,Orcish Warrior
+        recruit=Orcish Grunt,Orcish Archer,Wolf Rider,Troll, Goblin Knight,Orcish Assassin,Orcish Slayer,Orcish Warrior,Orcish Crossbowman,Troll Rocklobber,Orcish Warrior
 #endif
 
-        {GOLD 150 200 300}
-        income=2
+        {GOLD 150 200 350}
+        {INCOME 2 2 8}
         team_name=evil
         user_team_name=_"Evil"
 #ifndef EASY
@@ -219,10 +221,11 @@
         recruit=Orcish Grunt,Orcish Archer,Wolf Rider,Troll Whelp,Troll, Goblin Knight,Orcish Assassin,Orcish Crossbowman,Goblin Impaler
 #endif
 #ifdef HARD
-        recruit=Orcish Grunt,Orcish Archer,Wolf Rider,Troll Whelp,Troll, Goblin Knight,Orcish Assassin,Orcish Slayer,Orcish Warrior,Orcish Crossbowman,Troll Rocklobber,Goblin Impaler,Goblin Rouser
+        recruit=Orcish Grunt,Orcish Archer,Wolf Rider,Troll Whelp,Troll, Goblin Knight,Orcish Assassin,Orcish Slayer,Orcish Warrior,Orcish Crossbowman,Troll Rocklobber
 #endif
 
-        {GOLD 150 200 300}
+        {GOLD 150 200 350}
+        {INCOME 2 2 8}
         income=2
         team_name=evil
         user_team_name=_"Evil"
@@ -251,14 +254,14 @@
         recruit=Orcish Grunt,Orcish Archer,Wolf Rider,Troll Whelp,Orcish Assassin,Orcish Crossbowman,Troll Shaman
 #endif
 #ifdef NORMAL
-        recruit=Orcish Grunt,Orcish Archer,Wolf Rider,Troll Whelp,Troll, Goblin Knight,Orcish Assassin,Orcish Crossbowman,Troll Shaman
+        recruit=Orcish Grunt,Orcish Archer,Wolf Rider,Troll Whelp,Troll,Goblin Knight,Orcish Assassin,Orcish Crossbowman,Troll Shaman
 #endif
 #ifdef HARD
-        recruit=Orcish Grunt,Orcish Archer,Wolf Rider,Troll Whelp,Troll, Goblin Knight,Orcish Assassin,Orcish Slayer,Orcish Warrior,Orcish Crossbowman,Troll Rocklobber,Direwolf Rider
+        recruit=Orcish Grunt,Orcish Archer,Wolf Rider,Troll Whelp,Troll,Goblin Knight,Orcish Assassin,Orcish Slayer,Orcish Warrior,Orcish Crossbowman,Troll Rocklobber,Direwolf Rider
 #endif
 
-        {GOLD 150 200 300}
-        income=2
+        {GOLD 150 200 350}
+        {INCOME 2 2 8}
         team_name=evil
         user_team_name=_"Evil"
         [modifications]
@@ -266,10 +269,10 @@
                 [effect]
                     apply_to=new_ability
                     [abilities]
-#ifdef HARD
-                        {ABILITY_ABSORB_4}
-#else
+#ifdef EASY
                         {ABILITY_ABSORB_2}
+#else
+                        {ABILITY_ABSORB_4}
 #endif
                     [/abilities]
                 [/effect]

--- a/scenarios1/06_The_Ruins_of_Lost_Empires.cfg
+++ b/scenarios1/06_The_Ruins_of_Lost_Empires.cfg
@@ -11,7 +11,7 @@
     victory_when_enemies_defeated=no
 
     {DEFAULT_SCHEDULE}
-    turns=100
+    {TURNS 100 100 60}
     next_scenario=07_The_Return
 
     [event]
@@ -64,7 +64,7 @@
         recruit=Orcish Grunt,Orcish Archer,Wolf Rider,Troll Whelp, Goblin Knight,Orcish Assassin,Orcish Crossbowman,Orcish Warrior
 #endif
 #ifdef HARD
-        recruit=Orcish Grunt,Orcish Archer,Wolf Rider,Troll Whelp, Goblin Knight,Orcish Assassin,Orcish Slayer,Orcish Warrior,Orcish Crossbowman,Troll Rocklobber,Orcish Warrior
+        recruit=Orcish Grunt,Orcish Archer,Goblin Knight,Orcish Assassin,Orcish Slayer,Orcish Warrior,Orcish Crossbowman,Troll Rocklobber,Orcish Warrior
 #endif
 
         gold=0
@@ -129,7 +129,7 @@
         recruit=Orcish Grunt,Orcish Archer,Wolf Rider,Goblin Knight,Orcish Assassin,Orcish Crossbowman,Goblin Impaler
 #endif
 #ifdef HARD
-        recruit=Orcish Grunt,Orcish Archer,Wolf Rider,Goblin Knight,Orcish Assassin,Orcish Slayer,Orcish Warrior,Orcish Crossbowman,Goblin Impaler,Goblin Rouser
+        recruit=Orcish Grunt,Orcish Archer,Wolf Rider,Goblin Knight,Orcish Assassin,Orcish Slayer,Orcish Warrior,Orcish Crossbowman
 #endif
         ai_special=guardian
         {GOLD 0 0 0}
@@ -210,10 +210,10 @@
                 [effect]
                     apply_to=new_ability
                     [abilities]
-#ifdef HARD
-                        {ABILITY_CONVICTION 50}
-#else
+#ifdef EASY
                         {ABILITY_CONVICTION 30}
+#else
+                        {ABILITY_CONVICTION 50}
 #endif
                     [/abilities]
                 [/effect]
@@ -366,7 +366,7 @@
         recruit=Troll Whelp,Troll,Troll Rocklobber,Troll Shaman
 #endif
 #ifdef HARD
-        recruit=Troll Whelp,Troll,Troll Rocklobber,Troll Shaman,Troll Warrior
+        recruit=Troll,Troll Rocklobber,Troll Shaman,Troll Warrior
 #endif
 
         {GOLD 0 0 0}
@@ -518,7 +518,7 @@
         [/message]
         [modify_side]
             side=5
-            {GOLD 350 400 500}
+            {GOLD 350 400 600}
         [/modify_side]
     [/event]
     [event]
@@ -539,7 +539,7 @@
         [/message]
         [modify_side]
             side=6
-            {GOLD 350 400 500}
+            {GOLD 350 400 650}
         [/modify_side]
     [/event]
     [event]
@@ -560,7 +560,7 @@
         [/message]
         [modify_side]
             side=7
-            {GOLD 200 250 300}
+            {GOLD 200 250 350}
         [/modify_side]
     [/event]
     [event]
@@ -581,7 +581,7 @@
         [/message]
         [modify_side]
             side=8
-            {GOLD 300 350 450}
+            {GOLD 300 350 500}
         [/modify_side]
     [/event]
     [event]
@@ -635,31 +635,31 @@
         # To make it easier to orcs defeat other orcs
         [modify_side]
             side=5
-            {GOLD 300 300 400}
+            {GOLD 300 300 450}
             team_name=northeast_orcs
             user_team_name=_"Northeast Orcs"
         [/modify_side]
         [modify_side]
             side=6
-            {INCOME 15 20 25}
+            {INCOME 15 20 27}
             team_name=northwest_orcs
             user_team_name=_"Northwest Orcs"
         [/modify_side]
         [modify_side]
             side=7
-            {INCOME 15 20 25}
+            {INCOME 15 20 30}
             team_name=west_orcs
             user_team_name=_"West Orcs"
         [/modify_side]
         [modify_side]
             side=8
-            {INCOME 15 20 25}
+            {INCOME 15 20 28}
             team_name=south_orcs
             user_team_name=_"South Orcs"
         [/modify_side]
         [modify_side]
             side=9
-            {INCOME 15 20 25}
+            {INCOME 15 20 30}
             team_name=trolls
             user_team_name=_"Trolls"
         [/modify_side]
@@ -694,6 +694,7 @@
             side=1
             random_traits=yes
         [/unit]
+#ifndef HARD
         [unit]
             type=Elvish Druid
             generate_name=yes
@@ -702,6 +703,8 @@
             side=1
             random_traits=yes
         [/unit]
+        {UPDATE_ATTACKS 25 8}
+#endif
         [unit]
             type=Elvish Ranger
             gender=male
@@ -715,7 +718,6 @@
         [/unit]
         {UPDATE_ATTACKS 16 11}
         {UPDATE_ATTACKS 15 8}
-        {UPDATE_ATTACKS 25 8}
         {UPDATE_ATTACKS 22 6}
         [remove_shroud]
             side=1
@@ -739,6 +741,7 @@
             speaker=unit
             message= _ "Hey, I can see some elves in the distance. I hope they will help us."
         [/message]
+#ifndef HARD
         [unit]
             type=Elvish Marksman
             generate_name=yes
@@ -755,6 +758,9 @@
             side=1
             random_traits=yes
         [/unit]
+        {UPDATE_ATTACKS 49 33}
+        {UPDATE_ATTACKS 55 30}
+#endif
         [unit]
             type=Elvish Druid
             generate_name=yes
@@ -774,8 +780,6 @@
             side=1
             random_traits=yes
         [/unit]
-        {UPDATE_ATTACKS 49 33}
-        {UPDATE_ATTACKS 55 30}
         {UPDATE_ATTACKS 56 25}
         {UPDATE_ATTACKS 56 29}
         [remove_shroud]

--- a/scenarios1/07_The_Return.cfg
+++ b/scenarios1/07_The_Return.cfg
@@ -7,7 +7,7 @@
     {SCENARIO_MUSIC "wanderer.ogg"}
     {EXTRA_SCENARIO_MUSIC "legends_of_the_north.ogg"}
     {EXTRA_SCENARIO_MUSIC "journeys_end.ogg"}
-    {TURNS 18 17 16}
+    {TURNS 18 17 15}
     victory_when_enemies_defeated=no
 
     {AFTERNOON}
@@ -56,7 +56,7 @@
         recruit=
         team_name=adventurers
         user_team_name=_"Adventurers"
-        gold=150
+        {GOLD 150 150 100}
         controller=human
     [/side]
     [side]
@@ -91,10 +91,18 @@
             speaker=Efraim_de_Ceise
             message= _ "Wait, do not leave... I will miss you."
         [/message]
+#ifndef HARD
         [message]
             speaker=Delenia
             message= _ "Finally you ceased to show off before your new subject of desire. I will leave soon, so if I am carrying some things you want back, take them back."
         [/message]
+#else
+        [message]
+            speaker=Delenia
+            message= _ "Finally you ceased to show off before your new subject of desire."
+        [/message]
+#endif
+
     [/event]
 
     [event]
@@ -163,7 +171,7 @@
         [/unit]
 #ifdef HARD
         [unit]
-            type=Thug
+            type=Highwayman
             side=2
             x,y=20,17
             random_traits=yes
@@ -261,7 +269,7 @@
         [/unit]
 #ifdef HARD
         [unit]
-            type=Bandit
+            type=Highwayman
             side=2
             x,y=30,10
             random_traits=yes
@@ -379,12 +387,8 @@
             random_traits=yes
         [/unit]
 #ifdef HARD
-        [unit]
-            type=Thug
-            side=2
-            x,y=30,6
-            random_traits=yes
-        [/unit]
+        {GENERIC_UNIT 2 Fugitive 30 6}
+        {GENERIC_UNIT 2 Highwayman 32 5}
 #endif
         [message]
             speaker=Efraim_de_Ceise
@@ -496,6 +500,10 @@
             result=defeat
         [/endlevel]
     [/event]
+#ifdef HARD
     {DROPS 4 7 (sword,sword,sword,dagger,dagger,knife,xbow,bow,bow,staff,mace,spear) no 2}
+#else
+    {DROPS 3 5 (sword,sword,sword,dagger,dagger,knife,xbow,bow,bow,staff,mace,spear) no 2}
+#endif
     experience_modifier=125
 [/scenario]

--- a/scenarios1/07_The_Return.cfg
+++ b/scenarios1/07_The_Return.cfg
@@ -91,18 +91,10 @@
             speaker=Efraim_de_Ceise
             message= _ "Wait, do not leave... I will miss you."
         [/message]
-#ifndef HARD
         [message]
             speaker=Delenia
             message= _ "Finally you ceased to show off before your new subject of desire. I will leave soon, so if I am carrying some things you want back, take them back."
         [/message]
-#else
-        [message]
-            speaker=Delenia
-            message= _ "Finally you ceased to show off before your new subject of desire."
-        [/message]
-#endif
-
     [/event]
 
     [event]

--- a/scenarios1/08_Where_the_Sun_Does_not_Shine.cfg
+++ b/scenarios1/08_Where_the_Sun_Does_not_Shine.cfg
@@ -3,7 +3,7 @@
     id=08_Where_the_Sun_Does_not_Shine
     name= _ "Where the Sun Does not Shine"
     map_data="{~add-ons/Legend_of_the_Invincibles/maps/08_Cave_of_Lost_Souls.map}"
-    turns=100
+    {TURNS 100 100 70}
 
     {GLOBAL_EVENTS}
     {INTRO_AND_SCENARIO_MUSIC frantic.ogg the_deep_path.ogg}
@@ -427,7 +427,7 @@
         [/unit]
 #ifdef HARD
         [unit]
-            type=Drake Glider
+            type=Hurricane Drake
             generate_name=yes
             side=3
             x,y=44,25
@@ -435,7 +435,7 @@
             random_traits=yes
         [/unit]
 #endif
-#ifdef NORMAL
+#ifndef EASY
         [unit]
             type=Drake Glider
             generate_name=yes
@@ -600,6 +600,14 @@
             y=32
             side=3
         [/unit]
+#ifdef HARD
+        [unit]
+            type=Sea Serpent
+            x=10
+            y=32
+            side=3
+        [/unit]
+#endif
         [unit]
             type=Tentacle of the Deep
             x=7
@@ -690,13 +698,17 @@
                 {VARIABLE_OP spawn_type rand (Blood Bat,Blood Bat,Blood Bat,Vampire Bat,Dread Bat)}
 #endif
 #ifdef HARD
-                {VARIABLE_OP spawn_type rand (Blood Bat,Vampire Bat,Dread Bat)}
+                {VARIABLE_OP spawn_type rand (Blood Bat,Blood Bat,Vampire Bat,Dread Bat,Dread Bat)}
 #endif
                 {GENERIC_UNIT 3 $spawn_type 29 9}
             [/then]
         [/if]
         {CLEAR_VARIABLE spawn_type}
     [/event]
+#ifdef HARD 
+    {DROPS 3 5 (sword,dagger,knife,xbow,staff,staff) yes 3}
+#else
     {DROPS 4 7 (sword,dagger,knife,xbow,staff,staff) yes 3}
+#endif
     experience_modifier=125
 [/scenario]

--- a/scenarios1/09_Escape_from_Oblivion.cfg
+++ b/scenarios1/09_Escape_from_Oblivion.cfg
@@ -3,7 +3,7 @@
     id=09_Escape_from_Oblivion
     name= _ "Escape from Oblivion"
     map_data="{~add-ons/Legend_of_the_Invincibles/maps/09_Oblivion.map}"
-    turns=100
+    {TURNS 100 100 80}
 
     {GLOBAL_EVENTS}
     {INTRO_AND_SCENARIO_MUSIC the_dangerous_symphony.ogg the_deep_path.ogg}
@@ -54,7 +54,11 @@
                 condition=lose
             [/objective]
             [gold_carryover]
+#ifdef HARD
                 carryover_percentage=80
+#else
+                carryover_percentage=40
+#endif
                 bonus=yes
             [/gold_carryover]
         [/objectives]
@@ -87,7 +91,13 @@
         recruit=Skeleton,Skeleton Archer,Ghost,Walking Corpse,Soulless,Wraith,Revenant,Deathblade
 #endif
 #ifdef HARD
-        recruit=Skeleton,Skeleton Archer,Ghost,Walking Corpse,Soulless,Wraith,Revenant,Deathblade,Bone Shooter
+        recruit=Skeleton,Skeleton Archer,Ghost,Soulless,Wraith,Revenant,Deathblade,Bone Shooter,Draug
+        [unit]
+            type=Death Knight
+        [/unit]
+        [unit]
+            type=Death Knight
+        [/unit]
 #endif
         ai_special=guardian
         team_name=evil
@@ -634,8 +644,8 @@
         [/message]
         [modify_side]
             side=2
-            {GOLD 400 500 600}
-            {INCOME 20 30 40}
+            {GOLD 400 500 700}
+            {INCOME 20 30 50}
         [/modify_side]
         {VARIABLE progress 1}
         [objectives]
@@ -749,13 +759,42 @@
                 {VARIABLE_OP spawn_type rand (Blood Bat,Blood Bat,Vampire Bat,Vampire Bat,Dread Bat)}
 #endif
 #ifdef HARD
-                {VARIABLE_OP spawn_type rand (Blood Bat,Vampire Bat,Dread Bat)}
+                {VARIABLE_OP spawn_type rand (Blood Bat,Blood Bat,Vampire Bat,Dread Bat,Dread Bat,Dread Bat)}
 #endif
                 {GENERIC_UNIT 2 $spawn_type 32 3}
             [/then]
         [/if]
         {CLEAR_VARIABLE spawn_type}
     [/event]
+#ifdef HARD
+    [event]
+        name=moveto
+        id=not_very_nice
+        [filter]
+            side=1
+            x,y=34-42,27-33
+        [/filter]
+        [message]
+            speaker=Plutonius
+            message= _"Yes, come closer...  I have been waiting for you..."
+        [/message]
+        [modify_side]
+            side=2
+            gold=300
+            recruit=Deathblade,Revenant,Wraith,Bone Shooter
+        [/modify_side]
+        [transform_unit]
+            side=2
+            canrecruit=no
+        [/transform_unit]
+        [heal_unit]
+            [filter]
+                side=2
+            [/filter]
+        [/heal_unit]
+    [/event]
+#endif
+        
     {DROPS 4 7 (sword,dagger,knife,xbow,staff,staff) no 2,3}
     experience_modifier=125
 [/scenario]

--- a/scenarios1/12_Toxic_Sun.cfg
+++ b/scenarios1/12_Toxic_Sun.cfg
@@ -4,7 +4,7 @@
     name= _ "Toxic Sun"
     map_data="{~add-ons/Legend_of_the_Invincibles/maps/12_Outer_Cave.map}"
     {GLOBAL_EVENTS}
-    {TURNS 34 31 28}
+    {TURNS 34 31 26}
 
     {INTRO_AND_SCENARIO_MUSIC breaking_the_chains.ogg journeys_end.ogg}
     {EXTRA_SCENARIO_MUSIC underground.ogg}
@@ -127,8 +127,8 @@
         side=2
         canrecruit=yes
         recruit=Dwarvish Thunderguard,Dwarvish Steelclad,Dwarvish Berserker,Dwarvish Stalwart,Dwarvish Fighter
-        {GOLD 350 400 500}
-        income=20
+        {GOLD 350 400 300}
+        {INCOME 20 20 15}
         team_name=Good
         user_team_name=_"Good"
     [/side]
@@ -146,9 +146,9 @@
         recruit=Ghoul,Ghost,Skeleton Archer,Skeleton,Necrophage,Shadow
 #endif
 #ifdef HARD
-        recruit=Ghoul,Ghost,Skeleton Archer,Skeleton,Necrophage,Shadow,Wraith,Deathblade,Bone Shooter
+        recruit=Ghoul,Ghost,Skeleton Archer,Necrophage,Shadow,Wraith,Deathblade,Bone Shooter
 #endif
-        {GOLD 900 1000 1200}
+        {GOLD 900 1000 1300}
         team_name=Undead
         user_team_name=_"Undead"
 #ifndef EASY
@@ -180,9 +180,9 @@
         recruit=Ghoul,Ghost,Skeleton Archer,Skeleton,Necrophage,Shadow
 #endif
 #ifdef HARD
-        recruit=Ghoul,Ghost,Skeleton Archer,Skeleton,Necrophage,Shadow,Wraith,Deathblade,Bone Shooter,Revenant
+        recruit=Ghoul,Skeleton,Necrophage,Shadow,Wraith,Deathblade,Bone Shooter,Revenant
 #endif
-        {GOLD 900 1000 1100}
+        {GOLD 900 1000 1200}
         team_name=Undead
         user_team_name=_"Undead"
         [unit]
@@ -197,7 +197,7 @@
             y=28
             generate_name=yes
         [/unit]
-#ifdef HARD
+#ifndef EASY
         [modifications]
             [advancement]
                 [effect]
@@ -224,9 +224,9 @@
         recruit=Troll Whelp,Troll,Troll Rocklobber
 #endif
 #ifdef HARD
-        recruit=Troll Whelp,Troll,Troll Rocklobber,Troll Shaman,Troll Warrior
+        recruit=Troll,Troll Rocklobber,Troll Shaman,Troll Warrior
 #endif
-        {GOLD 150 180 210}
+        {GOLD 150 180 250}
         team_name=Trolls
         user_team_name=_"Trolls"
         [modifications]
@@ -255,9 +255,9 @@
         recruit=Troll Whelp,Troll,Troll Rocklobber
 #endif
 #ifdef HARD
-        recruit=Troll Whelp,Troll,Troll Rocklobber,Troll Shaman
+        recruit=Troll,Troll Rocklobber,Troll Shaman
 #endif
-        {GOLD 700 800 900}
+        {GOLD 700 800 1000}
         team_name=Trolls
         user_team_name=_"Trolls"
         [modifications]
@@ -287,7 +287,6 @@
                     [filter]
                         id=$army_store[$i].id
                     [/filter]
-                    amount=999
                 [/heal_unit]
             [/do]
         [/foreach]

--- a/scenarios1/13_Twilight.cfg
+++ b/scenarios1/13_Twilight.cfg
@@ -127,7 +127,14 @@
             type=Yeti
             x=42
             y=18
-            max_moves=4  # This yeti is just going to tear through side 2.  They can barely scratch it.  Give player a chance to help.
+            [modifications]  # This yeti is just going to tear through side 2.  They can barely scratch it.  Give player a chance to help.
+                [object]
+                    [effect]
+                        apply_to=movement
+                        increase=-1
+                    [/effect]
+                [/object]
+            [/modifications]
         [/unit]
         [unit]
             type=Ice Spirit

--- a/scenarios1/13_Twilight.cfg
+++ b/scenarios1/13_Twilight.cfg
@@ -7,7 +7,7 @@
     victory_when_enemies_defeated=no
     map_data="{~add-ons/Legend_of_the_Invincibles/maps/13_Valley_of_Cold_Harmony.map}"
     {GLOBAL_EVENTS}
-    {TURNS 26 25 24}
+    {TURNS 26 25 23}
     # We are close to the North Pole
     {DUSK}
     {FIRST_WATCH}
@@ -54,10 +54,14 @@
         unrenamable=yes
         side=1
         canrecruit=yes
+#ifdef HARD
+        recruit=Walking Corpse,Ghost,Skeleton,Skeleton Archer,Soulless
+#else
         recruit=Walking Corpse,Ghost,Skeleton,Skeleton Archer,Chocobone,Wraith,Soulless,Shadow,Bone Shooter,Deathblade,Revenant
+#endif
         team_name=good
         user_team_name=_"Good"
-        {GOLD 300 250 200}
+        {GOLD 300 250 160}
         controller=human
     [/side]
 
@@ -88,7 +92,8 @@
         side=3
         canrecruit=yes
         recruit=Gryphon
-        {GOLD 50 75 100}
+        {GOLD 50 75 200}
+        {INCOME 0 0 12}
         team_name=evil
         user_team_name=_"Evil"
         [ai]
@@ -96,6 +101,13 @@
                 terrain=Ai^Es
             [/avoid]
         [/ai]
+#ifdef HARD
+        [unit]
+            type=Gryphon
+            x=25
+            y=1
+        [/unit]
+#endif
         [unit]
             type=Gryphon
             x=26
@@ -115,6 +127,7 @@
             type=Yeti
             x=42
             y=18
+            max_moves=4  # This yeti is just going to tear through side 2.  They can barely scratch it.  Give player a chance to help.
         [/unit]
         [unit]
             type=Ice Spirit
@@ -372,7 +385,7 @@
         [/terrain]
         [redraw]
         [/redraw]
-#ifdef HARD
+#ifndef EASY
         {EMERGE_ICE_MONSTER Revenant 18,16 18 14}
 #else
         {EMERGE_ICE_MONSTER Skeleton 18,16 18 14}

--- a/scenarios1/14_Shadow_Empire.cfg
+++ b/scenarios1/14_Shadow_Empire.cfg
@@ -6,7 +6,7 @@
     victory_when_enemies_defeated=no
     map_data="{~add-ons/Legend_of_the_Invincibles/maps/14_Shadow_Empire.map}"
     {GLOBAL_EVENTS}
-    {TURNS 36 33 30}
+    {TURNS 36 33 27}
     {FIRST_WATCH}
     {FIRST_WATCH}
     {SECOND_WATCH}
@@ -33,6 +33,12 @@
                 description= _ "Death of Zorox (a unit other than Lethalia kills him)"
                 condition=lose
             [/objective]
+#ifdef HARD
+            [objective]
+                description= _ "Death of Garcyn"
+                condition=lose
+            [/objective]
+#endif
             [objective]
                 description= _ "Turns run out"
                 condition=lose
@@ -41,7 +47,9 @@
                 carryover_percentage=40
                 bonus=yes
             [/gold_carryover]
+#ifndef HARD
             note= _ " Note: Generals will turn to your side after Zorox's fall"
+#endif
         [/objectives]
     [/event]
 
@@ -65,10 +73,14 @@
         unrenamable=yes
         side=1
         canrecruit=yes
+#ifdef HARD
+        recruit=Walking Corpse,Ghost,Skeleton,Skeleton Archer
+#else
         recruit=Walking Corpse,Ghost,Skeleton,Skeleton Archer,Chocobone,Wraith,Soulless,Shadow,Bone Shooter,Deathblade,Revenant
+#endif
         team_name=good
         user_team_name=_"Good"
-        {GOLD 500 400 300}
+        {GOLD 500 400 275}
         controller=human
     [/side]
 
@@ -80,7 +92,7 @@
         side=2
         canrecruit=yes
         recruit=Spearman,Bowman,Cavalryman,Swordsman,Heavy Infantryman,Javelineer,Pikeman,Shock Trooper,Horseman,Lancer,Knight,Longbowman
-        {GOLD 600 500 400}
+        {GOLD 600 500 300}
         team_name=good
         user_team_name=_"Good"
     [/side]
@@ -99,9 +111,9 @@
         recruit=Spearman,Bowman,Cavalryman,Swordsman,Heavy Infantryman,Javelineer,Pikeman,Shock Trooper,Horseman,Revenant,Wraith,Longbowman
 #endif
 #ifdef HARD
-        recruit=Spearman,Bowman,Cavalryman,Swordsman,Heavy Infantryman,Javelineer,Pikeman,Shock Trooper,Horseman,Lancer,Knight,Revenant,Chocobone,Wraith,Longbowman
+        recruit=Swordsman,Heavy Infantryman,Javelineer,Pikeman,Shock Trooper,Horseman,Lancer,Knight,Revenant,Chocobone,Wraith,Longbowman
 #endif
-        {GOLD 800 900 1000}
+        {GOLD 800 900 1100}
         team_name=evil
         user_team_name=_"Evil"
         [modifications]
@@ -129,10 +141,11 @@
         recruit=Walking Corpse,Ghost,Skeleton,Skeleton Archer,Chocobone,Wraith,Soulless,Shadow,Bone Shooter,Deathblade,Revenant,Spearman,Bowman,Cavalryman,Swordsman,Heavy Infantryman,Javelineer,Pikeman,Shock Trooper,Horseman,Revenant,Wraith,Dark Adept,Dark Sorcerer
 #endif
 #ifdef HARD
-        recruit=Walking Corpse,Ghost,Skeleton,Skeleton Archer,Chocobone,Wraith,Soulless,Shadow,Bone Shooter,Deathblade,Revenant,Spearman,Bowman,Cavalryman,Swordsman,Heavy Infantryman,Javelineer,Pikeman,Shock Trooper,Horseman,Lancer,Knight,Revenant,Chocobone,Wraith,Dark Adept,Dark Sorcerer
+        recruit=Ghost,Chocobone,Wraith,Soulless,Shadow,Bone Shooter,Deathblade,Revenant,Swordsman,Heavy Infantryman,Javelineer,Pikeman,Shock Trooper,Horseman,Lancer,Knight,Revenant,Chocobone,Wraith,Dark Adept,Dark Sorcerer
 #endif
 
-        {GOLD 400 525 625}
+        {GOLD 400 525 750}
+        {INCOME 0 0 15}  # might go higher on HARD
         team_name=evil
         user_team_name=_"Evil"
 #ifndef EASY
@@ -164,13 +177,14 @@
         recruit=Walking Corpse,Ghost,Skeleton,Skeleton Archer,Chocobone,Wraith,Soulless,Shadow,Bone Shooter,Deathblade,Revenant,Spearman,Bowman,Cavalryman,Swordsman,Heavy Infantryman,Javelineer,Pikeman,Shock Trooper,Horseman,Revenant,Wraith,Dark Adept,Dark Sorcerer
 #endif
 #ifdef HARD
-        recruit=Walking Corpse,Ghost,Skeleton,Skeleton Archer,Chocobone,Wraith,Soulless,Shadow,Bone Shooter,Deathblade,Revenant,Spearman,Bowman,Cavalryman,Swordsman,Heavy Infantryman,Javelineer,Pikeman,Shock Trooper,Horseman,Lancer,Knight,Revenant,Chocobone,Wraith,Dark Adept,Dark Sorcerer
+        recruit=Chocobone,Wraith,Soulless,Shadow,Bone Shooter,Deathblade,Revenant,Swordsman,Heavy Infantryman,Javelineer,Pikeman,Shock Trooper,Horseman,Lancer,Knight,Revenant,Chocobone,Wraith,Dark Adept,Dark Sorcerer
 #endif
 
-        {GOLD 400 525 625}
+        {GOLD 400 525 750}
+        {INCOME 0 0 15}  # might go higher on HARD
         team_name=evil
         user_team_name=_"Evil"
-#ifdef HARD
+#ifndef EASY
         [modifications]
             [advancement]
                 [effect]
@@ -192,15 +206,7 @@
         type=General
         side=6
         canrecruit=yes
-#ifdef EASY
         recruit=Spearman,Bowman,Cavalryman,Swordsman,Heavy Infantryman,Javelineer,Pikeman,Shock Trooper,Longbowman
-#endif
-#ifdef NORMAL
-        recruit=Spearman,Bowman,Cavalryman,Swordsman,Heavy Infantryman,Javelineer,Pikeman,Shock Trooper,Horseman,Longbowman
-#endif
-#ifdef HARD
-        recruit=Spearman,Bowman,Cavalryman,Swordsman,Heavy Infantryman,Javelineer,Pikeman,Shock Trooper,Horseman,Lancer,Knight,Longbowman
-#endif
         {GOLD 250 275 300}
         team_name=evil
         user_team_name=_"Evil"
@@ -212,15 +218,7 @@
         type=General
         side=7
         canrecruit=yes
-#ifdef EASY
         recruit=Spearman,Bowman,Cavalryman,Swordsman,Heavy Infantryman,Javelineer,Pikeman,Shock Trooper,Longbowman
-#endif
-#ifdef NORMAL
-        recruit=Spearman,Bowman,Cavalryman,Swordsman,Heavy Infantryman,Javelineer,Pikeman,Shock Trooper,Horseman,Longbowman
-#endif
-#ifdef HARD
-        recruit=Spearman,Bowman,Cavalryman,Swordsman,Heavy Infantryman,Javelineer,Pikeman,Shock Trooper,Horseman,Lancer,Knight,Longbowman
-#endif
         {GOLD 250 275 300}
         team_name=evil
         user_team_name=_"Evil"
@@ -277,6 +275,10 @@
         [/message]
         [message]
             speaker=Efraim
+#ifdef HARD
+            message= _ "Well.  His arrogance is his greatest weakness.   It shall lead to his downfall on this field."
+        [/message]
+#else
             message= _ "Well. His arrogance is his greatest weakness. And it seems that only the necromancers are loyal to him. I think after his death the two cities to the south will turn to our side."
         [/message]
         [scroll_to_unit]
@@ -291,6 +293,7 @@
         [delay]
             time=500
         [/delay]
+#endif
         [message]
             speaker=Lethalia
             message= _ "And the necromancers will start a succession war like the orcs did."
@@ -357,19 +360,21 @@
             result=defeat
         [/endlevel]
     [/event]
+#ifdef HARD
     [event]
         name=last breath
         [filter]
-            id=Argan
+            id=Garcyn
         [/filter]
         [message]
-            speaker=unit
-            message= _ "And I was so close..."
+            speaker=Lethalia
+            message= _ "Who was supposed to be protecting Garcyn???  I can't do <span font='oblique'>everything</span> myself!"
         [/message]
         [endlevel]
             result=defeat
         [/endlevel]
     [/event]
+#endif
     [event]
         name=time over
         [if] # Prevent Beelzebub from causing a defeat

--- a/scenarios1/15_Long_Way_Home.cfg
+++ b/scenarios1/15_Long_Way_Home.cfg
@@ -4,7 +4,7 @@
     name= _ "Long Way Home"
     map_data="{~add-ons/Legend_of_the_Invincibles/maps/15_The_Path.map}"
     {GLOBAL_EVENTS}
-    {TURNS 45 42 40}
+    {TURNS 45 42 36}
 
     {INTRO_AND_SCENARIO_MUSIC heroes_rite.ogg transience.ogg}
     {EXTRA_SCENARIO_MUSIC siege_of_laurelmor.ogg}
@@ -18,6 +18,20 @@
     {FIRST_WATCH}
     {SECOND_WATCH}
     {SECOND_WATCH}
+
+#define HELP_FOR_SAURIANS
+#ifdef HARD
+    [terrain]  # A little more castle as a buffer against fast heroes, and a place to heal (yeah, right).
+        terrain=Gg^Ve
+        x,y=16,77
+    [/terrain]
+    [terrain]
+        terrain=Chs
+        x=12,12,13
+        y=76,77,76
+    [/terrain]
+#endif
+#enddef
 
     next_scenario=16_The_Battle_for_Ogira
     [time_area]
@@ -59,6 +73,7 @@
                 bonus=yes
             [/gold_carryover]
         [/objectives]
+        {HELP_FOR_SAURIANS}
     [/event]
 
     [side]
@@ -68,7 +83,11 @@
         unrenamable=yes
         side=1
         canrecruit=yes
+#ifdef HARD
+        recruit=Spearman,Horseman,Bowman
+#else
         recruit=Spearman,Horseman,Bowman,Longbowman,Swordsman,Pikeman,Javelineer
+#endif
         controller=human
         gold=100
         shroud=yes
@@ -90,9 +109,10 @@
         recruit=Orcish Grunt,Orcish Archer,Wolf Rider,Goblin Knight,Orcish Assassin,Orcish Crossbowman,Orcish Warrior
 #endif
 #ifdef HARD
-        recruit=Orcish Grunt,Orcish Archer,Wolf Rider,Goblin Knight,Orcish Assassin,Orcish Slayer,Orcish Warrior,Orcish Crossbowman,Orcish Warrior
+        recruit=Goblin Knight,Orcish Assassin,Orcish Slayer,Orcish Warrior,Orcish Crossbowman,Orcish Warrior
 #endif
-        {GOLD 350 400 500}
+        {GOLD 350 400 650}
+        {INCOME 0 0 12}
         team_name=evil
         user_team_name=_"Evil"
 #ifndef EASY
@@ -122,12 +142,12 @@
         recruit=Troll Whelp,Troll,Troll Rocklobber
 #endif
 #ifdef HARD
-        recruit=Troll Whelp,Troll Rocklobber,Troll,Troll Warrior,Troll Shaman
+        recruit=Troll Rocklobber,Troll,Troll Warrior,Troll Shaman
 #endif
-        {GOLD 150 200 250}
+        {GOLD 150 200 350}
         team_name=evil
         user_team_name=_"Evil"
-#ifdef HARD
+#ifndef EASY
         [modifications]
             [advancement]
                 [effect]
@@ -156,9 +176,10 @@
         recruit=Saurian Skirmisher,Saurian Augur,Saurian Soothsayer,Saurian Ambusher
 #endif
 #ifdef HARD
-        recruit=Saurian Skirmisher,Saurian Augur,Saurian Soothsayer,Saurian Ambusher,Saurian Oracle
+        recruit=Saurian Soothsayer,Saurian Ambusher,Saurian Oracle
 #endif
-        {GOLD 100 150 200}
+        {GOLD 100 150 400}
+        {INCOME 0 0 8}
         team_name=evil
         user_team_name=_"Evil"
         [modifications]
@@ -276,6 +297,7 @@
             expand=yes
             shrink=yes
         [/replace_map]
+        {HELP_FOR_SAURIANS}
         [message]
             speaker=Efraim
             message= _ "No! It is snowing. We have to hurry!"
@@ -288,9 +310,10 @@
             expand=yes
             shrink=yes
         [/replace_map]
+        {HELP_FOR_SAURIANS}
         [message]
             speaker=Efraim
-            message= _ "No! It is snowing. We really must hurry!"
+            message= _ "The snow is really starting to come down now!  We really must hurry!"
         [/message]
     [/event]
     [event]
@@ -307,10 +330,17 @@
             side=1
             type=Walking Corpse,Ghost,Skeleton,Skeleton Archer,Chocobone,Wraith,Soulless,Shadow,Bone Shooter,Deathblade,Revenant
         [/disallow_recruit]
+#ifdef EASY
         [message]
             speaker=Argan
             message= _ "I shall be leaving you very soon, the duties in my valley are waiting for me. If I am borrowing any items you need, take them, I do not want to owe you even more than I already do."
         [/message]
+#else
+        [message]
+            speaker=Argan
+            message= _ "I shall be leaving you very soon, the duties in my valley are waiting for me."
+        [/message]
+#endif
     [/event]
 
     [event]
@@ -380,6 +410,12 @@
             speaker=Efraim
             message= _ "I had nearly lost hope of seeing flowers again."
         [/message]
+#ifdef HARD
+        [modify_side]  
+            side=4
+            gold=250
+        [/modify_side]
+#endif
     [/event]
     [event]
         name=moveto
@@ -462,10 +498,17 @@
                     speaker=trader
                     message= _ "Hello, I am a trader. I sell items. Look at my stock and tell me what would you like to look at more closely."
                     {SELL_GEMS}
+#ifdef HARD
+                    {SHOP_ITEM _"The Fencer's Study" 100 26 items/book3.png i1}
+                    {SHOP_ITEM _"Ring of Iced Veins" 175 18 items/ring-silver.png i2}
+                    {SHOP_ITEM _"Ring of Dragon's Bane" 110 35 items/ring-red.png i3}
+                    {SHOP_ITEM _"Claymore" 80 28 items/sword.png i4}
+#else
                     {SHOP_ITEM _"The Fencer's Study" 60 26 items/book3.png i1}
                     {SHOP_ITEM _"Ring of Iced Veins" 80 18 items/ring-silver.png i2}
                     {SHOP_ITEM _"Ring of Dragon's Bane" 30 35 items/ring-red.png i3}
                     {SHOP_ITEM _"Claymore" 50 28 items/sword.png i4}
+#endif
                     [option]
                         label= _ "Nothing"
                         [command]

--- a/scenarios1/15_Long_Way_Home.cfg
+++ b/scenarios1/15_Long_Way_Home.cfg
@@ -112,7 +112,7 @@
         recruit=Goblin Knight,Orcish Assassin,Orcish Slayer,Orcish Warrior,Orcish Crossbowman,Orcish Warrior
 #endif
         {GOLD 350 400 650}
-        {INCOME 0 0 12}
+        {INCOME 0 6 12}
         team_name=evil
         user_team_name=_"Evil"
 #ifndef EASY
@@ -179,7 +179,7 @@
         recruit=Saurian Soothsayer,Saurian Ambusher,Saurian Oracle
 #endif
         {GOLD 100 150 400}
-        {INCOME 0 0 8}
+        {INCOME 0 4 8}
         team_name=evil
         user_team_name=_"Evil"
         [modifications]

--- a/scenarios1/16_The_Battle_for_Ogira.cfg
+++ b/scenarios1/16_The_Battle_for_Ogira.cfg
@@ -121,7 +121,11 @@
         unrenamable=yes
         side=1
         canrecruit=yes
+#ifdef HARD
+        recruit=Spearman,Horseman,Bowman
+#else
         recruit=Spearman,Horseman,Bowman,Longbowman,Swordsman,Pikeman,Javelineer
+#endif
         team_name=good
         user_team_name=_"Good"
         random_traits=yes
@@ -195,10 +199,10 @@
         recruit=Orcish Grunt,Orcish Archer,Wolf Rider,Orcish Assassin,Orcish Crossbowman,Orcish Warrior,Troll Whelp,Troll,Direwolf Rider,Goblin Impaler,Orcish Slurbow,Troll Warrior,Troll Hero
 #endif
 #ifdef HARD
-        recruit=Orcish Grunt,Orcish Archer,Wolf Rider,Orcish Assassin,Orcish Crossbowman,Orcish Warrior,Troll Whelp,Troll,Direwolf Rider,Goblin Impaler,Orcish Slurbow,Goblin Rouser,Troll Shaman,Orcish Warlord,Orcish Slayer,Orcish Warlord,Troll Rocklobber,Great Troll,Orcish Slurbow
+        recruit=Orcish Grunt,Orcish Archer,Wolf Rider,Orcish Assassin,Orcish Crossbowman,Orcish Warrior,Troll Whelp,Troll,Direwolf Rider,Orcish Slurbow,Troll Shaman,Orcish Warlord,Orcish Slayer,Orcish Warlord,Troll Rocklobber,Great Troll,Orcish Slurbow
 #endif
         {GOLD 700 900 1100}
-        income=5
+        {INCOME 5 5 15}
         team_name=evil
         user_team_name=_"Evil"
 #ifndef EASY
@@ -229,10 +233,10 @@
         recruit=Orcish Grunt,Orcish Archer,Wolf Rider,Orcish Assassin,Orcish Crossbowman,Orcish Warrior,Troll Whelp,Troll,Direwolf Rider,Goblin Impaler,Orcish Slurbow,Troll Warrior
 #endif
 #ifdef HARD
-        recruit=Orcish Grunt,Orcish Archer,Wolf Rider,Orcish Assassin,Orcish Crossbowman,Orcish Warrior,Troll Whelp,Troll,Direwolf Rider,Goblin Impaler,Orcish Slurbow,Troll Warrior,Goblin Rouser,Troll Shaman,Orcish Warlord,Orcish Slayer,Orcish Warlord,Orcish Slurbow
+        recruit=Orcish Grunt,Orcish Archer,Wolf Rider,Orcish Assassin,Orcish Crossbowman,Orcish Warrior,Troll Whelp,Troll,Direwolf Rider,Orcish Slurbow,Troll Warrior,Troll Shaman,Orcish Warlord,Orcish Slayer,Orcish Warlord,Orcish Slurbow
 #endif
-        {GOLD 600 700 900}
-        income=5
+        {GOLD 600 700 1200}
+        {INCOME 5 5 15}
         team_name=evil
         user_team_name=_"Evil"
         [modifications]
@@ -265,11 +269,11 @@
 #ifdef HARD
         recruit=Orcish Grunt,Wolf Rider,Orcish Warrior,Troll Whelp,Direwolf Rider,Goblin Impaler,Goblin Rouser,Orcish Warlord,Orcish Warlord
 #endif
-        {GOLD 800 1000 1200}
-        income=5
+        {GOLD 800 1000 1300}
+        {INCOME 5 5 24}
         team_name=evil
         user_team_name=_"Evil"
-#ifdef HARD
+#ifndef EASY
         [modifications]
             [advancement]
                 [effect]
@@ -297,10 +301,10 @@
         recruit=Orcish Grunt,Orcish Archer,Wolf Rider,Orcish Assassin,Orcish Crossbowman,Orcish Warrior,Troll Whelp,Troll,Goblin Impaler
 #endif
 #ifdef HARD
-        recruit=Orcish Grunt,Orcish Archer,Wolf Rider,Orcish Assassin,Orcish Crossbowman,Orcish Warrior,Troll Whelp,Troll,Goblin Impaler
+        recruit=Orcish Grunt,Orcish Archer,Wolf Rider,Orcish Assassin,Orcish Crossbowman,Orcish Warrior,Troll Whelp,Troll
 #endif
-        {GOLD 700 900 1100}
-        income=5
+        {GOLD 700 900 1200}
+        {INCOME 5 5 24}
         team_name=evil
         user_team_name=_"Evil"
         [modifications]
@@ -329,10 +333,10 @@
         recruit=Orcish Grunt,Orcish Archer,Wolf Rider,Orcish Assassin,Orcish Crossbowman,Orcish Warrior,Troll Whelp,Troll,Direwolf Rider,Goblin Impaler,Orcish Slurbow,Troll Warrior
 #endif
 #ifdef HARD
-        recruit=Orcish Grunt,Orcish Archer,Wolf Rider,Orcish Assassin,Orcish Crossbowman,Orcish Warrior,Troll Whelp,Troll,Direwolf Rider,Goblin Impaler,Orcish Slurbow,Troll Warrior,Goblin Rouser,Troll Shaman,Orcish Warlord,Orcish Slayer,Orcish Slurbow
+        recruit=Orcish Grunt,Orcish Archer,Wolf Rider,Orcish Assassin,Orcish Crossbowman,Orcish Warrior,Troll,Direwolf Rider,Goblin Impaler,Orcish Slurbow,Troll Warrior,Troll Shaman,Orcish Warlord,Orcish Slayer,Orcish Slurbow
 #endif
-        {GOLD 650 800 900}
-        income=5
+        {GOLD 650 800 1000}
+        {INCOME 5 5 20}
         team_name=evil
         user_team_name=_"Evil"
         [modifications]
@@ -356,8 +360,8 @@
         random_traits=yes
         canrecruit=yes
         recruit=Orcish Grunt,Orcish Archer,Wolf Rider,Orcish Assassin,Troll Whelp
-        {GOLD 600 800 1000}
-        income=5
+        {GOLD 600 800 1200}
+        {INCOME 5 5 15}
         team_name=evil
         user_team_name=_"Evil"
 #ifndef EASY
@@ -387,6 +391,7 @@
             id=Lethalia
             x,y=67,55
         [/recall]
+#ifndef HARD
         [recall]
             race=elf
             x,y=66,55
@@ -411,6 +416,7 @@
             race=elf
             x,y=69,54
         [/recall]
+#endif
         {OGIRA_GUARD 38 31}
         {OGIRA_GUARD 41 31}
         {OGIRA_GUARD 42 30}
@@ -432,18 +438,22 @@
         {OGIRA_GUARD 31 29}
         {OGIRA_GUARD 34 30}
         {OGIRA_GUARD 38 28}
+#ifndef HARD
         {OGIRA_GUARD 39 29}
+        {OGIRA_GUARD 39 28}
+#endif
         {OGIRA_GUARD 40 29}
         {OGIRA_GUARD 40 28}
-        {OGIRA_GUARD 39 28}
         {OGIRA_GUARD 41 24}
         {OGIRA_GUARD 35 31}
         {OGIRA_TOWN_GUARD 42 25}
         {OGIRA_TOWN_GUARD 42 26}
         {OGIRA_TOWN_GUARD 42 29}
+#ifndef HARD
         {OGIRA_TOWN_GUARD 39 24}
         {OGIRA_TOWN_GUARD 39 25}
         {OGIRA_TOWN_GUARD 39 26}
+#endif
         {OGIRA_TOWN_GUARD 38 23}
         {OGIRA_TOWN_GUARD 36 29}
         {OGIRA_TOWN_GUARD 35 23}
@@ -459,10 +469,12 @@
         {OGIRA_RESERVE_GUARD 37 24}
         {OGIRA_RESERVE_GUARD 36 23}
         {OGIRA_RESERVE_GUARD 35 24}
+        {OGIRA_RESERVE_GUARD 35 27}
+#ifndef HARD
         {OGIRA_RESERVE_GUARD 34 24}
         {OGIRA_RESERVE_GUARD 34 25}
         {OGIRA_RESERVE_GUARD 34 26}
-        {OGIRA_RESERVE_GUARD 35 27}
+#endif
         [message]
             speaker=Efraim
             message= _ "All right. We are near Ogira, but it seems we have arrived at the last minute."
@@ -730,7 +742,11 @@
                 condition=lose
             [/objective]
             [gold_carryover]
+#ifdef HARD
+                carryover_percentage=0
+#else
                 bonus=no
+#endif
             [/gold_carryover]
         [/objectives]
     [/event]
@@ -816,6 +832,9 @@
         [endlevel]
             result=victory
             bonus=no
+#ifdef HARD
+            carryover_percentage=0
+#endif
             next_scenario=01_The_Beginning
         [/endlevel]
     [/event]

--- a/units/Mario.cfg
+++ b/units/Mario.cfg
@@ -5,6 +5,9 @@
 #ifndef MULTIPLAYER
     advances_to=Spearman,Bowman,Sergeant
 #endif
+#ifdef HARD
+    advances_to=Spearman,Bowman
+#endif
     [base_unit]
         id=Peasant
     [/base_unit]

--- a/utils/utils.cfg
+++ b/utils/utils.cfg
@@ -336,6 +336,32 @@ $item_info.description"
     [/trait]
 #enddef
 
+#define TRAIT_PERFECTIONIST
+[trait]
+    id=perfectionist
+    male_name= _"perfectionist"
+    female_name= _"female^perfectionist"
+    generate_description=false
+    description= _"An obsessive attention to detail allows this unit to inflict 50% more damage, while requiring much more XP to advance"
+    [effect]
+        apply_to=max_experience
+#ifdef EASY
+        increase=100%
+#endif
+#ifdef NORMAL
+        increase=200%
+#endif
+#ifdef HARD
+        increase=300%
+#endif
+    [/effect]
+    [effect]
+        apply_to=attack
+        increase_damage=50%
+    [/effect]
+[/trait]
+#enddef
+
 #define CAMPAIGN3_DEATH_MESSAGES
     [event]
         name=last breath


### PR DESCRIPTION
Other than disabling Mario's advancement to sarge (duke), not much interesting here.  Mostly gold/turns, recruits limited to L1, and some terrain changes intended to protect enemy leaders from fast heroes killing them before they have a chance to recruit (much).  A few minor tweaks to existing levels intended to smooth out a couple areas where some scenarios were much harder than the rest, but nothing major.

I've tested these thoroughly, including playing through into chapter 5 to get a feel for the long term effects of some of the changes (less BZB encounters due to tighter turn limits, hopefully diminished recall list, etc).  Still not where I'd like it, you can still go without losing any non-fodder units, you just have to be really careful now, but enough of a start that I wouldn't want to go any further for now.

My gut says a lot of this may be offset by the new Sylph.  L just seems so much stronger now.

Of course, I just realized you can recruit horsemen in Pillowfight for Ogira, which means getting prophets much sooner than I'm used to, which is just going to make things much easier.  I'd be good with just removing that option.

My only real concern is Paradise Lost, and it's not really related to any changes I've made here.  Sometimes in that one things go poorly for the elves/wose in the beginning and it's all over before you can even get there to do anything about it.  I tried adjustments, but the only options I could find to ensure it was "fair" ended up making it way too easy most of the time, so I pretty much just left it as is.  I didn't try it, but I suspect giving the player control of Lethalia's side might make a difference (I would also consider this for Delly's side in Ogira as well). 