### PR TITLE
no cheating in tunnels

### DIFF
--- a/scenarios5/27_Power_Station.cfg
+++ b/scenarios5/27_Power_Station.cfg
@@ -57,6 +57,32 @@
         [recall]
             id=Lethalia
         [/recall]
+#ifdef HARD
+        [if]
+            [variable]
+                name=sc27
+                equals=1
+            [/variable]
+            [then]
+                # add check if already exist (put it in TRANSITION)
+                {TRANSITION 8-15,0-2 12,1 _"Entrance" 08_Entrance}
+                {VARIABLE transition_set[8] yes}  # move to TRANSITION
+                {TRANSITION 12-17,28-31 15,30 _"Amplificator 4" 22_Amplificator_4}
+                {VARIABLE transition_set[22] yes}
+            [/then]
+        [/if]
+        [switch]
+            variable=last_scenario
+            [case]
+                value=8
+                {TRANSITION 12-17,28-31 15,30 _"Amplificator 4" 22_Amplificator_4}
+            [/case]
+            [case]
+                value=22
+                {TRANSITION 8-15,0-2 12,1 _"Entrance" 08_Entrance}
+            [/case]
+        [/switch]
+#endif
     [/event]
     {RECALL_ALL}
     [side]
@@ -91,7 +117,7 @@
         name=start
         {VARIABLE efraim_spells_left 1}
         {VARIABLE lethalia_spells_left 1}
-        {VARIABLE last_scenario 27}
+        {VARIABLE last_scenario 27}  # Move me to victory, or better yet transistion?  Not NECESSARY as long as all dependencies kept in prestart, but better to be sure.
         {CHAPTER5_ITEM item_1_sc_27 32 26}
         {VARIABLE enemies_slain 0}
         [if]
@@ -106,12 +132,12 @@
                     fire_event=no
                 [/kill]
             [/then]
-            [else]
+            [else]  # change sc27 into an array (or part thereof) and semaphore this
                 [message]
                     speaker=Efraim
                     message=_"I can feel great amounts of energy being created and carried from this place elsewhere."
                 [/message]
-                [message]
+                [message]  
                     speaker=Lethalia
                     message=_"What is also weird, is that this place was not on the map..."
                 [/message]
@@ -148,6 +174,10 @@
                             message=_"All the machines were destroyed. Well done."
                         [/message]
                         {VARIABLE sc27 1}
+#ifdef HARD
+                        {TRANSITION 8-15,0-2 12,1 _"Entrance" 08_Entrance}
+                        {TRANSITION 12-17,28-31 15,30 _"Amplificator 4" 22_Amplificator_4}
+#endif
                     [/then]
                     [else]
                         [if]
@@ -172,10 +202,9 @@
     [event]
         name=victory
         {CLEAR_VARIABLE enemies_slain}
+        {CLEAR_VARIABLE transition[8]}  # move to TRANSITION [endlevel]
     [/event]
 
-    {TRANSITION 12-17,28-31 15,30 _"Amplificator 4" 22_Amplificator_4}
-    {TRANSITION 8-15,0-2 12,1 _"Entrance" 08_Entrance}
     {CAMPAIGN5_EVENTS}
     {DISABLE_UPKEEP 1}
     {SHOW_MAP}


### PR DESCRIPTION
Chapter 5 tunnels were pretty cool, right about until I figured out cheating.  Leave a unit by the scenario entrance and as soon as you get into trouble (or have killed an enemy leader or two), cast soulgate twice, run back to the previous scenario (fully healed), cast soulgate twice, go back to the scenario you "failed", and try again (fully healed, with more XP, potentially a new autorecall list, and in some cases with one or more enemy leaders now defeated).

Obviously, soulgate needs a cooldown (changing scenarios NOT counted as a turn) and healing between scenarios removed (should be easy, just store your units, but they keep healing on me anyway).  But to being with I'm looking at an idea which is going to be a good bit of work so I'd like your opinion before I go too far with it.  Every scenario (save Entrance) has an objective.  You don't leave the room until you complete it, or they carry you out feet first.  Or perhaps, you can't leave the way you came in.  I'm starting with the later, as it provides the player an out should situations arise where it's hopeless (I assume there will need to be difficulty tweaks if you can't just Sir Robin at will).  

While I'd like to see this applied across the board, right now I only want to touch hard, and not just because the lower levels would require a ton of tuning.  Mostly, if a player runs into an impossible situation, they can always restart the scenario on normal and play on instead of having to wait for a fix.

While the file here works, it's not quite complete.  Mostly because if you invoke TRANSITION twice in the same place you have to answer "do you want to go..." twice.  Easy to fix, but I don't want to touch the macro until I know if I'm going to apply this to all 47 scenarios.  I included just enough to show intent.  [EDIT:  Actually, just give the event an id (which I'm a fan of anyway, since it makes debugging with inspect SO MUCH easier) and don't worry about it]
