### PR TITLE
add text when spell eater become more powerful

### DIFF
--- a/utils/abilities_events.cfg
+++ b/utils/abilities_events.cfg
@@ -5052,6 +5052,19 @@
                         increase_damage=1
                     [/effect]
                 [/object]
+                [store_unit]
+                    [filter]
+                        id=$this_item.id
+                    [/filter]
+                    variable=spell_eater
+                    kill=yes
+                [/store_unit]
+                [unstore_unit]
+                    variable=spell_eater
+                    x,y=$this_item.x,$this_item.y
+                    {COLOR_HEAL}
+                    text = _"+2 resist / +8 HP / +4 MAX_HP / +1 damage"
+                [/unstore_unit]
             [/do]
         [/foreach]
         {CLEAR_VARIABLE eaters}
@@ -6427,7 +6440,6 @@
             [/then]
         [/if]
     [/event]
-
 
     [event]
         name=attack


### PR DESCRIPTION
So now I know why those spell eaters are so nasty.  It doesn't seem right to have a unit with such an ability and not make it quite obvious to the player what is going on.

IMO, the improvement is fine on hard, but is probably too much for easy (+4HP is half murderlust and it gets that just because an adjacent unit is hit by magic?  and +1 damage isn't trivial either).

The change feels like a bit of a hack, storing a unit that's already stored.  Part of me thinks I should append the new object to the stored unit and unstore that, but I'd have to search for a proper example and this way is just so much easier.  Not like it occurs often.