### PR TITLE
strength power generators

### DIFF
--- a/units/Power_Generator.cfg
+++ b/units/Power_Generator.cfg
@@ -6,7 +6,8 @@
     race=monster
     image="units/enemies/core-compact.png"
     ellipse="misc/ellipse"
-    hitpoints=80
+    hitpoints=720
+    {QUANTITY hitpoints 80 240 720}
     movement_type=smallfoot
     {TRAIT_MECHANICAL}
     [movement_costs]
@@ -21,7 +22,7 @@
         cold=70
         arcane=20
     [/resistance]
-    movement=7
+    movement=0
     experience=150
     level=3
     alignment=neutral
@@ -33,18 +34,34 @@
     description= _ "High amounts of an unknown kind energy are created in this machine, and used in an unknown way somewhere else. You have pretty much no idea what this thing is meant to do. The light it creates seems to harm everyone nearby."
     [abilities]
         {ABILITY_ILLUMINATES}
+#ifdef EASY
         {ABILITY_DEATHAURA 16}
+#else
+#ifdef NORMAL
+        {ABILITY_DEATHAURA 24}
+
+#else
+        {ABILITY_DEATHAURA 48}
+#endif
+#endif
+        {ABILITY_ELECTRICAL_DISCHARGE}
     [/abilities]
     [attack]
         name=lightning
         description=_"lightning"
         icon=attacks/lightning.png
-        type=fire
+        type=lightning
         range=ranged
-        damage=6
+        damage=18
+        {QUANTITY damage 6 12 18}
         number=3
         [specials]
+#ifndef HARD
             {WEAPON_SPECIAL_MAGICAL}
+#else
+            {WEAPON_SPECIAL_GUIDED}
+#            {WEAPON_SPECIAL_SLOW}   # want this to cancel penetrates, but don't want to affect attackers damage since we're going to return it
+#endif
         [/specials]
     [/attack]
     [attack_anim]

--- a/utils/abilities.cfg
+++ b/utils/abilities.cfg
@@ -1685,6 +1685,15 @@ Enemy units cannot see this unit during dawn or dusk, except if they have units 
         halo_image_self="halo/reflect-aura-1.png:100,halo/reflect-aura-2.png:100,halo/reflect-aura-3.png:100,halo/reflect-aura-2.png:100"
     [/dummy]
 #enddef
+#define ABILITY_ELECTRICAL_DISCHARGE
+    [dummy]
+        id=electrical_discharge
+        name= _ "electrical discharge"
+        female_name= _ "female^electrical discharge"
+        description= _ "When this unit is hit with a melee attack, the resulting discharge of electricity causes an equal amount of lightning damage to be taken by the attacker. It can kill."
+#        halo_image_self="halo/reflect.png"  # need something that looks like it's throwing off sparks
+    [/dummy]
+#enddef
 #define ABILITY_SOUL_EATER
     [dummy]
         id=soul eater

--- a/utils/abilities_events.cfg
+++ b/utils/abilities_events.cfg
@@ -6102,7 +6102,57 @@
             kill=no
         [/harm_unit]
     [/event]
-
+    [event]
+        name=attacker hits
+        id=electrical_discharge
+        first_time_only=no
+        [filter_second]
+            ability=electrical_discharge
+        [/filter_second]
+        [if]
+            [variable]
+                name=weapon.range
+                equal=melee
+            [/variable]
+            [then]
+                [harm_unit]
+                    [filter]
+                        x,y=$x1,$y1
+                    [/filter]
+                    amount=$damage_inflicted
+                    damage_type=lightning
+                    fire_event=yes
+                    experience=no
+                    animate=no
+                    kill=yes
+                [/harm_unit]
+            [/then]
+        [/if]
+    [/event]
+    [event]
+        name=defender hits
+        id=electrical_discharge
+        first_time_only=no
+        [if]
+            [variable]
+                name=second_weapon.range
+                equal=melee
+            [/variable]
+            [then]
+                [harm_unit]
+                    [filter]
+                        x,y=$x2,$y2
+                    [/filter]
+                    amount=$damage_inflicted
+                    damage_type=lightning
+                    fire_event=yes
+                    experience=no
+                    animate=no
+                    kill=yes
+                [/harm_unit]
+            [/then]
+        [/if]
+    [/event]
     [event]
         name=attack
         first_time_only=no


### PR DESCRIPTION
I was under the impression that the power generators were somewhat important, like they did something to weaken Akula.  It actually doesn't look like they do anything (at least not the ones in Power Station), but I already went into the work of beefing them up.  Might have to do something about that.  

Changed damage type to lightning, because it's called lightning and it makes sense.  Increased the damage, 6x3 isn't going to do much this late in part 1, even if it's lightning. 

Added full damage reflect ability.  Originally I wanted high damage when hit by metal weapons, but except for assuming all blade weapons are metal that's kind of hard to do.  So I just made it reflect on melee.  And it's lightning.  Seriously, don't hit stuff with sparks coming out.  This needs a halo.

I wanted to make it slow, so that units with penetrate couldn't back off to avoid retaliation (including improved deathaura), but that would also limit the amount of retaliatory damage.

Also, changed name of deathaura to deathaura (X) to make it easier to identify.