### PR TITLE
fix typo

### DIFF
--- a/utils/chapter9_utils.cfg
+++ b/utils/chapter9_utils.cfg
@@ -1787,7 +1787,7 @@
                         [if]
                             [variable]
                                 name=demons_killed
-                                greater_than_equal_to=400
+                                greater_than_equal_to=300
                             [/variable]
                             [and]
                                 [variable]


### PR DESCRIPTION
When demons called is between 300 and 400, none spawn from portals because of this typo