### PR TITLE
end tunnel transition abuse on hard

### DIFF
--- a/scenarios5/08_Entrance.cfg
+++ b/scenarios5/08_Entrance.cfg
@@ -32,12 +32,22 @@
         [objectives]
             side=1
             [objective]
+                description= _ "Defeat the enemy leader"
+                condition=win
+                [show_if]
+                    [variable]
+                        name=ch5_quests.sc08.done
+                        not_equals=yes
+                    [/variable]
+                [/show_if]
+            [/objective]
+            [objective]
                 description= _ "Familiarise yourself with the dungeon and proceed further"
                 condition=win
                 [show_if]
                     [variable]
-                        name=sc08
-                        not_equals=1
+                        name=ch5_quests.sc08.done
+                        equals=yes
                     [/variable]
                 [/show_if]
             [/objective]
@@ -52,6 +62,22 @@
         [recall]
             id=Lethalia
         [/recall]
+        [if]
+            [variable]
+                name=ch5_quests.sc08.done
+                not_equals=yes
+            [/variable]
+            [then]
+                [unit]
+                    side=2
+                    id=enemy
+                    type=General_steel
+                    canrecruit=yes
+                    generate_name=yes
+                    x,y=36,6
+                [/unit]
+            [/then]
+        [/if]
     [/event]
     {RECALL_ALL}
     [side]
@@ -70,11 +96,7 @@
         village_gold=1
     [/side]
     [side]
-        generate_name=yes
-        id=enemy
-        type=General_steel
         side=2
-        canrecruit=yes
         recruit=Spearman_steel,Dark Adept_steel,Fencer_steel,Bowman_steel
         {GOLD 400 450 500}
         {INCOME 30 40 50}
@@ -101,8 +123,8 @@
         {CHAPTER5_ITEM item_2_sc_8 23 2}
         [if]
             [variable]
-                name=sc08
-                equals=1
+                name=ch5_quests.sc08.done
+                equals=yes
             [/variable]
             [else]
                 [message]
@@ -111,12 +133,31 @@
                 [/message]
                 [message]
                     speaker=Efraim
-                    message= _ "I suggest to do so, people scared so much usually do not lie."
+                    message= _ "I suggest we do just that, people so scared rarely lie."
                 [/message]
                 [message]
                     speaker=Lethalia
                     message= _ "Fortunately it is so dark here. Our undead will have an advantage."
                 [/message]
+                [message]
+                    speaker=Efraim
+                    message= _ "Good point.  Perhaps we should have brought more of them."
+                    [show_if] # No idea what the actual limit we should use here is.  Also checking Valahlla left as an exercise for the reader.
+                        [lua]
+                            code=<< return #wesnoth.units.find{side=1,race="undead"} < 20 >>
+                        [/lua]
+                    [/show_if]
+                [/message]
+                [message]
+                    speaker=Lethalia
+                    message= _ "I raised an army of them.  You're the one who led them to their deaths.  Re-deaths.  <span font='italic'>Whatever</span>.  It's not <span font='italic'>my</span> fault."
+                    [show_if]
+                         [lua] 
+                            code=<< return #wesnoth.units.find{side=1,race="undead"} < 20 >>
+                        [/lua]
+                    [/show_if]
+                [/message]
+                # Could add another message here, if (# of undead >= level 3)<X then "I wish we hadn't neglected advancing them...".  Not today, though.
                 [message]
                     speaker=narrator
                     image="wesnoth-icon.png"
@@ -133,12 +174,17 @@ Note: Consult the map selecting the newly added menu item."
         [/if]
     [/event]
     [event]
-        name=victory
-        {VARIABLE sc08 1}
+        name=die
+        id=sc8_enemy_leader
+        [filter]
+            id=enemy
+        [/filter]
+        {VARIABLE ch5_quests.sc08.done yes}
+        {TRANSITION 42-45,14-18 43,16 _"Northwestern Storeroom" 09_Northwestern_Storeroom}
+        {TRANSITION 42-45,28-32 43,29 _"Soldiers' Quarters" 21_Soldiers_Quarters}
+        {TRANSITION 1-17,32-34 10,32 _"Power Station" 27_Power_Station}
+        [show_objectives][/show_objectives]
     [/event]
-    {TRANSITION 42-45,14-18 43,16 _"Northwestern Storeroom" 09_Northwestern_Storeroom}
-    {TRANSITION 42-45,28-32 43,29 _"Soldiers' Quarters" 21_Soldiers_Quarters}
-    {TRANSITION 1-17,32-34 10,32 _"Power Station" 27_Power_Station}
     {CAMPAIGN5_EVENTS}
     {DISABLE_UPKEEP 1}
     {SHOW_MAP}

--- a/scenarios5/09_Northwestern_Storeroom.cfg
+++ b/scenarios5/09_Northwestern_Storeroom.cfg
@@ -38,8 +38,8 @@
                 condition=win
                 [show_if]
                     [variable]
-                        name=sc09
-                        not_equals=1
+                        name=ch5_quests.sc09.done
+                        not_equals=yes
                     [/variable]
                 [/show_if]
             [/objective]
@@ -52,6 +52,38 @@
         [recall]
             id=Lethalia
         [/recall]
+#ifdef HARD
+        [if]
+            [variable]
+                name=ch5_quests.sc09.done
+                equals=yes
+            [/variable]
+            [then]
+                {TRANSITION 14-22,15-19 18,16 _"Entrance" 08_Entrance}
+                {TRANSITION 28-32,6-11 30,8 _"Guards' Quarters" 10_Guards_Quarters}
+            [/then]
+            #
+            # In this scenario, you can't exit in any direction until you collect the items.  If we wanted to change this to work like
+            # other scenarios, we'd have to make the items collected count global.
+            #
+            #            [else]
+            #                [switch]
+            #                    variable=last_scenario
+            #                    [case]
+            #                        value=8
+            #                        {TRANSITION 28-32,6-11 30,8 _"Guards' Quarters" 10_Guards_Quarters}
+            #                    [/case]
+            #                    [case]
+            #                        value=10
+            #                        {TRANSITION 14-22,15-19 18,16 _"Entrance" 08_Entrance}
+            #                    [/case]
+            #                [/switch]
+            #            [/else]
+        [/if]
+#else
+        {TRANSITION 14-22,15-19 18,16 _"Entrance" 08_Entrance}
+        {TRANSITION 28-32,6-11 30,8 _"Guards' Quarters" 10_Guards_Quarters}
+#endif
     [/event]
     {RECALL_ALL}
     [side]
@@ -99,8 +131,8 @@
         {VARIABLE items_taken 0}
         [if]
             [variable]
-                name=sc09
-                equals=1
+                name=ch5_quests.sc09.done
+                equals=yes
             [/variable]
             [else]
                 {RARE_ITEM_TURN 5 7 -999}  # In case player leaves room on turn 1
@@ -120,9 +152,15 @@
         name=victory
         {CLEAR_VARIABLE items_taken}
     [/event]
+    [event]
+        name=done_picking
+        {TRANSITION 14-22,15-19 18,16 _"Entrance" 08_Entrance}
+        {TRANSITION 28-32,6-11 30,8 _"Guards' Quarters" 10_Guards_Quarters}
+    [/event]
 
     [event]
         name=moveto
+        id=visit_trader
         first_time_only=no
         [filter]
             side=1
@@ -156,10 +194,8 @@
         [/while]
         {CLEAR_VARIABLE gold,loti_shop}
     [/event]
-    {ITEM_COUNT_OBJECTIVE 5 sc09}
+    {ITEM_COUNT_OBJECTIVE 5 ch5_quests.sc09.done done_picking}
 
-    {TRANSITION 14-22,15-19 18,16 _"Entrance" 08_Entrance}
-    {TRANSITION 28-32,6-11 30,8 _"Guards' Quarters" 10_Guards_Quarters}
     {CAMPAIGN5_EVENTS}
     [event]
         name=start

--- a/scenarios5/10_Guards_Quarters.cfg
+++ b/scenarios5/10_Guards_Quarters.cfg
@@ -43,8 +43,8 @@
                 condition=win
                 [show_if]
                     [variable]
-                        name=sc10
-                        not_equals=1
+                        name=ch5_quests.sc10.done
+                        not_equals=yes
                     [/variable]
                 [/show_if]
             [/objective]
@@ -58,6 +58,44 @@
         [recall]
             id=Lethalia
         [/recall]
+#ifdef HARD
+        [if]
+            [variable]
+                name=ch5_quests.sc10.done
+                equals=yes
+            [/variable]
+            [then]
+                {TRANSITION 1-3,9-13 2,10 _"Northwestern Storeroom" 09_Northwestern_Storeroom}
+                {TRANSITION 42-50,21-25 46,23 _"Northern Guardian Room" 11_Northern_Guardian_Room}
+                {TRANSITION 58-62,16-20 60,17 _"Amplificator 1" 12_Amplificator_1}
+            [/then]
+            [else]
+                [switch]
+                    variable=last_scenario
+                    [case]
+                        value=9
+                        {TRANSITION 42-50,21-25 46,23 _"Northern Guardian Room" 11_Northern_Guardian_Room}
+                        {TRANSITION 58-62,16-20 60,17 _"Amplificator 1" 12_Amplificator_1}
+                    [/case]
+                    [case]
+                        value=11
+                        {TRANSITION 1-3,9-13 2,10 _"Northwestern Storeroom" 09_Northwestern_Storeroom}
+                        {TRANSITION 58-62,16-20 60,17 _"Amplificator 1" 12_Amplificator_1}
+                    [/case]
+                    [case]
+                        value=12
+                        {TRANSITION 1-3,9-13 2,10 _"Northwestern Storeroom" 09_Northwestern_Storeroom}
+                        {TRANSITION 42-50,21-25 46,23 _"Northern Guardian Room" 11_Northern_Guardian_Room}
+                    [/case]
+                [/switch]
+            [/else]
+        [/if]
+
+#else
+        {TRANSITION 1-3,9-13 2,10 _"Northwestern Storeroom" 09_Northwestern_Storeroom}
+        {TRANSITION 42-50,21-25 46,23 _"Northern Guardian Room" 11_Northern_Guardian_Room}
+        {TRANSITION 58-62,16-20 60,17 _"Amplificator 1" 12_Amplificator_1}
+#endif
     [/event]
     {RECALL_ALL}
     [side]
@@ -92,8 +130,8 @@
         {VARIABLE enemies_slain 0}
         [if]
             [variable]
-                name=sc10
-                equals=1
+                name=ch5_quests.sc10.done
+                equals=yes
             [/variable]
             [else]
                 [message]
@@ -117,8 +155,8 @@
         {VARIABLE_OP enemies_slain add 1}
         [if]
             [variable]
-                name=sc10
-                equals=1
+                name=ch5_quests.sc10.done
+                equals=yes
             [/variable]
             [else]
                 [if]
@@ -131,7 +169,10 @@
                             speaker=Lethalia
                             message= _ "I think this should be enough."
                         [/message]
-                        {VARIABLE sc10 1}
+                        {VARIABLE ch5_quests.sc10.done yes}
+                        {TRANSITION 1-3,9-13 2,10 _"Northwestern Storeroom" 09_Northwestern_Storeroom}
+                        {TRANSITION 42-50,21-25 46,23 _"Northern Guardian Room" 11_Northern_Guardian_Room}
+                        {TRANSITION 58-62,16-20 60,17 _"Amplificator 1" 12_Amplificator_1}
                     [/then]
                     [else]
                         [if]
@@ -159,9 +200,6 @@
     [/event]
 
     {BEELZEBUB_SPAWN_POINT 3 6 30 20 25-35,15-25}
-    {TRANSITION 1-3,9-13 2,10 _"Northwestern Storeroom" 09_Northwestern_Storeroom}
-    {TRANSITION 58-62,16-20 60,17 _"Amplificator 1" 12_Amplificator_1}
-    {TRANSITION 42-50,21-25 46,23 _"Northern Guardian Room" 11_Northern_Guardian_Room}
     {CAMPAIGN5_EVENTS}
     {DISABLE_UPKEEP 1}
     {SHOW_MAP}

--- a/scenarios5/11_Northern_Guardian_Room.cfg
+++ b/scenarios5/11_Northern_Guardian_Room.cfg
@@ -40,15 +40,54 @@
         [objectives]
             side=1
             [objective]
+                description= _ "Defeat the enemy leaders"
+                condition=win
+                [show_if]
+                    [variable]
+                        name=ch5_quests.sc11.done
+                        not_equals=yes
+                    [/variable]
+                [/show_if]
+            [/objective]
+            [objective]
                 description= _ "Destruction of Efraim or Lethalia"
                 condition=lose
             [/objective]
         [/objectives]
         {ORIGIN 23 17,29}
+        {VARIABLE leaders_slain 0}
         [recall]
             id=Lethalia
         [/recall]
     [/event]
+#ifdef HARD
+    [if]
+        [variable]
+            name=ch5_quests.sc11.done
+            equals=yes
+        [/variable]
+        [then]
+            {TRANSITION 14-23,0-2 17,1 _"Guards' Quarters" 10_Guards_Quarters}
+            {TRANSITION 14-20,29-31 17,30 _"Akula's Place" 23_Akulas_Place}
+        [/then]
+        [else]
+            [switch]
+                variable=last_scenario
+                [case]
+                    value=10
+                    {TRANSITION 14-20,29-31 17,30 _"Akula's Place" 23_Akulas_Place}
+                [/case]
+                [case]
+                    value=23
+                    {TRANSITION 14-23,0-2 17,1 _"Guards' Quarters" 10_Guards_Quarters}
+                [/case]
+            [/switch]
+        [/else]
+    [/if]
+#else
+    {TRANSITION 14-23,0-2 17,1 _"Guards' Quarters" 10_Guards_Quarters}
+    {TRANSITION 14-20,29-31 17,30 _"Akula's Place" 23_Akulas_Place}
+#endif
     {RECALL_ALL}
     [side]
         type=Efraim_lich
@@ -143,8 +182,27 @@
         {VARIABLE lethalia_spells_left 2}
         {VARIABLE last_scenario 11}
     [/event]
-    {TRANSITION 14-23,0-2 17,1 _"Guards' Quarters" 10_Guards_Quarters}
-    {TRANSITION 14-20,29-31 17,30 _"Akula's Place" 23_Akulas_Place}
+    [event]
+        name=die
+        id=enemy_leader
+        first_time_only=no
+        [filter]
+            id=enemy,enemy2,enemy3
+        [/filter]
+        {VARIABLE_OP leaders_slain add 1}
+        [if]
+            [variable]
+                name=leaders_slain
+                equals=3
+            [/variable]
+            [then]
+                {VARIABLE ch5_quests.sc11.done yes}
+                {TRANSITION 14-23,0-2 17,1 _"Guards' Quarters" 10_Guards_Quarters}
+                {TRANSITION 14-20,29-31 17,30 _"Akula's Place" 23_Akulas_Place}
+                {CLEAR_VARIABLE leaders_slain}
+            [/then]
+        [/if]
+    [/event]
     {CAMPAIGN5_EVENTS}
     {DISABLE_UPKEEP 1}
     {SHOW_MAP}

--- a/scenarios5/12_Amplificator1.cfg
+++ b/scenarios5/12_Amplificator1.cfg
@@ -46,8 +46,8 @@
                 condition=win
                 [show_if]
                     [variable]
-                        name=sc12
-                        not_equals=1
+                        name=ch5_quests.sc12.done
+                        not_equals=yes
                     [/variable]
                 [/show_if]
             [/objective]
@@ -62,6 +62,54 @@
         [recall]
             id=Lethalia
         [/recall]
+#ifdef HARD
+        [if]
+            [variable]
+                name=ch5_quests.sc12.done
+                equals=yes
+            [/variable]
+            [then]
+                {TRANSITION 0-2,7-12 1,9 _"Guards' Quarters" 10_Guards_Quarters}
+                {TRANSITION 48-54,25-28 51,27 _"Eastern Storeroom" 13_Eastern_Storeroom}
+                {TRANSITION 0-3,25-28 2,26 _"Library" 26_Library}
+                {TRANSITION 53-54,3-6 53,5 _"War Zone" 28_War_Zone}
+            [/then]
+            [else]
+                [switch]
+                    variable=last_scenario
+                    [case]
+                        value=10
+                        {TRANSITION 48-54,25-28 51,27 _"Eastern Storeroom" 13_Eastern_Storeroom}
+                        {TRANSITION 0-3,25-28 2,26 _"Library" 26_Library}
+                        {TRANSITION 53-54,3-6 53,5 _"War Zone" 28_War_Zone}
+                    [/case]
+                    [case]
+                        value=13
+                        {TRANSITION 0-2,7-12 1,9 _"Guards' Quarters" 10_Guards_Quarters}
+                        {TRANSITION 0-3,25-28 2,26 _"Library" 26_Library}
+                        {TRANSITION 53-54,3-6 53,5 _"War Zone" 28_War_Zone}
+                    [/case]
+                    [case]
+                        value=26
+                        {TRANSITION 0-2,7-12 1,9 _"Guards' Quarters" 10_Guards_Quarters}
+                        {TRANSITION 48-54,25-28 51,27 _"Eastern Storeroom" 13_Eastern_Storeroom}
+                        {TRANSITION 53-54,3-6 53,5 _"War Zone" 28_War_Zone}
+                    [/case]
+                    [case]
+                        value=28
+                        {TRANSITION 0-2,7-12 1,9 _"Guards' Quarters" 10_Guards_Quarters}
+                        {TRANSITION 48-54,25-28 51,27 _"Eastern Storeroom" 13_Eastern_Storeroom}
+                        {TRANSITION 0-3,25-28 2,26 _"Library" 26_Library}
+                    [/case]
+                [/switch]
+            [/else]
+        [/if]
+#else
+        {TRANSITION 0-2,7-12 1,9 _"Guards' Quarters" 10_Guards_Quarters}
+        {TRANSITION 0-3,25-28 2,26 _"Library" 26_Library}
+        {TRANSITION 53-54,3-6 53,5 _"War Zone" 28_War_Zone}
+        {TRANSITION 48-54,25-28 51,27 _"Eastern Storeroom" 13_Eastern_Storeroom}
+#endif
     [/event]
     {RECALL_ALL}
     [side]
@@ -106,8 +154,8 @@
         {CHAPTER5_ITEM item_1_sc_12 23 27}
         [if]
             [variable]
-                name=sc12
-                equals=1
+                name=ch5_quests.sc12.done
+                equals=yes
             [/variable]
             [then]
                 [kill]
@@ -123,49 +171,29 @@
         [/if]
     [/event]
 
-    [event]
-        name=die
-        [filter]
-            id=amplificator
-        [/filter]
-        {VARIABLE_OP enemies_slain add 1}
+    [event]  # fired from ch5_utils
+        name=amplificator_destroyed
+        {VARIABLE_OP ch5_quests.amplificators.destroyed_count add 1}
+        {VARIABLE ch5_quests.amplificators.1.destroyed yes}
+        {VARIABLE ch5_quests.sc12.done yes}  # technically redundant with ch5_quests.amplificators.1.destroyed, but consistent with other scenarios
+        {TRANSITION 0-2,7-12 1,9 _"Guards' Quarters" 10_Guards_Quarters}
+        {TRANSITION 0-3,25-28 2,26 _"Library" 26_Library}
+        {TRANSITION 53-54,3-6 53,5 _"War Zone" 28_War_Zone}
+        {TRANSITION 48-54,25-28 51,27 _"Eastern Storeroom" 13_Eastern_Storeroom}
         [if]
             [variable]
-                name=sc12
+                name=ch5_quests.amplificators.destroyed_count
                 equals=1
             [/variable]
-            [or]
-                [variable]
-                    name=sc15
-                    equals=1
-                [/variable]
-            [/or]
-            [or]
-                [variable]
-                    name=sc17
-                    equals=1
-                [/variable]
-            [/or]
-            [or]
-                [variable]
-                    name=sc22
-                    equals=1
-                [/variable]
-            [/or]
-            [else]
+            [then]
                 [message]
                     speaker=Lethalia
-                    message=_"What a terrible creation! Akula must be a really twisted mind."
+                    message=_"What a terrible creation! Akula must have a really twisted mind."
                 [/message]
-            [/else]
+            [/then]
         [/if]
-        {VARIABLE sc12 1}
     [/event]
 
-    {TRANSITION 0-2,7-12 1,9 _"Guards' Quarters" 10_Guards_Quarters}
-    {TRANSITION 0-3,25-28 2,26 _"Library" 26_Library}
-    {TRANSITION 53-54,3-6 53,5 _"War Zone" 28_War_Zone}
-    {TRANSITION 48-54,25-28 51,27 _"Eastern Storeroom" 13_Eastern_Storeroom}
     {CAMPAIGN5_EVENTS}
     {DISABLE_UPKEEP 1}
     {SHOW_MAP}

--- a/scenarios5/13_Eastern_Storeroom.cfg
+++ b/scenarios5/13_Eastern_Storeroom.cfg
@@ -48,8 +48,8 @@
                 condition=win
                 [show_if]
                     [variable]
-                        name=sc13
-                        not_equals=1
+                        name=ch5_quests.sc13.done
+                        not_equals=yes
                     [/variable]
                 [/show_if]
             [/objective]
@@ -62,6 +62,39 @@
         [recall]
             id=Lethalia
         [/recall]
+#ifdef HARD
+        [if]
+            [variable]
+                name=ch5_quests.sc13.done
+                equals=yes
+            [/variable]
+            [then]
+                {TRANSITION 1-5,0-2 3,1 _"Amplificator 1" 12_Amplificator_1}
+                {TRANSITION 19-28,21-23 23,22 _"Armoury" 14_Armoury}
+            [/then]
+            #
+            # In this scenario, you can't exit in any direction until you collect the items.  If we wanted to change this to work like
+            # other scenarios, we'd have to make the items collected count global.
+            #
+            #            [else]
+            #                [switch]
+            #                    variable=last_scenario
+            #                    [case]
+            #                        value=12
+            #                        {TRANSITION 19-28,21-23 23,22 _"Armoury" 14_Armoury}
+            #                    [/case]
+            #                    [case]
+            #                        value=14
+            #                        {TRANSITION 1-5,0-2 3,1 _"Amplificator 1" 12_Amplificator_1}
+            #                    [/case]
+            #                [/switch]
+            #            [/else]
+        [/if]
+
+#else
+        {TRANSITION 1-5,0-2 3,1 _"Amplificator 1" 12_Amplificator_1}
+        {TRANSITION 19-28,21-23 23,22 _"Armoury" 14_Armoury}
+#endif
     [/event]
     {RECALL_ALL}
     [side]
@@ -97,8 +130,8 @@
         {VARIABLE items_taken 0}
         [if]
             [variable]
-                name=sc13
-                equals=1
+                name=ch5_quests.sc13.done
+                equals=yes
             [/variable]
             [else]
                 {RARE_ITEM_TURN 13 22 -999}  # In case player leaves room on turn 1}
@@ -113,16 +146,19 @@
             [/else]
         [/if]
     [/event]
+    [event]
+        name=done_picking
+        {TRANSITION 1-5,0-2 3,1 _"Amplificator 1" 12_Amplificator_1}
+        {TRANSITION 19-28,21-23 23,22 _"Armoury" 14_Armoury}
+    [/event]
 
     [event]
         name=victory
         {CLEAR_VARIABLE items_taken}
     [/event]
 
-    {ITEM_COUNT_OBJECTIVE 6 sc13}
+    {ITEM_COUNT_OBJECTIVE 6 ch5_quests.sc13.done done_picking}
 
-    {TRANSITION 1-5,0-2 3,1 _"Amplificator 1" 12_Amplificator_1}
-    {TRANSITION 19-28,21-23 23,22 _"Armoury" 14_Armoury}
     {CAMPAIGN5_EVENTS}
     {DISABLE_UPKEEP 1}
     {SHOW_MAP}

--- a/scenarios5/14_Armoury.cfg
+++ b/scenarios5/14_Armoury.cfg
@@ -45,8 +45,8 @@
                 condition=win
                 [show_if]
                     [variable]
-                        name=sc14
-                        not_equals=1
+                        name=ch5_quests.sc14.done
+                        not_equals=yes
                     [/variable]
                 [/show_if]
             [/objective]
@@ -60,6 +60,45 @@
         [recall]
             id=Lethalia
         [/recall]
+#ifdef HARD
+        [if]
+            [variable]
+                name=ch5_quests.sc14.done
+                equals=yes
+            [/variable]
+            [then]
+                {TRANSITION 32-39,1-4 37,1 _"Eastern Storeroom" 13_Eastern_Storeroom}
+                {TRANSITION 17-22,25-28 20,26 _"Amplificator 2" 15_Amplificator_2}
+                {TRANSITION 0-3,2-7 2,4 _"Eastern Guardian Room" 18_Eastern_Guardian_Room}
+            [/then]
+            # In this scenario, you can't exit in any direction until you collect the items.  If we wanted to change this to work like
+            # other scenarios, we'd have to make the items collected count global.
+            #            [else]
+            #                [switch]
+            #                    variable=last_scenario
+            #                    [case]
+            #                        value=13
+            #                        {TRANSITION 17-22,25-28 20,26 _"Amplificator 2" 15_Amplificator_2}
+            #                        {TRANSITION 0-3,2-7 2,4 _"Eastern Guardian Room" 18_Eastern_Guardian_Room}
+            #                    [/case]
+            #                    [case]
+            #                        value=15
+            #                        {TRANSITION 32-39,1-4 37,1 _"Eastern Storeroom" 13_Eastern_Storeroom}
+            #                        {TRANSITION 0-3,2-7 2,4 _"Eastern Guardian Room" 18_Eastern_Guardian_Room}
+            #                    [/case]
+            #                    [case]
+            #                        value=18
+            #                        {TRANSITION 32-39,1-4 37,1 _"Eastern Storeroom" 13_Eastern_Storeroom}
+            #                        {TRANSITION 17-22,25-28 20,26 _"Amplificator 2" 15_Amplificator_2}
+            #                    [/case]
+            #                [/switch]
+            #            [/else]
+        [/if]
+#else
+        {TRANSITION 32-39,1-4 37,1 _"Eastern Storeroom" 13_Eastern_Storeroom}
+        {TRANSITION 17-22,25-28 20,26 _"Amplificator 2" 15_Amplificator_2}
+        {TRANSITION 0-3,2-7 2,4 _"Eastern Guardian Room" 18_Eastern_Guardian_Room}
+#endif
     [/event]
     {RECALL_ALL}
     [side]
@@ -101,8 +140,8 @@
         {VARIABLE items_taken 0}
         [if]
             [variable]
-                name=sc14
-                equals=1
+                name=ch5_quests.sc14.done
+                equals=yes
             [/variable]
             [then]
                 [kill]
@@ -132,6 +171,12 @@
             [/else]
         [/if]
     [/event]
+    [event]
+        name=done_picking
+        {TRANSITION 32-39,1-4 37,1 _"Eastern Storeroom" 13_Eastern_Storeroom}
+        {TRANSITION 17-22,25-28 20,26 _"Amplificator 2" 15_Amplificator_2}
+        {TRANSITION 0-3,2-7 2,4 _"Eastern Guardian Room" 18_Eastern_Guardian_Room}
+    [/event]
 
     [event]
         name=victory
@@ -140,11 +185,8 @@
 
     {BEELZEBUB_SPAWN_POINT 3 7 14 8 9-19,3-13}
 
-    {ITEM_COUNT_OBJECTIVE 6 sc14}
+    {ITEM_COUNT_OBJECTIVE 6 ch5_quests.sc14.done done_picking}
 
-    {TRANSITION 32-39,1-4 37,1 _"Eastern Storeroom" 13_Eastern_Storeroom}
-    {TRANSITION 17-22,25-28 20,26 _"Amplificator 2" 15_Amplificator_2}
-    {TRANSITION 0-3,2-7 2,4 _"Eastern Guardian Room" 18_Eastern_Guardian_Room}
     {CAMPAIGN5_EVENTS}
     {DISABLE_UPKEEP 1}
     {SHOW_MAP}

--- a/scenarios5/15_Amplificator2.cfg
+++ b/scenarios5/15_Amplificator2.cfg
@@ -46,8 +46,8 @@
                 condition=win
                 [show_if]
                     [variable]
-                        name=sc15
-                        not_equals=1
+                        name=ch5_quests.sc15.done
+                        not_equals=yes
                     [/variable]
                 [/show_if]
             [/objective]
@@ -61,6 +61,43 @@
         [recall]
             id=Lethalia
         [/recall]
+#ifdef HARD
+        [if]
+            [variable]
+                name=ch5_quests.sc15.done
+                equals=yes
+            [/variable]
+            [then]
+                {TRANSITION 11-18,0-2 15,1 _"Armoury" 14_Armoury}
+                {TRANSITION 37-43,20-23 39,22 _"Southeastern Storeroom" 16_Southeastern_Storeroom}
+                {TRANSITION 9-17,20-23 12,22 _"Amplificator 3" 17_Amplificator_3}
+            [/then]
+            [else]
+                [switch]
+                    variable=last_scenario
+                    [case]
+                        value=14
+                        {TRANSITION 37-43,20-23 39,22 _"Southeastern Storeroom" 16_Southeastern_Storeroom}
+                        {TRANSITION 9-17,20-23 12,22 _"Amplificator 3" 17_Amplificator_3}
+                    [/case]
+                    [case]
+                        value=16
+                        {TRANSITION 11-18,0-2 15,1 _"Armoury" 14_Armoury}
+                        {TRANSITION 9-17,20-23 12,22 _"Amplificator 3" 17_Amplificator_3}
+                    [/case]
+                    [case]
+                        value=17
+                        {TRANSITION 11-18,0-2 15,1 _"Armoury" 14_Armoury}
+                        {TRANSITION 37-43,20-23 39,22 _"Southeastern Storeroom" 16_Southeastern_Storeroom}
+                    [/case]
+                [/switch]
+            [/else]
+        [/if]
+#else
+        {TRANSITION 11-18,0-2 15,1 _"Armoury" 14_Armoury}
+        {TRANSITION 37-43,20-23 39,22 _"Southeastern Storeroom" 16_Southeastern_Storeroom}
+        {TRANSITION 9-17,20-23 12,22 _"Amplificator 3" 17_Amplificator_3}
+#endif
     [/event]
     {RECALL_ALL}
     [side]
@@ -120,8 +157,8 @@
         {CHAPTER5_ITEM item_1_sc_15 37 5}
         [if]
             [variable]
-                name=sc15
-                equals=1
+                name=ch5_quests.sc15.done
+                equals=yes
             [/variable]
             [then]
                 [kill]
@@ -137,43 +174,26 @@
         [/if]
     [/event]
 
-    [event]
-        name=die
-        [filter]
-            id=amplificator
-        [/filter]
-        {VARIABLE_OP enemies_slain add 1}
+    [event]  # fired by ch5_utils
+        name=amplificator_destroyed
+        {VARIABLE_OP ch5_quests.amplificators.destroyed_count add 1}
+        {VARIABLE ch5_quests.amplificators.2.destroyed yes}
+        {VARIABLE ch5_quests.sc15.done yes}  # technically redundant with ch5_quests.amplificators.2.destroyed, but consistent with other scenarios
+        {TRANSITION 11-18,0-2 15,1 _"Armoury" 14_Armoury}
+        {TRANSITION 37-43,20-23 39,22 _"Southeastern Storeroom" 16_Southeastern_Storeroom}
+        {TRANSITION 9-17,20-23 12,22 _"Amplificator 3" 17_Amplificator_3}
         [if]
             [variable]
-                name=sc12
+                name=ch5_quests.amplificators.destroyed_count
                 equals=1
             [/variable]
-            [or]
-                [variable]
-                    name=sc15
-                    equals=1
-                [/variable]
-            [/or]
-            [or]
-                [variable]
-                    name=sc17
-                    equals=1
-                [/variable]
-            [/or]
-            [or]
-                [variable]
-                    name=sc22
-                    equals=1
-                [/variable]
-            [/or]
-            [else]
+            [then]
                 [message]
                     speaker=Lethalia
-                    message=_"What a terrible creation! Akula must be a really twisted mind."
+                    message=_"What a terrible creation! That Akula must have been at least partially human at some point if she can devise something like <span font='italic'>that</span>."
                 [/message]
-            [/else]
+            [/then]
         [/if]
-        {VARIABLE sc15 1}
     [/event]
     [event]
         name=moveto
@@ -211,9 +231,6 @@
         {CLEAR_VARIABLE gold,loti_shop}
     [/event]
 
-    {TRANSITION 11-18,0-2 15,1 _"Armoury" 14_Armoury}
-    {TRANSITION 37-43,20-23 39,22 _"Southeastern Storeroom" 16_Southeastern_Storeroom}
-    {TRANSITION 9-17,20-23 12,22 _"Amplificator 3" 17_Amplificator_3}
     {CAMPAIGN5_EVENTS}
     [event]
         name=start

--- a/scenarios5/16_Southeastern_Storeroom.cfg
+++ b/scenarios5/16_Southeastern_Storeroom.cfg
@@ -51,8 +51,8 @@
                 condition=win
                 [show_if]
                     [variable]
-                        name=sc16
-                        not_equals=1
+                        name=ch5_quests.sc16.done
+                        not_equals=yes
                     [/variable]
                 [/show_if]
             [/objective]
@@ -65,6 +65,38 @@
         [recall]
             id=Lethalia
         [/recall]
+#ifdef HARD
+        [if]
+            [variable]
+                name=ch5_quests.sc16.done
+                equals=yes
+            [/variable]
+            [then]
+                {TRANSITION 18-22,0-2 20,0 _"Amplificator 2" 15_Amplificator_2}
+                {TRANSITION 0-4,12-15 2,13 _"Amplificator 3" 17_Amplificator_3}
+            [/then]
+            #
+            # In this scenario, you can't exit in any direction until you collect the items.  If we wanted to change this to work like
+            # other scenarios, we'd have to make the items collected count global.
+            #
+            #            [else]
+            #                [switch]
+            #                    variable=last_scenario
+            #                    [case]
+            #                        value=2
+            #                        {TRANSITION 0-4,12-15 2,13 _"Amplificator 3" 17_Amplificator_3}
+            #                    [/case]
+            #                    [case]
+            #                        value=3
+            #                        {TRANSITION 18-22,0-2 20,0 _"Amplificator 2" 15_Amplificator_2}
+            #                    [/case]
+            #                [/switch]
+            #            [/else]
+        [/if]
+#else
+        {TRANSITION 18-22,0-2 20,0 _"Amplificator 2" 15_Amplificator_2}
+        {TRANSITION 0-4,12-15 2,13 _"Amplificator 3" 17_Amplificator_3}
+#endif
     [/event]
     {RECALL_ALL}
     [side]
@@ -100,8 +132,8 @@
         {VARIABLE items_taken 0}
         [if]
             [variable]
-                name=sc16
-                equals=1
+                name=ch5_quests.sc16.done
+                equals=yes
             [/variable]
             [else]
                 {RARE_ITEM_TURN 1 18 -999}  # In case player leaves room on turn 1
@@ -117,16 +149,19 @@
             [/else]
         [/if]
     [/event]
+    [event]
+        name=done_picking
+        {TRANSITION 18-22,0-2 20,0 _"Amplificator 2" 15_Amplificator_2}
+        {TRANSITION 0-4,12-15 2,13 _"Amplificator 3" 17_Amplificator_3}
+    [/event]
 
     [event]
         name=victory
         {CLEAR_VARIABLE items_taken}
     [/event]
 
-    {ITEM_COUNT_OBJECTIVE 8 sc16}
+    {ITEM_COUNT_OBJECTIVE 8 ch5_quests.sc16.done done_picking}
 
-    {TRANSITION 18-22,0-2 20,0 _"Amplificator 2" 15_Amplificator_2}
-    {TRANSITION 0-4,12-15 2,13 _"Amplificator 3" 17_Amplificator_3}
     {CAMPAIGN5_EVENTS}
     {DISABLE_UPKEEP 1}
     {SHOW_MAP}

--- a/scenarios5/17_Amplificator3.cfg
+++ b/scenarios5/17_Amplificator3.cfg
@@ -43,8 +43,8 @@
                 condition=win
                 [show_if]
                     [variable]
-                        name=sc17
-                        not_equals=1
+                        name=ch5_quests.sc17.done
+                        not_equals=yes
                     [/variable]
                 [/show_if]
             [/objective]
@@ -58,6 +58,43 @@
         [recall]
             id=Lethalia
         [/recall]
+#ifdef HARD
+        [if]
+            [variable]
+                name=ch5_quests.sc17.done
+                equals=yes
+            [/variable]
+            [then]
+                {TRANSITION 20-27,0-4 23,1 _"Amplificator 2" 15_Amplificator_2}
+                {TRANSITION 50-54,6-8 52,7 _"Southeastern Storeroom" 16_Southeastern_Storeroom}
+                {TRANSITION 1-3,14-19 1,17 _"Soldiers' Training Room" 19_Soldiers_Training_Room}
+            [/then]
+            [else]
+                [switch]
+                    variable=last_scenario
+                    [case]
+                        value=15
+                        {TRANSITION 50-54,6-8 52,7 _"Southeastern Storeroom" 16_Southeastern_Storeroom}
+                        {TRANSITION 1-3,14-19 1,17 _"Soldiers' Training Room" 19_Soldiers_Training_Room}
+                    [/case]
+                    [case]
+                        value=16
+                        {TRANSITION 20-27,0-4 23,1 _"Amplificator 2" 15_Amplificator_2}
+                        {TRANSITION 1-3,14-19 1,17 _"Soldiers' Training Room" 19_Soldiers_Training_Room}
+                    [/case]
+                    [case]
+                        value=19
+                        {TRANSITION 20-27,0-4 23,1 _"Amplificator 2" 15_Amplificator_2}
+                        {TRANSITION 50-54,6-8 52,7 _"Southeastern Storeroom" 16_Southeastern_Storeroom}
+                    [/case]
+                [/switch]
+            [/else]
+        [/if]
+#else
+        {TRANSITION 20-27,0-4 23,1 _"Amplificator 2" 15_Amplificator_2}
+        {TRANSITION 50-54,6-8 52,7 _"Southeastern Storeroom" 16_Southeastern_Storeroom}
+        {TRANSITION 1-3,14-19 1,17 _"Soldiers' Training Room" 19_Soldiers_Training_Room}
+#endif
     [/event]
     {RECALL_ALL}
     [side]
@@ -115,8 +152,8 @@
         {CHAPTER5_ITEM item_1_sc_17 35 27}
         [if]
             [variable]
-                name=sc17
-                equals=1
+                name=ch5_quests.sc17.done
+                equals=yes
             [/variable]
             [then]
                 [kill]
@@ -132,46 +169,30 @@
         [/if]
     [/event]
 
-    [event]
-        name=die
-        [filter]
-            id=amplificator
-        [/filter]
-        {VARIABLE_OP enemies_slain add 1}
+    [event]  # fired by ch5_utils
+        name=amplificator_destroyed
+        {VARIABLE_OP ch5_quests.amplificators.destroyed_count add 1}
+        {VARIABLE ch5_quests.amplificators.3.destroyed yes}
+        {VARIABLE ch5_quests.sc17.done yes}  # technically redundant with ch5_quests.amplificators.3.destroyed, but consistent with other scenarios
+        {TRANSITION 20-27,0-4 23,1 _"Amplificator 2" 15_Amplificator_2}
+        {TRANSITION 50-54,6-8 52,7 _"Southeastern Storeroom" 16_Southeastern_Storeroom}
+        {TRANSITION 1-3,14-19 1,17 _"Soldiers' Training Room" 19_Soldiers_Training_Room}
         [if]
             [variable]
-                name=sc12
+                name=ch5_quests.amplificators.destroyed_count
                 equals=1
             [/variable]
-            [or]
-                [variable]
-                    name=sc15
-                    equals=1
-                [/variable]
-            [/or]
-            [or]
-                [variable]
-                    name=sc17
-                    equals=1
-                [/variable]
-            [/or]
-            [or]
-                [variable]
-                    name=sc22
-                    equals=1
-                [/variable]
-            [/or]
-            [else]
+            [then]
                 [message]
                     speaker=Lethalia
-                    message=_"What a terrible creation! Akula must be a really twisted mind."
+                    message=_"What a terrible creation! That Akula, I don't know, there's something very wrong with her."
                 [/message]
-            [/else]
+            [/then]
         [/if]
-        {VARIABLE sc17 1}
     [/event]
     [event]
         name=moveto
+        id=visit_trader
         first_time_only=no
         [filter]
             side=1
@@ -191,8 +212,13 @@
                     message= _ "Hello, I am a trader. I sell items. Look at my stock and tell me what would you like to look at more closely."
                     {SELL_GEMS}
                     {SHOP_ITEM _"Ring of Unearthly Existence" 150 9 items/ring-white.png sc17_i1}
+#ifdef HARD
+                    {SHOP_ITEM _"Holy Sword" 250 14 items/holy-sword.png sc17_i2}
+                    {SHOP_ITEM _"Amulet of Reason" 140 17 items/ankh-necklace.png sc17_i3}
+#else
                     {SHOP_ITEM _"Holy Sword" 50 14 items/holy-sword.png sc17_i2}
                     {SHOP_ITEM _"Amulet of Reason" 40 17 items/ankh-necklace.png sc17_i3}
+#endif
                     {SHOP_ITEM _"Foul Potion" 70 16 items/potion-green.png sc17_i4}
                     [option]
                         label=_"Nothing"
@@ -205,9 +231,6 @@
         [/while]
         {CLEAR_VARIABLE gold,loti_shop}
     [/event]
-    {TRANSITION 1-3,14-19 1,17 _"Soldiers' Training Room" 19_Soldiers_Training_Room}
-    {TRANSITION 50-54,6-8 52,7 _"Southeastern Storeroom" 16_Southeastern_Storeroom}
-    {TRANSITION 20-27,0-4 23,1 _"Amplificator 2" 15_Amplificator_2}
     {CAMPAIGN5_EVENTS}
     [event]
         name=start

--- a/scenarios5/18_Eastern_Guardian_Room.cfg
+++ b/scenarios5/18_Eastern_Guardian_Room.cfg
@@ -40,6 +40,16 @@
         [objectives]
             side=1
             [objective]
+                description= _ "Defeat the enemy leaders"
+                condition=win
+                [show_if]
+                    [variable]
+                        name=ch5_quests.sc18.done
+                        not_equals=yes
+                    [/variable]
+                [/show_if]
+            [/objective]
+            [objective]
                 description= _ "Destruction of Efraim or Lethalia"
                 condition=lose
             [/objective]
@@ -48,6 +58,41 @@
         [recall]
             id=Lethalia
         [/recall]
+#ifdef HARD
+        [if]
+            [variable]
+                name=ch5_quests.sc18.done
+                equals=yes
+            [/variable]
+            [then]
+                {TRANSITION 48-50,6-12 49,8 _"Armoury" 14_Armoury}
+                {TRANSITION 0-2,5-13 1,8 _"Akula's Place" 23_Akulas_Place}
+            [/then]
+            [else]
+                [switch]
+                    variable=last_scenario
+                    [case]
+                        value=14
+                        # There is no path from here directly to Library, even though we can come from Library
+                        {TRANSITION 0-2,5-13 1,8 _"Akula's Place" 23_Akulas_Place}
+                    [/case]
+                    [case]
+                        value=23
+                        # There is no path from here directly to Library, even though we can come from Library
+                        {TRANSITION 48-50,6-12 49,8 _"Armoury" 14_Armoury}
+                    [/case]
+                    [case]
+                        value=26
+                        # Don't allow player to escape to Armoury, as the transition would be right next to entrance from the Library
+                        {TRANSITION 0-2,5-13 1,8 _"Akula's Place" 23_Akulas_Place}
+                    [/case]
+                [/switch]
+            [/else]
+        [/if]
+#else
+        {TRANSITION 48-50,6-12 49,8 _"Armoury" 14_Armoury}
+        {TRANSITION 0-2,5-13 1,8 _"Akula's Place" 23_Akulas_Place}
+#endif
     [/event]
     {RECALL_ALL}
     [side]
@@ -143,8 +188,28 @@
         {VARIABLE lethalia_spells_left 2}
         {VARIABLE last_scenario 18}
     [/event]
-    {TRANSITION 48-50,6-12 49,8 _"Armoury" 14_Armoury}
-    {TRANSITION 0-2,5-13 1,8 _"Akula's Place" 23_Akulas_Place}
+    [event]
+        name=die
+        id=enemy_leader
+        first_time_only=no
+        [filter]
+            id=enemy,enemy2,enemy3
+        [/filter]
+        {VARIABLE_OP leaders_slain add 1}
+        [if]
+            [variable]
+                name=leaders_slain
+                equals=3
+            [/variable]
+            [then]
+                {VARIABLE ch5_quests.sc18.done yes}
+                {TRANSITION 48-50,6-12 49,8 _"Armoury" 14_Armoury}
+                {TRANSITION 0-2,5-13 1,8 _"Akula's Place" 23_Akulas_Place}
+                {CLEAR_VARIABLE leaders_slain}
+            [/then]
+        [/if]
+    [/event]
+
     {CAMPAIGN5_EVENTS}
     {DISABLE_UPKEEP 1}
     {SHOW_MAP}

--- a/scenarios5/19_Soldiers_Training_Room.cfg
+++ b/scenarios5/19_Soldiers_Training_Room.cfg
@@ -42,8 +42,8 @@
                 condition=win
                 [show_if]
                     [variable]
-                        name=sc19
-                        not_equals=1
+                        name=ch5_quests.sc19.done
+                        not_equals=yes
                     [/variable]
                 [/show_if]
             [/objective]
@@ -57,6 +57,44 @@
         [recall]
             id=Lethalia
         [/recall]
+#ifdef HARD
+        [if]
+            [variable]
+                name=ch5_quests.sc19.done
+                equals=yes
+            [/variable]
+            [then]
+                {TRANSITION 43-45,24-28 44,25 _"Amplificator 3" 17_Amplificator_3}
+                {TRANSITION 10-17,0-2 14,1 _"Southern Guardian Room" 20_Southern_Guardian_Room}
+                {TRANSITION 0-2,18-24 2,21 _"Amplificator 4" 22_Amplificator_4}
+            [/then]
+            [else]
+                [switch]
+                    variable=last_scenario
+                    [case]
+                        value=17
+                        {TRANSITION 10-17,0-2 14,1 _"Southern Guardian Room" 20_Southern_Guardian_Room}
+                        {TRANSITION 0-2,18-24 2,21 _"Amplificator 4" 22_Amplificator_4}
+                    [/case]
+                    [case]
+                        value=20
+                        {TRANSITION 43-45,24-28 44,25 _"Amplificator 3" 17_Amplificator_3}
+                        {TRANSITION 0-2,18-24 2,21 _"Amplificator 4" 22_Amplificator_4}
+                    [/case]
+                    [case]
+                        value=22
+                        {TRANSITION 43-45,24-28 44,25 _"Amplificator 3" 17_Amplificator_3}
+                        {TRANSITION 10-17,0-2 14,1 _"Southern Guardian Room" 20_Southern_Guardian_Room}
+                    [/case]
+                [/switch]
+            [/else]
+        [/if]
+
+#else
+        {TRANSITION 43-45,24-28 44,25 _"Amplificator 3" 17_Amplificator_3}
+        {TRANSITION 10-17,0-2 14,1 _"Southern Guardian Room" 20_Southern_Guardian_Room}
+        {TRANSITION 0-2,18-24 2,21 _"Amplificator 4" 22_Amplificator_4}
+#endif
     [/event]
     {RECALL_ALL}
     [side]
@@ -108,8 +146,8 @@
         {VARIABLE enemies_slain 0}
         [if]
             [variable]
-                name=sc19
-                equals=1
+                name=ch5_quests.sc19.done
+                equals=yes
             [/variable]
             [then]
                 [kill]
@@ -137,11 +175,12 @@
         [filter]
             side=2
         [/filter]
+        # Enemies are enemies I guess (doesn't account for BZB's team)
         {VARIABLE_OP enemies_slain add 1}
         [if]
             [variable]
-                name=sc19
-                equals=1
+                name=ch5_quests.sc19.done
+                equals=yes
             [/variable]
             [else]
                 [if]
@@ -154,7 +193,10 @@
                             speaker=Lethalia
                             message=_"I think this should be enough."
                         [/message]
-                        {VARIABLE sc19 1}
+                        {VARIABLE ch5_quests.sc19.done yes}
+                        {TRANSITION 43-45,24-28 44,25 _"Amplificator 3" 17_Amplificator_3}
+                        {TRANSITION 10-17,0-2 14,1 _"Southern Guardian Room" 20_Southern_Guardian_Room}
+                        {TRANSITION 0-2,18-24 2,21 _"Amplificator 4" 22_Amplificator_4}
                     [/then]
                     [else]
                         [if]
@@ -182,9 +224,6 @@
     [/event]
 
     {BEELZEBUB_SPAWN_POINT 3 6 16 18 11-21,13-23}
-    {TRANSITION 43-45,24-28 44,25 _"Amplificator 3" 17_Amplificator_3}
-    {TRANSITION 0-2,18-24 2,21 _"Amplificator 4" 22_Amplificator_4}
-    {TRANSITION 10-17,0-2 14,1 _"Southern Guardian Room" 20_Southern_Guardian_Room}
     {CAMPAIGN5_EVENTS}
     {DISABLE_UPKEEP 1}
     {SHOW_MAP}

--- a/scenarios5/20_Southern_Guardian_Room.cfg
+++ b/scenarios5/20_Southern_Guardian_Room.cfg
@@ -40,14 +40,53 @@
         [objectives]
             side=1
             [objective]
+                description= _ "Defeat the enemy leaders"
+                condition=win
+                [show_if]
+                    [variable]
+                        name=ch5_quests.sc20.done
+                        not_equals=yes
+                    [/variable]
+                [/show_if]
+            [/objective]
+            [objective]
                 description= _ "Destruction of Efraim or Lethalia"
                 condition=lose
             [/objective]
         [/objectives]
         {ORIGIN 23 16,2}
+        {VARIABLE leaders_slain 0}
         [recall]
             id=Lethalia
         [/recall]
+#ifdef HARD
+        [if]
+            [variable]
+                name=ch5_quests.sc20.done
+                equals=yes
+            [/variable]
+            [then]
+                {TRANSITION 9-17,30-31 13,30 _"Soldiers' Training Room" 19_Soldiers_Training_Room}
+                {TRANSITION 11-19,0-2 15,1 _"Akula's Place" 23_Akulas_Place}
+            [/then]
+            [else]
+                [switch]
+                    variable=last_scenario
+                    [case]
+                        value=19
+                        {TRANSITION 11-19,0-2 15,1 _"Akula's Place" 23_Akulas_Place}
+                    [/case]
+                    [case]
+                        value=23
+                        {TRANSITION 9-17,30-31 13,30 _"Soldiers' Training Room" 19_Soldiers_Training_Room}
+                    [/case]
+                [/switch]
+            [/else]
+        [/if]
+#else
+        {TRANSITION 9-17,30-31 13,30 _"Soldiers' Training Room" 19_Soldiers_Training_Room}
+        {TRANSITION 11-19,0-2 15,1 _"Akula's Place" 23_Akulas_Place}
+#endif
     [/event]
     {RECALL_ALL}
     [side]
@@ -138,13 +177,33 @@
         [/object]
     [/side]
     [event]
+        name=die
+        id=enemy_leader
+        first_time_only=no
+        [filter]
+            id=enemy,enemy2,enemy3
+        [/filter]
+        {VARIABLE_OP leaders_slain add 1}
+        [if]
+            [variable]
+                name=leaders_slain
+                equals=3
+            [/variable]
+            [then]
+                {VARIABLE ch5_quests.sc20.done yes}
+                {CLEAR_VARIABLE leaders_slain}
+                {TRANSITION 9-17,30-31 13,30 _"Soldiers' Training Room" 19_Soldiers_Training_Room}
+                {TRANSITION 11-19,0-2 15,1 _"Akula's Place" 23_Akulas_Place}
+            [/then]
+        [/if]
+    [/event]
+
+    [event]
         name=start
         {VARIABLE efraim_spells_left 2}
         {VARIABLE lethalia_spells_left 2}
         {VARIABLE last_scenario 20}
     [/event]
-    {TRANSITION 9-17,30-31 13,30 _"Soldiers' Training Room" 19_Soldiers_Training_Room}
-    {TRANSITION 11-19,0-2 15,1 _"Akula's Place" 23_Akulas_Place}
     {CAMPAIGN5_EVENTS}
     {DISABLE_UPKEEP 1}
     {SHOW_MAP}

--- a/scenarios5/21_Soldiers_Quarters.cfg
+++ b/scenarios5/21_Soldiers_Quarters.cfg
@@ -222,7 +222,7 @@
 
     [event]
         name=victory
-        {CLEAR_VARIABLE enemies_slain}
+        {CLEAR_VARIABLE enemies_slain,enemies_to_slay}
     [/event]
 
     {CAMPAIGN5_EVENTS}

--- a/scenarios5/21_Soldiers_Quarters.cfg
+++ b/scenarios5/21_Soldiers_Quarters.cfg
@@ -35,12 +35,12 @@
         [objectives]
             side=1
             [objective]
-                description= _ "Kill 50 soldiers"
+                {QUANTITY description _"Kill 50 soldiers" _"Kill 75 soldiers" _"Kill 100 soldiers"}
                 condition=win
                 [show_if]
                     [variable]
-                        name=sc21
-                        not_equals=1
+                        name=ch5_quests.sc21.done
+                        not_equals=yes
                     [/variable]
                 [/show_if]
             [/objective]
@@ -54,6 +54,50 @@
         [recall]
             id=Lethalia
         [/recall]
+#ifdef EASY
+        {VARIABLE enemies_to_slay 50}
+#endif
+#ifdef NORMAL
+        {VARIABLE enemies_to_slay 75}
+#endif
+#ifdef HARD
+        {VARIABLE enemies_to_slay 100}
+        [if]
+            [variable]
+                name=ch5_quests.sc21.done
+                equals=yes
+            [/variable]
+            [then]
+                {TRANSITION 27-33,32-34 31,33 _"Amplificator 4" 22_Amplificator_4}
+                {TRANSITION 19-24,0-2 21,1 _"Entrance" 08_Entrance}
+                {TRANSITION 43-45,11-14 44,13 _"Secret Escape Tunnel" 24_Escape_Tunnel}
+            [/then]
+            [else]
+                [switch]
+                    variable=last_scenario
+                    [case]
+                        value=8
+                        {TRANSITION 27-33,32-34 31,33 _"Amplificator 4" 22_Amplificator_4}
+                        {TRANSITION 43-45,11-14 44,13 _"Secret Escape Tunnel" 24_Escape_Tunnel}
+                    [/case]
+                    [case]
+                        value=22
+                        {TRANSITION 19-24,0-2 21,1 _"Entrance" 08_Entrance}
+                        {TRANSITION 43-45,11-14 44,13 _"Secret Escape Tunnel" 24_Escape_Tunnel}
+                    [/case]
+                    [case]
+                        value=24
+                        {TRANSITION 27-33,32-34 31,33 _"Amplificator 4" 22_Amplificator_4}
+                        {TRANSITION 19-24,0-2 21,1 _"Entrance" 08_Entrance}
+                    [/case]
+                [/switch]
+            [/else]
+        [/if]
+#else
+        {TRANSITION 27-33,32-34 31,33 _"Amplificator 4" 22_Amplificator_4}
+        {TRANSITION 19-24,0-2 21,1 _"Entrance" 08_Entrance}
+        {TRANSITION 43-45,11-14 44,13 _"Secret Escape Tunnel" 24_Escape_Tunnel}
+#endif
     [/event]
     {RECALL_ALL}
     [side]
@@ -105,8 +149,8 @@
         {VARIABLE enemies_slain 0}
         [if]
             [variable]
-                name=sc21
-                equals=1
+                name=ch5_quests.sc21.done
+                equals=yes
             [/variable]
             [then]
                 [kill]
@@ -121,7 +165,7 @@
                     message=_"Grr, my supernatural senses indicate that the enemy soldiers managed to unite under one command."
                 [/message]
                 [print]
-                    text= _ "Enemies to slay: $(50-$enemies_slain)"
+                    text= _ "Enemies to slay: $($enemies_to_slay-$enemies_slain)"
                     duration=5000
                     red,green,blue=255,255,255
                 [/print]
@@ -137,31 +181,34 @@
         {VARIABLE_OP enemies_slain add 1}
         [if]
             [variable]
-                name=sc21
-                equals=1
+                name=ch5_quests.sc21.done
+                equals=yes
             [/variable]
             [else]
                 [if]
                     [variable]
                         name=enemies_slain
-                        equals=50
+                        equals=$enemies_to_slay
                     [/variable]
                     [then]
                         [message]
                             speaker=Lethalia
                             message=_"I think this should be enough."
                         [/message]
-                        {VARIABLE sc21 1}
+                        {VARIABLE ch5_quests.sc21.done yes}
+                        {TRANSITION 27-33,32-34 31,33 _"Amplificator 4" 22_Amplificator_4}
+                        {TRANSITION 19-24,0-2 21,1 _"Entrance" 08_Entrance}
+                        {TRANSITION 43-45,11-14 44,13 _"Secret Escape Tunnel" 24_Escape_Tunnel}
                     [/then]
                     [else]
                         [if]
                             [variable]
                                 name=enemies_slain
-                                greater_than=50
+                                greater_than=$enemies_to_slay
                             [/variable]
                             [else]
                                 [print]
-                                    text= _ "Enemies to slay: $(50-$enemies_slain)"
+                                    text= _ "Enemies to slay: $($enemies_to_slay-$enemies_slain)"
                                     duration=5000
                                     red,green,blue=255,255,255
                                 [/print]
@@ -178,9 +225,6 @@
         {CLEAR_VARIABLE enemies_slain}
     [/event]
 
-    {TRANSITION 27-33,32-34 31,33 _"Amplificator 4" 22_Amplificator_4}
-    {TRANSITION 19-24,0-2 21,1 _"Entrance" 08_Entrance}
-    {TRANSITION 43-45,11-14 44,13 _"Secret Escape Tunnel" 24_Escape_Tunnel}
     {CAMPAIGN5_EVENTS}
     {DISABLE_UPKEEP 1}
     {SHOW_MAP}

--- a/scenarios5/22_Amplificator4.cfg
+++ b/scenarios5/22_Amplificator4.cfg
@@ -43,8 +43,8 @@
                 condition=win
                 [show_if]
                     [variable]
-                        name=sc22
-                        not_equals=1
+                        name=ch5_quests.sc22.done
+                        not_equals=yes
                     [/variable]
                 [/show_if]
             [/objective]
@@ -59,6 +59,55 @@
         [recall]
             id=Lethalia
         [/recall]
+#ifdef HARD
+        [if]
+            [variable]
+                name=ch5_quests.sc22.done
+                equals=yes
+            [/variable]
+            [then]
+                {TRANSITION 53-56,25-30 54,27 _"Soldiers' Training Room" 19_Soldiers_Training_Room}
+                {TRANSITION 0-2,18-21 1,19 _"Prison" 25_Prison}
+                {TRANSITION 0-2,3-5 1,4 _"Power Station" 27_Power_Station}
+                {TRANSITION 34-38,0-2 36,0 _"Soldiers' Quarters" 21_Soldiers_Quarters}
+            [/then]
+            [else]
+                [switch]
+                    variable=last_scenario
+                    [case]
+                        value=19
+                        {TRANSITION 0-2,18-21 1,19 _"Prison" 25_Prison}
+                        {TRANSITION 0-2,3-5 1,4 _"Power Station" 27_Power_Station}
+                        {TRANSITION 34-38,0-2 36,0 _"Soldiers' Quarters" 21_Soldiers_Quarters}
+                    [/case]
+                    [case]
+                        value=21
+                        {TRANSITION 53-56,25-30 54,27 _"Soldiers' Training Room" 19_Soldiers_Training_Room}
+                        {TRANSITION 0-2,18-21 1,19 _"Prison" 25_Prison}
+                        {TRANSITION 0-2,3-5 1,4 _"Power Station" 27_Power_Station}
+                    [/case]
+                    [case]
+                        value=25
+                        {TRANSITION 53-56,25-30 54,27 _"Soldiers' Training Room" 19_Soldiers_Training_Room}
+                        {TRANSITION 0-2,18-21 1,19 _"Prison" 25_Prison} # only one way in, always included
+                        {TRANSITION 0-2,3-5 1,4 _"Power Station" 27_Power_Station}
+                        {TRANSITION 34-38,0-2 36,0 _"Soldiers' Quarters" 21_Soldiers_Quarters}
+                    [/case]
+                    [case]
+                        value=27
+                        {TRANSITION 53-56,25-30 54,27 _"Soldiers' Training Room" 19_Soldiers_Training_Room}
+                        {TRANSITION 0-2,18-21 1,19 _"Prison" 25_Prison}
+                        {TRANSITION 34-38,0-2 36,0 _"Soldiers' Quarters" 21_Soldiers_Quarters}
+                    [/case]
+                [/switch]
+            [/else]
+        [/if]
+#else
+        {TRANSITION 53-56,25-30 54,27 _"Soldiers' Training Room" 19_Soldiers_Training_Room}
+        {TRANSITION 0-2,18-21 1,19 _"Prison" 25_Prison}
+        {TRANSITION 0-2,3-5 1,4 _"Power Station" 27_Power_Station}
+        {TRANSITION 34-38,0-2 36,0 _"Soldiers' Quarters" 21_Soldiers_Quarters}
+#endif
     [/event]
     {RECALL_ALL}
     [side]
@@ -111,8 +160,8 @@
         {CHAPTER5_ITEM item_1_sc_22 4 30}
         [if]
             [variable]
-                name=sc22
-                equals=1
+                name=ch5_quests.amplificators.4.destroyed
+                equals=yes
             [/variable]
             [then]
                 [kill]
@@ -136,8 +185,8 @@
         [/filter]
         [if]
             [variable]
-                name=sc22_undead
-                equals=2
+                name=ch5_quests.sc22.undead
+                equals="controlled"
             [/variable]
             [else]
                 {GENERIC_UNIT 4 "Revenant" 21 18}
@@ -160,50 +209,50 @@
                 {GENERIC_UNIT 4 "Revenant" 24 25}
                 {GENERIC_UNIT 4 "Ghoul" 23 31}
                 {GENERIC_UNIT 4 "Revenant" 18 24}
-                {VARIABLE sc22_undead 1}
+                {VARIABLE ch5_quests.sc22.undead "seen"}
             [/else]
+        [/if]
+    [/event]
+
+    [event]  # fired by ch5_utils
+        name=amplificator_destroyed
+        {VARIABLE_OP ch5_quests.amplificators.destroyed_count add 1}
+        {VARIABLE ch5_quests.amplificators.4.destroyed yes}
+        {VARIABLE ch5_quests.sc22.done yes}  # technically redundant with ch5_quests.amplificators.4.destroyed, but consistent with other scenarios
+        {TRANSITION 53-56,25-30 54,27 _"Soldiers' Training Room" 19_Soldiers_Training_Room}
+        {TRANSITION 0-2,18-21 1,19 _"Prison" 25_Prison}
+        {TRANSITION 0-2,3-5 1,4 _"Power Station" 27_Power_Station}
+        {TRANSITION 34-38,0-2 36,0 _"Soldiers' Quarters" 21_Soldiers_Quarters}
+        [if]
+            [variable]
+                name=ch5_quests.amplificators.destroyed_count
+                equals=1
+            [/variable]
+            [then]
+                [message]
+                    speaker=Lethalia
+                    message=_"What a terrible creation! That Akula is one sick puppy!" #translator: 'sick puppy' is slang for a very twisted/evil person
+                [/message]
+            [/then]
         [/if]
     [/event]
 
     [event]
         name=die
+        id=amplificator_by_undead
         [filter]
             id=amplificator
         [/filter]
         [filter_second]
-            side=1
+            side=4
         [/filter_second]
-        [if]
-            [variable]
-                name=sc12
-                equals=1
-            [/variable]
-            [or]
-                [variable]
-                    name=sc15
-                    equals=1
-                [/variable]
-            [/or]
-            [or]
-                [variable]
-                    name=sc17
-                    equals=1
-                [/variable]
-            [/or]
-            [or]
-                [variable]
-                    name=sc22
-                    equals=1
-                [/variable]
-            [/or]
-            [else]
-                [message]
-                    speaker=Lethalia
-                    message=_"What a terrible creation! Akula must be a really twisted mind."
-                [/message]
-            [/else]
-        [/if]
-        {VARIABLE sc22 1}
+        [message]
+            speaker=Efraim
+            message=_"The undead killed the amplificator."
+        [/message]
+        [fire_event]
+            name=amplificator_destroyed
+        [/fire_event]
     [/event]
     [event]
         name=attack
@@ -218,39 +267,20 @@
             message=_"Undead... They seem to have no master... There should be a way to command them."
         [/message]
     [/event]
-    [event]
-        name=die
-        [filter]
-            id=amplificator
-        [/filter]
-        [filter_second]
-            side=4
-        [/filter_second]
-        {VARIABLE_OP enemies_slain add 1}
-        [message]
-            speaker=Lethalia
-            message=_"The undead killed the amplificator."
-        [/message]
-        {VARIABLE sc22 1}
-    [/event]
 
     [event]
         name=victory
         [if]
             [variable]
-                name=sc22_undead
-                equals=2
+                name=ch5_quests.sc22.undead
+                equals="controlled"
             [/variable]
             [else]
-                {CLEAR_VARIABLE sc22_undead}
+                {CLEAR_VARIABLE ch5_quests.sc22.undead}
             [/else]
         [/if]
     [/event]
 
-    {TRANSITION 53-56,25-30 54,27 _"Soldiers' Training Room" 19_Soldiers_Training_Room}
-    {TRANSITION 0-2,18-21 1,19 _"Prison" 25_Prison}
-    {TRANSITION 0-2,3-5 1,4 _"Power Station" 27_Power_Station}
-    {TRANSITION 34-38,0-2 36,0 _"Soldiers' Quarters" 21_Soldiers_Quarters}
     {CAMPAIGN5_EVENTS}
     {DISABLE_UPKEEP 1}
     {SHOW_MAP}

--- a/scenarios5/23_Akulas_Place.cfg
+++ b/scenarios5/23_Akulas_Place.cfg
@@ -59,6 +59,40 @@
             id=Lethalia
         [/recall]
         {PLACE_IMAGE scenery/monolith2.png 52 9}
+#ifdef HARD
+        [switch]
+            variable=last_scenario
+            [case]
+                value=11
+                {TRANSITION 54-56,21-25 55,23 _"Eastern Guardian Room" 18_Eastern_Guardian_Room}
+                {TRANSITION 38-44,35-37 42,36 _"Southern Guardian Room" 20_Southern_Guardian_Room}
+                {TRANSITION 0-2,17-20 2,17 _"Escape Tunnel" 24_Escape_Tunnel}
+            [/case]
+            [case]
+                value=18
+                {TRANSITION 44-49,0-2 46,1 _"Northern Guardian Room" 11_Northern_Guardian_Room}
+                {TRANSITION 38-44,35-37 42,36 _"Southern Guardian Room" 20_Southern_Guardian_Room}
+                {TRANSITION 0-2,17-20 2,17 _"Escape Tunnel" 24_Escape_Tunnel}
+            [/case]
+            [case]
+                value=20
+                {TRANSITION 44-49,0-2 46,1 _"Northern Guardian Room" 11_Northern_Guardian_Room}
+                {TRANSITION 54-56,21-25 55,23 _"Eastern Guardian Room" 18_Eastern_Guardian_Room}
+                {TRANSITION 0-2,17-20 2,17 _"Escape Tunnel" 24_Escape_Tunnel}
+            [/case]
+            [case]
+                value=24
+                {TRANSITION 44-49,0-2 46,1 _"Northern Guardian Room" 11_Northern_Guardian_Room}
+                {TRANSITION 54-56,21-25 55,23 _"Eastern Guardian Room" 18_Eastern_Guardian_Room}
+                {TRANSITION 38-44,35-37 42,36 _"Southern Guardian Room" 20_Southern_Guardian_Room}
+            [/case]
+        [/switch]
+#else
+        {TRANSITION 44-49,0-2 46,1 _"Northern Guardian Room" 11_Northern_Guardian_Room}
+        {TRANSITION 54-56,21-25 55,23 _"Eastern Guardian Room" 18_Eastern_Guardian_Room}
+        {TRANSITION 38-44,35-37 42,36 _"Southern Guardian Room" 20_Southern_Guardian_Room}
+        {TRANSITION 0-2,17-20 2,17 _"Escape Tunnel" 24_Escape_Tunnel}
+#endif
     [/event]
     {RECALL_ALL}
     [side]
@@ -228,7 +262,6 @@
         {VARIABLE efraim_spells_left 4}
         {VARIABLE lethalia_spells_left 4}
         {VARIABLE last_scenario 23}
-        {VARIABLE amplificators_destroyed 0}
         {MODIFY_UNIT side=7 status.petrified yes}
 
         # BEGIN populate Akula's team's castles
@@ -288,8 +321,8 @@
         [/place_shroud]
         [if]
             [variable]
-                name=sc28
-                equals=1
+                name=ch5_quests.sc28.done
+                equals=yes
             [/variable]
             [else]
                 [kill]
@@ -301,8 +334,8 @@
         [/if]
         [if]
             [variable]
-                name=sc12
-                equals=1
+                name=ch5_quests.amplificators.1.destroyed
+                equals=yes
             [/variable]
             [then]
                 [object]
@@ -316,13 +349,12 @@
                         increase_attacks=-50%
                     [/effect]
                 [/object]
-                {VARIABLE_OP amplificators_destroyed add 1}
             [/then]
         [/if]
         [if]
             [variable]
-                name=sc15
-                equals=1
+                name=ch5_quests.amplificators.2.destroyed
+                equals=yes
             [/variable]
             [then]
                 [object]
@@ -336,13 +368,12 @@
                         increase_damage=-50%
                     [/effect]
                 [/object]
-                {VARIABLE_OP amplificators_destroyed add 1}
             [/then]
         [/if]
         [if]
             [variable]
-                name=sc17
-                equals=1
+                name=ch5_quests.amplificators.3.destroyed
+                equals=yes
             [/variable]
             [then]
                 [object]
@@ -361,13 +392,12 @@
                         increase_damage=-10%
                     [/effect]
                 [/object]
-                {VARIABLE_OP amplificators_destroyed add 1}
             [/then]
         [/if]
         [if]
             [variable]
-                name=sc22
-                equals=1
+                name=ch5_quests.amplificators.4.destroyed
+                equals=yes
             [/variable]
             [then]
                 [object]
@@ -386,13 +416,12 @@
                         increase_damage=-10%
                     [/effect]
                 [/object]
-                {VARIABLE_OP amplificators_destroyed add 1}
             [/then]
         [/if]
         [if]
             [variable]
-                name=sc23
-                equals=1
+                name=ch5_quests.sc23.visited
+                equals=yes
             [/variable]
             [else]
                 [message]
@@ -426,18 +455,23 @@
                 [message]
                     speaker=ally
                     message= _ "I will make sure the good will prevail, as my comrade promised!"
+                    [show_if]
+                        [have_unit]
+                            id=ally
+                        [/have_unit]
+                    [/show_if]
                 [/message]
                 [message]
                     speaker=Efraim
                     message= _ "You can not stand a chance against us. Prepare to die, you hideous archdevil!"
                 [/message]
-                {VARIABLE sc23 1}
+                {VARIABLE ch5_quests.sc23.visited yes}
             [/else]
         [/if]
         [if]
             [variable]
-                name=sisters_chat
-                equals=1
+                name=ch5_quests.sc23.sisters_chat
+                equals=yes
             [/variable]
             [else]
                 [if]
@@ -465,7 +499,7 @@
                             speaker=Akula
                             message= _ "You will <i>never</i> persuade me about that. Let us finish this."
                         [/message]
-                        {VARIABLE sisters_chat 1}
+                        {VARIABLE ch5_quests.sc23.sisters_chat yes}
                     [/then]
                 [/if]
             [/else]
@@ -480,12 +514,10 @@
         [filter_second]
             id=Akula
         [/filter_second]
-        [if]
-            [variable]
-                name=amplificators_destroyed
-                equals=4
-            [/variable]
-            [then]
+        [switch]
+            variable=ch5_quests.amplificators.destroyed_count
+            [case]
+                value=4
                 [harm_unit]
                     [filter]
                         x,y=$x1,$y1
@@ -499,14 +531,9 @@
                     experience=no
                     animate=no
                 [/harm_unit]
-            [/then]
-        [/if]
-        [if]
-            [variable]
-                name=amplificators_destroyed
-                equals=3
-            [/variable]
-            [then]
+            [/case]
+            [case]
+                value=3
                 [harm_unit]
                     [filter]
                         x,y=$x1,$y1
@@ -520,14 +547,9 @@
                     experience=no
                     animate=no
                 [/harm_unit]
-            [/then]
-        [/if]
-        [if]
-            [variable]
-                name=amplificators_destroyed
-                equals=2
-            [/variable]
-            [then]
+            [/case]
+            [case]
+                value=2
                 [harm_unit]
                     [filter]
                         x,y=$x1,$y1
@@ -541,14 +563,9 @@
                     experience=no
                     animate=no
                 [/harm_unit]
-            [/then]
-        [/if]
-        [if]
-            [variable]
-                name=amplificators_destroyed
-                equals=1
-            [/variable]
-            [then]
+            [/case]
+            [case]
+                value=1
                 [harm_unit]
                     [filter]
                         x,y=$x1,$y1
@@ -562,20 +579,15 @@
                     experience=no
                     animate=no
                 [/harm_unit]
-            [/then]
-        [/if]
-        [if]
-            [variable]
-                name=amplificators_destroyed
-                equals=5
-            [/variable]
-            [then]
+            [/case]
+            [case]
+                value=0
                 [harm_unit]
                     [filter]
-                        x,y=$x1,$y1
+                        x,y=$x2,$y2
                     [/filter]
                     [filter_second]
-                        x,y=$x2,$y2
+                        x,y=$x1,$y1
                     [/filter_second]
                     amount=50
                     damage_type=pierce
@@ -583,8 +595,8 @@
                     experience=no
                     animate=no
                 [/harm_unit]
-            [/then]
-        [/if]
+            [/case]
+        [/switch]
     [/event]
     [event]
         name=defender hits,defender misses
@@ -595,12 +607,10 @@
         [filter_attack]
             range=melee
         [/filter_attack]
-        [if]
-            [variable]
-                name=amplificators_destroyed
-                equals=4
-            [/variable]
-            [then]
+        [switch]
+            variable=ch5_quests.amplificators.destroyed_count
+            [case]
+                value=4
                 [harm_unit]
                     [filter]
                         x,y=$x2,$y2
@@ -614,14 +624,9 @@
                     experience=no
                     animate=no
                 [/harm_unit]
-            [/then]
-        [/if]
-        [if]
-            [variable]
-                name=amplificators_destroyed
-                equals=3
-            [/variable]
-            [then]
+            [/case]
+            [case]
+                value=3
                 [harm_unit]
                     [filter]
                         x,y=$x2,$y2
@@ -635,14 +640,9 @@
                     experience=no
                     animate=no
                 [/harm_unit]
-            [/then]
-        [/if]
-        [if]
-            [variable]
-                name=amplificators_destroyed
-                equals=2
-            [/variable]
-            [then]
+            [/case]
+            [case]
+                value=2
                 [harm_unit]
                     [filter]
                         x,y=$x2,$y2
@@ -656,14 +656,9 @@
                     experience=no
                     animate=no
                 [/harm_unit]
-            [/then]
-        [/if]
-        [if]
-            [variable]
-                name=amplificators_destroyed
-                equals=1
-            [/variable]
-            [then]
+            [/case]
+            [case]
+                value=1
                 [harm_unit]
                     [filter]
                         x,y=$x2,$y2
@@ -677,14 +672,9 @@
                     experience=no
                     animate=no
                 [/harm_unit]
-            [/then]
-        [/if]
-        [if]
-            [variable]
-                name=amplificators_destroyed
-                equals=0
-            [/variable]
-            [then]
+            [/case]
+            [case]
+                value=0
                 [harm_unit]
                     [filter]
                         x,y=$x2,$y2
@@ -698,8 +688,8 @@
                     experience=no
                     animate=no
                 [/harm_unit]
-            [/then]
-        [/if]
+            [/case]
+        [/switch]
     [/event]
 
     [event]
@@ -761,12 +751,10 @@
                 [/animate_unit]
             [/else]
         [/if]
-        [if]
-            [variable]
-                name=amplificators_destroyed
-                equals=4
-            [/variable]
-            [then]
+        [switch]
+            variable=ch5_quests.amplificators_destroyed
+            [case]
+                value=4
                 [harm_unit]
                     [filter]
                         x,y=$x1,$y1
@@ -777,14 +765,9 @@
                     experience=no
                     animate=no
                 [/harm_unit]
-            [/then]
-        [/if]
-        [if]
-            [variable]
-                name=amplificators_destroyed
-                equals=3
-            [/variable]
-            [then]
+            [/case]
+            [case]
+                value=3
                 [harm_unit]
                     [filter]
                         x,y=$x1,$y1
@@ -795,14 +778,9 @@
                     experience=no
                     animate=no
                 [/harm_unit]
-            [/then]
-        [/if]
-        [if]
-            [variable]
-                name=amplificators_destroyed
-                equals=2
-            [/variable]
-            [then]
+            [/case]
+            [case]
+                value=2
                 [harm_unit]
                     [filter]
                         x,y=$x1,$y1
@@ -813,14 +791,9 @@
                     experience=no
                     animate=no
                 [/harm_unit]
-            [/then]
-        [/if]
-        [if]
-            [variable]
-                name=amplificators_destroyed
-                equals=1
-            [/variable]
-            [then]
+            [/case]
+            [case]
+                value=1
                 [harm_unit]
                     [filter]
                         x,y=$x1,$y1
@@ -831,14 +804,9 @@
                     experience=no
                     animate=no
                 [/harm_unit]
-            [/then]
-        [/if]
-        [if]
-            [variable]
-                name=amplificators_destroyed
-                equals=0
-            [/variable]
-            [then]
+            [/case]
+            [case]
+                value=0
                 [harm_unit]
                     [filter]
                         x,y=$x1,$y1
@@ -849,8 +817,8 @@
                     experience=no
                     animate=no
                 [/harm_unit]
-            [/then]
-        [/if]
+            [/case]
+        [/switch]
     [/event]
     [event]
         name=defender hits
@@ -911,13 +879,10 @@
                 [/animate_unit]
             [/else]
         [/if]
-
-        [if]
-            [variable]
-                name=amplificators_destroyed
-                equals=4
-            [/variable]
-            [then]
+        [switch]
+            variable=ch5_quests.amplificators_destroyed
+            [case]
+                value=4
                 [harm_unit]
                     [filter]
                         x,y=$x2,$y2
@@ -928,14 +893,9 @@
                     experience=no
                     animate=no
                 [/harm_unit]
-            [/then]
-        [/if]
-        [if]
-            [variable]
-                name=amplificators_destroyed
-                equals=3
-            [/variable]
-            [then]
+            [/case]
+            [case]
+                value=3
                 [harm_unit]
                     [filter]
                         x,y=$x2,$y2
@@ -946,14 +906,9 @@
                     experience=no
                     animate=no
                 [/harm_unit]
-            [/then]
-        [/if]
-        [if]
-            [variable]
-                name=amplificators_destroyed
-                equals=2
-            [/variable]
-            [then]
+            [/case]
+            [case]
+                value=2
                 [harm_unit]
                     [filter]
                         x,y=$x2,$y2
@@ -964,14 +919,9 @@
                     experience=no
                     animate=no
                 [/harm_unit]
-            [/then]
-        [/if]
-        [if]
-            [variable]
-                name=amplificators_destroyed
-                equals=1
-            [/variable]
-            [then]
+            [/case]
+            [case]
+                value=1
                 [harm_unit]
                     [filter]
                         x,y=$x2,$y2
@@ -982,14 +932,9 @@
                     experience=no
                     animate=no
                 [/harm_unit]
-            [/then]
-        [/if]
-        [if]
-            [variable]
-                name=amplificators_destroyed
-                equals=0
-            [/variable]
-            [then]
+            [/case]
+            [case]
+                value=0
                 [harm_unit]
                     [filter]
                         x,y=$x2,$y2
@@ -1000,8 +945,8 @@
                     experience=no
                     animate=no
                 [/harm_unit]
-            [/then]
-        [/if]
+            [/case]
+        [/switch]
     [/event]
 
     [event]
@@ -1203,10 +1148,6 @@
         [/endlevel]
     [/event]
 
-    {TRANSITION 38-44,35-37 42,36 _"Southern Guardian Room" 20_Southern_Guardian_Room}
-    {TRANSITION 54-56,21-25 55,23 _"Eastern Guardian Room" 18_Eastern_Guardian_Room}
-    {TRANSITION 44-49,0-2 46,1 _"Northern Guardian Room" 11_Northern_Guardian_Room}
-    {TRANSITION 0-2,17-20 2,17 _"Escape Tunnel" 24_Escape_Tunnel}
     {CAMPAIGN5_EVENTS}
     {DISABLE_UPKEEP 1}
     {SHOW_MAP}

--- a/scenarios5/23_Akulas_Place.cfg
+++ b/scenarios5/23_Akulas_Place.cfg
@@ -584,10 +584,10 @@
                 value=0
                 [harm_unit]
                     [filter]
-                        x,y=$x2,$y2
+                        x,y=$x1,$y1
                     [/filter]
                     [filter_second]
-                        x,y=$x1,$y1
+                        x,y=$x2,$y2
                     [/filter_second]
                     amount=50
                     damage_type=pierce

--- a/scenarios5/25_Prison.cfg
+++ b/scenarios5/25_Prison.cfg
@@ -41,27 +41,9 @@
                 condition=win
                 [show_if]
                     [variable]
-                        name=sc25
-                        not_equals=1
+                        name=ch5_quests.sc25.done
+                        not_equals=yes
                     [/variable]
-                    [or]
-                        [variable]
-                            name=sc25_manta
-                            not_equals=1
-                        [/variable]
-                    [/or]
-                    [or]
-                        [variable]
-                            name=sc25_betrayer
-                            not_equals=1
-                        [/variable]
-                    [/or]
-                    [or]
-                        [variable]
-                            name=sc25_intruder
-                            not_equals=1
-                        [/variable]
-                    [/or]
                 [/show_if]
             [/objective]
             [objective]
@@ -72,6 +54,151 @@
         [recall]
             id=Lethalia
         [/recall]
+        [if]
+            [variable]
+                name=ch5_quests.sc25.done
+                not_equals=yes
+            [/variable]
+            [then]
+                [unit]
+                    side=3
+                    x,y=30,9
+                    type=Troll
+                    id=the_troll
+                    generate_name=yes
+                    random_traits=yes
+                    [modifications]
+                        [advancement]
+                            description=_"better with club"
+                            id="you_should_never_see_this"
+                            image="attacks/club.png"
+                            max_times=1
+                            require_amla=""
+                            [effect]
+                                apply_to="attack"
+                                increase_attacks=1
+                                increase_damage=4
+                            [/effect]
+                        [/advancement]
+                    [/modifications]
+                [/unit]
+                [unit]
+                    side=2
+                    x,y=26,8
+                    type=Royal Guard_steel
+                    id=trolled_guard
+                    generate_name=yes
+                    random_traits=yes
+                [/unit]
+            [/then]
+        [/if]
+        [switch]
+            variable=ch5_quests.sc25.intruder
+            [case]
+                value="accepted"
+            [/case]
+            [else]
+                [unit]
+                    side=3
+                    x,y=3,20
+                    type=Shadowalker
+                    id=prisoner2
+                    generate_name=yes
+                    random_traits=yes
+                    [modifications]
+                        [object]
+                            name= _ "Nightstalker"
+                            image=items/dagger.png
+                            description= _ "This dagger creates shadows by itself, allows its user to stalk in the shadows, darkens and backstabs very effectively."
+                            sort=dagger
+                            number=50
+                            [effect]
+                                apply_to=attack
+                                name=dagger
+                                remove_specials=backstab
+                                [set_specials]
+                                    mode=append
+                                    {WEAPON_SPECIAL_GREATER_BACKSTAB}
+                                [/set_specials]
+                            [/effect]
+                            [effect]
+                                apply_to=new_ability
+                                [abilities]
+                                    {ABILITY_DARKENS}
+                                    {ABILITY_NIGHTSTALK}
+                                [/abilities]
+                            [/effect]
+                        [/object]
+                    [/modifications]
+                [/unit]
+            [/else]
+        [/switch]
+        [switch]
+            variable=ch5_quests.sc25.betrayer
+            [case]
+                value="accepted"
+            [/case]
+            [else]
+                [unit]
+                    side=3
+                    x,y=31,24
+                    type=Spearman_steel
+                    id=prisoner1
+                    generate_name=yes
+                    random_traits=yes
+                    [modifications]
+                        [object]
+                            [effect]
+                                apply_to=new_ability
+                                [abilities]
+                                    {WEAPON_SPECIAL_BACKSTAB}   # He is a betrayer after all
+                                [/abilities]
+                            [/effect]
+                        [/object]
+                    [/modifications]
+                [/unit]
+            [/else]
+        [/switch]
+        [switch]
+            variable=ch5_quests.sc25.akulas_sister
+            [case]
+                value="accepted"
+            [/case]
+            [else]
+                [unit]
+                    side=3
+                    x,y=14,4
+                    type=Akula
+                    id=akulas_sister
+                    name=_"Manta"
+                    random_traits=yes
+                    [modifications]
+                        [object]
+                            name= _ "Dragon Claw"
+                            image=items/sword.png
+                            number=36
+                            sort=sword
+                            damage=30
+                            attacks=30
+                            damage_plus=2
+                        [/object]
+                    [/modifications]
+                [/unit]
+            [/else]
+        [/switch]
+#ifdef HARD
+        [if]
+            [variable]
+                name=ch5_quests.sc25.done
+                equals=yes
+            [/variable]
+            [then]
+                {TRANSITION 37-39,2-6 38,3 _"Amplificator 4" 22_Amplificator_4}
+            [/then]
+        [/if]
+#else
+        {TRANSITION 37-39,2-6 38,3 _"Amplificator 4" 22_Amplificator_4}
+#endif
     [/event]
     {RECALL_ALL}
     [side]
@@ -96,13 +223,6 @@
         {AI_OVERHAUL_PLACE_2 2}
         team_name="Dreadful Evil"
         user_team_name=_"Dreadful Evil"
-        [unit]
-            x,y=26,8
-            type=Royal Guard_steel
-            id=trolled_guard
-            generate_name=yes
-            random_traits=yes
-        [/unit]
         {GUARDIAN_UNIT 2 "Royal Guard_steel" 10 4}
         {GUARDIAN_UNIT 2 "Royal Guard_steel" 27 23}
         {GUARDIAN_UNIT 2 "Royal Guard_steel" 5 18}
@@ -113,84 +233,6 @@
         team_name="good,Dreadful Evil"
         user_team_name=_"Good"
         ai_algorithm=idle_ai
-        [unit]
-            x,y=14,4
-            type=Akula
-            id=akulas_sister
-            name=_"Manta"
-            random_traits=yes
-            [modifications]
-                [object]
-                    name= _ "Dragon Claw"
-                    image=items/sword.png
-                    number=36
-                    sort=sword
-                    damage=30
-                    attacks=30
-                    damage_plus=2
-                [/object]
-            [/modifications]
-        [/unit]
-        [unit]
-            x,y=30,9
-            type=Troll
-            id=the_troll
-            generate_name=yes
-            random_traits=yes
-            [modifications]
-                [advancement]
-                    description=_"better with club"
-                    id="you_should_never_see_this"
-                    image="attacks/club.png"
-                    max_times=1
-                    require_amla=""
-                    [effect]
-                        apply_to="attack"
-                        increase_attacks=1
-                        increase_damage=4
-                    [/effect]
-                [/advancement]
-            [/modifications]
-        [/unit]
-        [unit]
-            x,y=31,24
-            type=Spearman_steel
-            id=prisoner1
-            generate_name=yes
-            random_traits=yes
-        [/unit]
-        [unit]
-            x,y=3,20
-            type=Shadowalker
-            id=prisoner2
-            generate_name=yes
-            random_traits=yes
-            [modifications]
-                [object]
-                    name= _ "Nightstalker"
-                    image=items/dagger.png
-                    description= _ "This dagger creates shadows by itself, allows its user to stalk in the shadows, darkens and backstabs very effectively."
-                    sort=dagger
-                    number=50
-                    [effect]
-                        apply_to=attack
-                        name=dagger
-                        remove_specials=backstab
-                        [set_specials]
-                            mode=append
-                            {WEAPON_SPECIAL_GREATER_BACKSTAB}
-                        [/set_specials]
-                    [/effect]
-                    [effect]
-                        apply_to=new_ability
-                        [abilities]
-                            {ABILITY_DARKENS}
-                            {ABILITY_NIGHTSTALK}
-                        [/abilities]
-                    [/effect]
-                [/object]
-            [/modifications]
-        [/unit]
     [/side]
 
     [event]
@@ -204,22 +246,10 @@
         {VARIABLE last_scenario 25}
         [if]
             [variable]
-                name=sc25
-                equals=1
+                name=ch5_quests.sc25.done
+                not_equals=yes
             [/variable]
             [then]
-                [kill]
-                    x,y=30,9
-                    animate=no
-                    fire_event=no
-                [/kill]
-                [kill]
-                    x,y=26,8
-                    animate=no
-                    fire_event=no
-                [/kill]
-            [/then]
-            [else]
                 [remove_shroud]
                     side=1
                     x=24-33
@@ -344,62 +374,7 @@
                     speaker=the_troll
                     message=_"Very well, now I will join you. But I will smash you if I notice you are only an enemy decoy."
                 [/message]
-                {VARIABLE sc25 1}
                 {MODIFY_UNIT id=the_troll side 1}
-            [/else]
-        [/if]
-        [if]
-            [variable]
-                name=sc25_manta
-                equals=1
-            [/variable]
-            [then]
-                [kill]
-                    x,y=14,4
-                    animate=no
-                    fire_event=no
-                [/kill]
-                [kill]
-                    x,y=10,4
-                    animate=no
-                    fire_event=no
-                [/kill]
-            [/then]
-        [/if]
-        [if]
-            [variable]
-                name=sc25_betrayer
-                equals=1
-            [/variable]
-            [then]
-                [kill]
-                    x,y=27,23
-                    animate=no
-                    fire_event=no
-                [/kill]
-                [kill]
-                    x,y=31,24
-                    animate=no
-                    fire_event=no
-                [/kill]
-            [/then]
-        [/if]
-        [if]
-            [variable]
-                name=sc25_intruder
-                equals=1
-            [/variable]
-            [then]
-                [kill]
-                    x,y=5,18
-                    animate=no
-                    fire_event=no
-                [/kill]
-                [kill]
-                    x,y=3,20
-                    animate=no
-                    fire_event=no
-                [/kill]
             [/then]
         [/if]
     [/event]
@@ -410,13 +385,15 @@
             side=1
             x,y=11-15,2-7
         [/filter]
-        [if]
-            [variable]
-                name=sc25_manta
-                equals=1
-            [/variable]
+        [switch]
+            variable=ch5_quests.sc25.akulas_sister
+            [case]
+                value="accepted"
+            [/case]
+            [case]
+                value="rejected"
+            [/case]
             [else]
-                {VARIABLE sc25_manta 1}
                 [message]
                     speaker=unit
                     message=_"I have found Akula. She was waiting here, hidden, and tricked us to hunt her elsewhere."
@@ -452,6 +429,7 @@
                         label= _"It is worth a try, come with us."
                         [command]
                             {MODIFY_UNIT id=akulas_sister side 1}
+                            {VARIABLE ch5_quests.sc25.akulas_sister "accepted"}
                             [message]
                                 speaker=akulas_sister
                                 message= _ "Thank you. I will not betray you."
@@ -462,11 +440,14 @@
                         label= _"Die, wretched monstrosity!"
                         [command]
                             {MODIFY_UNIT id=akulas_sister side 2}
+                            {VARIABLE ch5_quests.sc25.akulas_sister "rejected"}
                         [/command]
                     [/option]
                 [/message]
+                {VARIABLE ch5_quests.sc25.done yes}
+                {TRANSITION 37-39,2-6 38,3 _"Amplificator 4" 22_Amplificator_4}
             [/else]
-        [/if]
+        [/switch]
     [/event]
     [event]
         name=moveto
@@ -474,13 +455,15 @@
             side=1
             x,y=28-38,22-27
         [/filter]
-        [if]
-            [variable]
-                name=sc25_betrayer
-                equals=1
-            [/variable]
+        [switch]
+            variable=ch5_quests.sc25.betrayer
+            [case]
+                value="accepted"
+            [/case]
+            [case]
+                value="rejected"
+            [/case]
             [else]
-                {VARIABLE sc25_betrayer 1}
                 [message]
                     speaker=prisoner1
                     message=_"I am a betrayer, a turncoat. I am on your side, would you let me join you?"
@@ -488,17 +471,21 @@
                         label= _"Go ahead, come with us."
                         [command]
                             {MODIFY_UNIT id=prisoner1 side 1}
+                            {VARIABLE ch5_quests.sc25.betrayer "accepted"}
                         [/command]
                     [/option]
                     [option]
                         label= _"No, I do not think so."
                         [command]
                             {MODIFY_UNIT id=prisoner1 side 2}
+                            {VARIABLE ch5_quests.sc25.betrayer "rejected"}
                         [/command]
                     [/option]
                 [/message]
+                {VARIABLE ch5_quests.sc25.done yes}
+                {TRANSITION 37-39,2-6 38,3 _"Amplificator 4" 22_Amplificator_4}
             [/else]
-        [/if]
+        [/switch]
     [/event]
     [event]
         name=moveto
@@ -506,13 +493,15 @@
             side=1
             x,y=1-5,17-26
         [/filter]
-        [if]
-            [variable]
-                name=sc25_intruder
-                equals=1
-            [/variable]
+        [switch]
+            variable=ch5_quests.sc25.intruder
+            [case]
+                value="accepted"
+            [/case]
+            [case]
+                value="rejected"
+            [/case]
             [else]
-                {VARIABLE sc25_intruder 1}
                 [message]
                     speaker=prisoner2
                     message=_"I sneaked in, hell-bent to assassinate Akula. Stabbed her with my dagger in the back. Darn, what an idiot I was! She got away with a weeny scratch. That iron maiden just got a laugh at my expense. Hey, come on! Take me with you so I can defeat these... steel hybrids."
@@ -520,20 +509,23 @@
                         label= _"I believe you, come with us."
                         [command]
                             {MODIFY_UNIT id=prisoner2 side 1}
+                            {VARIABLE ch5_quests.sc25.intruder "accepted"}
                         [/command]
                     [/option]
                     [option]
                         label= _"No, I do not think so. It is too obvious that you are an impostor."
                         [command]
                             {MODIFY_UNIT id=prisoner2 side 2}
+                            {VARIABLE ch5_quests.sc25.intruder "rejected"}
                         [/command]
                     [/option]
                 [/message]
+                {VARIABLE ch5_quests.sc25.done yes}
+                {TRANSITION 37-39,2-6 38,3 _"Amplificator 4" 22_Amplificator_4}
             [/else]
-        [/if]
+        [/switch]
     [/event]
 
-    {TRANSITION 37-39,2-6 38,3 _"Amplificator 4" 22_Amplificator_4}
     {CAMPAIGN5_EVENTS}
     {DISABLE_UPKEEP 1}
     {SHOW_MAP}

--- a/scenarios5/26_Library.cfg
+++ b/scenarios5/26_Library.cfg
@@ -35,6 +35,12 @@
             [objective]
                 description= _ "Learn everything the library has to offer"
                 condition=win
+                [show_if]
+                    [variable]
+                        name=ch5_quests.sc26.done
+                        not_equals=yes
+                    [/variable]
+                [/show_if]
             [/objective]
             [objective]
                 description= _ "Destruction of Efraim or Lethalia"

--- a/scenarios5/26_Library.cfg
+++ b/scenarios5/26_Library.cfg
@@ -33,6 +33,10 @@
         [objectives]
             side=1
             [objective]
+                description= _ "Learn everything the library has to offer"
+                condition=win
+            [/objective]
+            [objective]
                 description= _ "Destruction of Efraim or Lethalia"
                 condition=lose
             [/objective]
@@ -41,6 +45,34 @@
         [recall]
             id=Lethalia
         [/recall]
+#ifdef HARD
+        [if]
+            [variable]
+                name=ch5_quests.sc26.done
+                equals=yes
+            [/variable]
+            [then]
+                {TRANSITION 20-28,0-2 23,1 _"Amplificator 1" 12_Amplificator_1}
+                {TRANSITION 2-4,26-28 3,27 _"Eastern Guardian Room" 18_Eastern_Guardian_Room}
+            [/then]
+            [else]
+                [switch]
+                    variable=last_scenario
+                    [case]
+                        value=12
+                        {TRANSITION 2-4,26-28 3,27 _"Eastern Guardian Room" 18_Eastern_Guardian_Room}
+                    [/case]
+                    [case]
+                        value=18
+                        {TRANSITION 20-28,0-2 23,1 _"Amplificator 1" 12_Amplificator_1}
+                    [/case]
+                [/switch]
+            [/else]
+        [/if]
+#else
+        {TRANSITION 20-28,0-2 23,1 _"Amplificator 1" 12_Amplificator_1}
+        {TRANSITION 2-4,26-28 3,27 _"Eastern Guardian Room" 18_Eastern_Guardian_Room}
+#endif
     [/event]
     {RECALL_ALL}
     [side]
@@ -78,6 +110,41 @@
         {PLACE_IMAGE scenery/bookshelf-5.png 9 11}
     [/event]
     [event]
+        name=learned_something
+        first_time_only=no
+        {VARIABLE books_read 0}
+        [foreach]
+            array=ch5_quests.sc26.books
+            [do]
+                [if]
+                    [variable]
+                        name=this_item.read
+                        equals=yes
+                    [/variable]
+                    [then]
+                        {VARIABLE_OP books_read add 1}
+                    [/then]
+                [/if]
+            [/do]
+        [/foreach]
+        [if]
+            [variable]
+                name=books_read
+                equals=5
+            [/variable]
+            [then]
+                {VARIABLE ch5_quests.sc26.done yes}
+                {TRANSITION 20-28,0-2 23,1 _"Amplificator 1" 12_Amplificator_1}
+                {TRANSITION 2-4,26-28 3,27 _"Eastern Guardian Room" 18_Eastern_Guardian_Room}
+                [message]
+                    speaker=Lethalia
+                    message= _"I think we have learned all that we need here, let's move on."
+                [/message]
+            [/then]
+        [/if]
+        {CLEAR_VARIABLE books_read}
+    [/event]
+    [event]
         name=moveto
         first_time_only=no
         [filter]
@@ -96,6 +163,10 @@
             immediate=yes
         [/set_global_variable]
         {CLEAR_VARIABLE secret_4}
+        {VARIABLE ch5_quests.sc26.books[0].read yes}
+        [fire_event]
+            name=learned_something
+        [/fire_event]
     [/event]
     [event]
         name=moveto
@@ -108,6 +179,10 @@
             speaker=unit
             message= _ "These tunnels have existed for millennia. They are remains of an ancient underground fortress of the Argazars, build to protect themselves from an unknown military force, called Rythé, apparently with the same technological level. Because a few places look like they were once some kind of underground forests, the surface was probably destroyed, maybe by a natural cataclysm, maybe by the forces of Rythé, and maybe also by themselves to hide from their enemies. The forces of Rythé obviously did not scout the area for hidden Argazar colonies, probably because of the number of shaxthals roaming the surface and doubt that something except highly adaptive shaxthals could survive the doom."
         [/message]
+        {VARIABLE ch5_quests.sc26.books[1].read yes}
+        [fire_event]
+            name=learned_something
+        [/fire_event]
     [/event]
     [event]
         name=moveto
@@ -120,6 +195,10 @@
             speaker=unit
             message= _ "These tunnels were discovered during an excavation led by Lady Akula, and named Antediluvian Tunnels. Large numbers of interesting objects were found inside, and most of them seemed to be still able to serve their purposes. They ranged from mysterious shooting weapons, slightly similar to dwarves' thunderstaves, but much stronger, strange pipes that could breathe flames, destroying anything, thawing stones to molten lava, shining swords that could cut through anything, a lot of objects that shone and showed some weird symbols depending on the way how buttons were pushed, the purpose of those is still unknown, and also regular objects like chairs, tables or chests, but with mysterious designs. There were no traps, so the excavation has mapped the entire area easily. After that, Lady Akula decided to try to put on one of the mysterious devices, one that looked like an armour designed for creatures with really weirdly shaped bodies. She died painfully and the rest of the excavation group fled, trying to avoid touching any devices. Now, it is known how to use these devices, and there is still enough of them for new soldiers. The absence of shaxthal bodies annoys Akula, because using them for warfare instead of human or half-human soldiers would be a great way to minimise losses."
         [/message]
+        {VARIABLE ch5_quests.sc26.books[2].read yes}
+        [fire_event]
+            name=learned_something
+        [/fire_event]
     [/event]
     [event]
         name=moveto
@@ -132,6 +211,10 @@
             speaker=unit
             message= _ "After the end of the war the Argazars fought against the Rythenians, the shaxthals, their greatest invention, started attacking them, considering them to be their enemies as well. They were facing countless enemies, so they had to make sure that no shaxthal could kill them in combat. They created robotic replacements for several body parts, using their organic parts to digest, think, and as parts that can easily regenerate, while all their movement system was replaced by robotic devices. This allowed them to handle the shaxthals, but prevented them from reproducing, which they noticed after defeating them, and only three women and no men remained unchanged by then. With no way to reproduce, they died from age. It is speculated, however, that some of them became liches and still may possibly hide in the depths of the cavern system, waiting for something that would allow them to breed offspring. This is a danger to everyone, because it is not known if they would not consider all beings inferior and try to exterminate them."
         [/message]
+        {VARIABLE ch5_quests.sc26.books[3].read yes}
+        [fire_event]
+            name=learned_something
+        [/fire_event]
     [/event]
     [event]
         name=moveto
@@ -144,10 +227,12 @@
             speaker=unit
             message= _ "This place was destroyed by the shaxthals by the end of the war, short before the Argazars found a way to destroy them globally. The Argazars fought them bravely, and a thousand shaxthals died to kill a single Argazar. But because of the sheer quantity of the shaxthals, any loss was affordable if it led to an Argazar killed. Their Hive was producing new shaxthals at incredible speed, and a constant flow of drones was marching into the tunnels, where they were slaughtered by hundreds, only to have a little chance that, because of some mistake, malfunction or pure luck, they would hit a vulnerable spot in an Argazar's armour that could lead to death a single foe. One by one, the Argazars died. The shaxthals carried their dead back into the Hive, to unblock the tunnels and to gain material to produce new Shaxthal drones. Their numbers were countless, and so the Argazar numbers dwindled slowly. Anything that could cause harm to the drones, including all traps, was destroyed at the cost of huge losses on the drones' side. After the battle, the shaxthals took their bodies back into the Hive to continue the operations against other Argazar keeps. That is why no shaxthals were found inside."
         [/message]
+        {VARIABLE ch5_quests.sc26.books[4].read yes}
+        [fire_event]
+            name=learned_something
+        [/fire_event]
     [/event]
 
-    {TRANSITION 20-28,0-2 23,1 _"Amplificator 1" 12_Amplificator_1}
-    {TRANSITION 2-4,26-28 3,27 _"Eastern Guardian Room" 18_Eastern_Guardian_Room}
     {CAMPAIGN5_EVENTS}
     {DISABLE_UPKEEP 1}
     {SHOW_MAP}

--- a/scenarios5/27_Power_Station.cfg
+++ b/scenarios5/27_Power_Station.cfg
@@ -43,8 +43,8 @@
                 condition=win
                 [show_if]
                     [variable]
-                        name=sc27
-                        not_equals=1
+                        name=ch5_quests.sc27.done
+                        not_equals=yes
                     [/variable]
                 [/show_if]
             [/objective]
@@ -57,6 +57,34 @@
         [recall]
             id=Lethalia
         [/recall]
+#ifdef HARD
+        [if]
+            [variable]
+                name=ch5_quests.sc27.done
+                equals=yes
+            [/variable]
+            [then]
+                {TRANSITION 8-15,0-2 12,1 _"Entrance" 08_Entrance}
+                {TRANSITION 12-17,28-31 15,30 _"Amplificator 4" 22_Amplificator_4}
+            [/then]
+            [else]
+                [switch]
+                    variable=last_scenario
+                    [case]
+                        value=8
+                        {TRANSITION 12-17,28-31 15,30 _"Amplificator 4" 22_Amplificator_4}
+                    [/case]
+                    [case]
+                        value=22
+                        {TRANSITION 8-15,0-2 12,1 _"Entrance" 08_Entrance}
+                    [/case]
+                [/switch]
+            [/else]
+        [/if]
+#else
+        {TRANSITION 8-15,0-2 12,1 _"Entrance" 08_Entrance}
+        {TRANSITION 12-17,28-31 15,30 _"Amplificator 4" 22_Amplificator_4}
+#endif
     [/event]
     {RECALL_ALL}
     [side]
@@ -91,13 +119,13 @@
         name=start
         {VARIABLE efraim_spells_left 1}
         {VARIABLE lethalia_spells_left 1}
-        {VARIABLE last_scenario 27}
+        {VARIABLE last_scenario 27}  # Move me to victory, or better yet transistion?  Not NECESSARY as long as all dependencies kept in prestart, but better to be sure.
         {CHAPTER5_ITEM item_1_sc_27 32 26}
         {VARIABLE enemies_slain 0}
         [if]
             [variable]
-                name=sc27
-                equals=1
+                name=ch5_quests.sc27.done
+                equals=yes
             [/variable]
             [then]
                 [kill]
@@ -114,7 +142,14 @@
                 [message]
                     speaker=Lethalia
                     message=_"What is also weird, is that this place was not on the map..."
+                    [show_if]
+                        [variable]
+                            name=ch5_quests.sc27.map_comment
+                            not_equal=yes
+                        [/variable]
+                    [/show_if]
                 [/message]
+                {VARIABLE ch5_quests.sc27.map_comment yes}
                 [print]
                     text= _ "Generators to destroy: $(5-$enemies_slain)"
                     duration=5000
@@ -125,6 +160,7 @@
     [/event]
     [event]
         name=die
+        id=power_generator
         first_time_only=no
         [filter]
             side=2
@@ -133,8 +169,8 @@
         {VARIABLE_OP enemies_slain add 1}
         [if]
             [variable]
-                name=sc27
-                equals=1
+                name=ch5_quests.sc27.done
+                equals=yes
             [/variable]
             [else]
                 [if]
@@ -147,7 +183,11 @@
                             speaker=Lethalia
                             message=_"All the machines were destroyed. Well done."
                         [/message]
-                        {VARIABLE sc27 1}
+                        {VARIABLE ch5_quests.sc27.done yes}
+#ifdef HARD
+                        {TRANSITION 8-15,0-2 12,1 _"Entrance" 08_Entrance}
+                        {TRANSITION 12-17,28-31 15,30 _"Amplificator 4" 22_Amplificator_4}
+#endif
                     [/then]
                     [else]
                         [if]
@@ -168,14 +208,11 @@
             [/else]
         [/if]
     [/event]
-
     [event]
         name=victory
         {CLEAR_VARIABLE enemies_slain}
     [/event]
 
-    {TRANSITION 12-17,28-31 15,30 _"Amplificator 4" 22_Amplificator_4}
-    {TRANSITION 8-15,0-2 12,1 _"Entrance" 08_Entrance}
     {CAMPAIGN5_EVENTS}
     {DISABLE_UPKEEP 1}
     {SHOW_MAP}

--- a/scenarios5/28_War_Zone.cfg
+++ b/scenarios5/28_War_Zone.cfg
@@ -36,8 +36,8 @@
                 condition=win
                 [show_if]
                     [variable]
-                        name=sc28
-                        not_equals=1
+                        name=ch5_quests.sc28.done
+                        not_equals=yes
                     [/variable]
                 [/show_if]
             [/objective]
@@ -46,9 +46,49 @@
                 condition=lose
             [/objective]
         [/objectives]
+        [if]
+            [variable]
+                name=ch5_quests.sc28.done
+                not_equals=yes
+            [/variable]
+            [then]
+                [unit]
+                    side=2
+                    generate_name=yes
+                    id=enemy
+                    type=Grand Marshal_steel
+                    canrecruit=yes
+                    random_traits=yes
+                    x,y=18,14
+                    [object]
+                        [effect]
+                            apply_to=movement_costs
+                            replace="true"
+                            [movement_costs]
+                                flat={UNREACHABLE}
+                                cave={UNREACHABLE}
+                            [/movement_costs]
+                        [/effect]
+                    [/object]
+                [/unit]
+            [/then]
+        [/if]
         [recall]
             id=Lethalia
         [/recall]
+#ifdef HARD
+        [if]
+            [variable]
+                name=ch5_quests.sc28.done
+                equals=yes
+            [/variable]
+            [then]
+                {TRANSITION 0-2,20-23 1,21 _"Amplificator 1" 12_Amplificator_1}
+            [/then]
+        [/if]
+#else
+        {TRANSITION 0-2,20-23 1,21 _"Amplificator 1" 12_Amplificator_1}
+#endif
     [/event]
     {RECALL_ALL}
     [side]
@@ -66,31 +106,16 @@
         village_gold=2
     [/side]
     [side]
-        generate_name=yes
-        id=enemy
-        type=Grand Marshal_steel
         side=2
-        canrecruit=yes
         recruit=Spearman_steel,Dark Adept_steel,Fencer_steel,Bowman_steel
         {GOLD 600 700 800}
         {INCOME 40 50 60}
-        random_traits=yes
         team_name="Dreadful Evil"
         user_team_name=_"Dreadful Evil"
         {AI_OVERHAUL_PLACE 2}
         {AI_OVERHAUL_PLACE_2 2}
         {GENERIC_UNIT 2 "Dark Sorcerer_steel" 19 16}
         {GENERIC_UNIT 2 "Swordsman_steel" 18 13}
-        [object]
-            [effect]
-                apply_to=movement_costs
-                replace="true"
-                [movement_costs]
-                    flat={UNREACHABLE}
-                    cave={UNREACHABLE}
-                [/movement_costs]
-            [/effect]
-        [/object]
     [/side]
     [side]
         generate_name=yes
@@ -107,6 +132,7 @@
         {GENERIC_UNIT 3 "Dwarvish Berserker" 37 7}
         {GENERIC_UNIT 3 "Dwarvish Berserker" 41 9}
     [/side]
+
     [event]
         name=start
         {VARIABLE efraim_spells_left 1}
@@ -114,17 +140,10 @@
         {VARIABLE last_scenario 28}
         [if]
             [variable]
-                name=sc28
-                equals=1
+                name=ch5_quests.sc28.done
+                not_equals=yes
             [/variable]
             [then]
-                [kill]
-                    side=2
-                    animate=no
-                    fire_event=no
-                [/kill]
-            [/then]
-            [else]
                 [message]
                     speaker=Efraim
                     message=_"Look, we are not the only ones fighting them."
@@ -157,7 +176,7 @@
                     speaker=ally
                     message=_"We are not much pleased to ally with necromancers, but I think that wasting men to fight these abomination might not be the ideal way... I will ally with you... until the enemy leader dies."
                 [/message]
-            [/else]
+            [/then]
         [/if]
     [/event]
     [event]
@@ -185,11 +204,11 @@
             speaker=ally
             message=_"I do not wish to have more of my men dead. We have a common enemy, I guess. So, I suggest to meet near their leader. I will help you to defeat that... ehm,... Kakula."
         [/message]
-        {VARIABLE sc28 1}
+        {VARIABLE ch5_quests.sc28.done yes}
+        {TRANSITION 0-2,20-23 1,21 _"Amplificator 1" 12_Amplificator_1}
     [/event]
     {BEELZEBUB_SPAWN_POINT 4 7 30 16 25-35,11-21}
     {FORCE_CHANCE_TO_HIT side=2 id=ally 0 ()}
-    {TRANSITION 0-2,20-23 1,21 _"Amplificator 1" 12_Amplificator_1}
     {CAMPAIGN5_EVENTS}
     [event]
         name=start

--- a/utils/chapter5_utils.cfg
+++ b/utils/chapter5_utils.cfg
@@ -1,13 +1,13 @@
 #textdomain wesnoth-loti
 
-#define ITEM_COUNT_OBJECTIVE NUMBER SCENARIO
+#define ITEM_COUNT_OBJECTIVE NUMBER SCENARIO EVENT
     [event]
         name=prestart
         {VARIABLE items_dropped 0}
         [if]
             [variable]
                 name={SCENARIO}
-                equals=1
+                equals=yes
             [/variable]
             [else]
                 [event]
@@ -44,7 +44,10 @@
             speaker=Lethalia
             message=_"This should be enough."
         [/message]
-        {VARIABLE {SCENARIO} 1}
+        {VARIABLE {SCENARIO} yes}
+        [fire_event]
+            name={EVENT}
+        [/fire_event]
     [/event]
 #enddef
 
@@ -238,7 +241,13 @@
                             [/variable]
                             [then]
 #ifdef HARD
-                                {GENERIC_UNIT {SIDE} $spawn_type {X} {Y}}
+                                [unit]
+                                    side={SIDE}
+                                    type=$spawn_type
+                                    x,y={X},{Y}
+                                    placement=map
+                                    passable=yes
+                                [/unit]
 #endif
 #ifdef NORMAL
                                 {VARIABLE_OP did_really_spawn rand (1,1,1,1,0)}
@@ -248,7 +257,13 @@
                                         equals=1
                                     [/variable]
                                     [then]
-                                        {GENERIC_UNIT {SIDE} $spawn_type {X} {Y}}
+                                        [unit]
+                                            side={SIDE}
+                                            type=$spawn_type
+                                            x,y={X},{Y}
+                                            placement=map
+                                            passable=yes
+                                        [/unit]
                                     [/then]
                                 [/if]
 #endif
@@ -260,7 +275,13 @@
                                         equals=1
                                     [/variable]
                                     [then]
-                                        {GENERIC_UNIT {SIDE} $spawn_type {X} {Y}}
+                                        [unit]
+                                            side={SIDE}
+                                            type=$spawn_type
+                                            x,y={X},{Y}
+                                            placement=map
+                                            passable=yes
+                                        [/unit]
                                     [/then]
                                 [/if]
 #endif
@@ -308,6 +329,7 @@
     [/label]
     [event]
         name=moveto
+        id=transition_{ID}
         first_time_only=no
         [filter]
             side=1
@@ -331,6 +353,40 @@
             [/variable]
             [then]
                 {CLEAR_VARIABLE confirm_go}
+#ifdef HARD
+                [store_unit]
+                    [filter]
+                        side=1
+                        [not]
+                            id=Efraim,Lethalia
+                        [/not]
+                        [not]  # hopefully this works.  make sure poisoned units on recall don't get healed if we skip them.
+                            # poison unit, edit autorecall so it is not recalled next scenario, change scenario, edit autorecall back, change scenario
+                            x,y=recall,recall
+                        [/not]
+                    [/filter]
+                    variable=recall_no_heal
+                    kill=yes
+                [/store_unit]
+                [foreach]
+                    array=recall_no_heal
+                    [do]
+                        {VARIABLE this_item.attacks_left $this_item.max_attacks}
+                    [/do]
+                [/foreach]
+                [store_unit]  # stats will be reset at end of scenario, save them
+                    [filter]
+                        id=Efraim
+                    [/filter]
+                    variable=Efrstore
+                [/store_unit]
+                [store_unit]  # stats will be reset at end of scenario, save them
+                    [filter]
+                        id=Lethalia
+                    [/filter]
+                    variable=Lethstore
+                [/store_unit]
+#endif
                 [endlevel]
                     result=victory
                     bonus=no
@@ -378,8 +434,8 @@ Spells remaining: " + ${VARIABLE_NAME}
                             label= _ "Undead superiority: Turns enemy undead to your side. Costs as much as two spells cost."
                             [show_if]
                                 [variable]
-                                    name=sc22_undead
-                                    equals=1
+                                    name=ch5_quests.sc22.undead
+                                    equals="seen"
                                 [/variable]
                                 [and]
                                     [variable]
@@ -390,7 +446,7 @@ Spells remaining: " + ${VARIABLE_NAME}
                             [/show_if]
                             [command]
                                 {MODIFY_UNIT side=4 side 1}
-                                {VARIABLE sc22_undead 2}
+                                {VARIABLE ch5_quests.sc22.undead "controlled"}
                                 {VARIABLE_OP {VARIABLE_NAME} sub 2}
                             [/command]
                         [/option]
@@ -792,6 +848,44 @@ Spells remaining: " + ${VARIABLE_NAME}
             type=Chapter5 Event Loader
             animate=no
         [/kill]
+        # Backward compatability for tunnels
+        [lua]
+            code=<<
+                local vars = { ["sc08"] = {"ch5_quests.sc08.done"}, ["sc09"] = {"ch5_quests.sc09.done"}, ["sc10"] = {"ch5_quests.sc10.done"}, ["sc11"] = {"ch5_quests.sc11.done"}, ["sc12"] = {"ch5_quests.sc12.done", "ch5_quests.amplificators.1.destroyed"}, ["sc13"] = {"ch5_quests.sc13.done"}, ["sc14"] = {"ch5_quests.sc14.done"}, ["sc15"] = {"ch5_quests.sc15.done", "ch5_quests.amplificators.2.destroyed"}, ["sc16"] = {"ch5_quests.sc16.done"}, ["sc17"] = {"ch5_quests.sc17.done", "ch5_quests.amplificators.3.destroyed"}, ["sc18"] = {"ch5_quests.sc18.done"}, ["sc19"] = {"ch5_quests.sc19.done"}, ["sc20"] = {"ch5_quests.sc20.done"}, ["sc21"] = {"ch5_quests.sc21.done"}, ["sc22"] = {"ch5_quests.sc22.done", "ch5_quests.amplificators.4.destroyed"}, ["sc23"] = {"ch5_quests.sc23.visited"}, ["sc24"] = {"ch5_quests.sc24.done"}, ["sc25"] = {"ch5_quests.sc25.done"}, ["sc26"] = {"ch5_quests.sc26.done"}, ["sc27"] = {"ch5_quests.sc27.done"}, ["sc28"] = {"ch5_quests.sc28.done"} }
+                local amps = { ["sc12"] = 1, ["sc15"] = 1, ["sc17"] = 1, ["sc22"] = 1 }
+                local amp_count = 0
+                for old, news in pairs(vars) do
+                    if wml.variables[old] ~= nil then
+                        for _,new in ipairs(news) do
+                            if wml.variables[old] == 1 then wml.variables[new] = true end
+                        end
+                        if amps[old] ~= nil and wml.variables[old] == 1 then amp_count = amp_count + 1 end
+                        wml.variables[old] = nil
+                    end
+                end
+                wml.variables["ch5_quests.amplificators.destroyed_count"] = amp_count
+                if wml.variables["sisters_chat"] ~= nil and wml.variables["sisters_chat"] == 0 then wml.variables["ch5_quests.sc23.sisters_chat"]=true end
+                wml.variables["sisters_chat"] = nil
+                if wml.variables["sc22_undead"] ~= nil then
+                    if wml.variables["sc22_undead"] == 1 then wml.variables["ch5_quests.sc22.undead"] = "seen" end
+                    if wml.variables["sc22_undead"] == 2 then wml.variables["ch5_quests.sc22.undead"] = "controlled" end
+                    wml.variables["sc22_undead"] = nil
+                end
+                -- converting prisoners isn't perfect, we didn't used to track if they were accepted/rejected, just contacted (will use old behaviour)
+                if wml.variables["sc25_betrayer"] ~= nil and wml.variables["sc25_betrayer"] == 1 then -- should always be 1, but if not it will fall through the cracks to be found
+                    wml.variables["ch5_quests.sc25.betrayer"] = "accepted"
+                    wml.variables["sc25_betrayer"] = nil
+                end
+                if wml.variables["sc25_intruder"] ~= nil and wml.variables["sc25_intruder"] == 1 then
+                    wml.variables["ch5_quests.sc25.intruder"] = "accepted"
+                    wml.variables["sc25_intruder"] = nil
+                end
+                if wml.variables["sc25_manta"] ~= nil and wml.variables["sc25_manta"] == 1 then
+                    wml.variables["ch5_quests.sc25.manta"] = "accepted"
+                    wml.variables["sc25_manta"] = nil
+                end
+        >>
+        [/lua]
     [/event]
 #enddef
 
@@ -1261,8 +1355,15 @@ Spells remaining: " + ${VARIABLE_NAME}
             canrecruit=yes
         [/update_stats]
     [/event]
-
+#ifdef EASY
     {DROPS 10 13 (sword,sword,sword,bow,bow,bow,staff,staff,staff,axe,axe,axe,xbow,dagger,knife,mace,mace,spear) yes 2,3,4,5}
+#endif
+#ifdef NORMAL
+    {DROPS 7 10 (sword,sword,sword,bow,bow,bow,staff,staff,staff,axe,axe,axe,xbow,dagger,knife,mace,mace,spear) yes 2,3,4,5}
+#endif
+#ifdef HARD
+    {DROPS 4 5 (sword,sword,sword,bow,bow,bow,staff,staff,staff,axe,axe,axe,xbow,dagger,knife,mace,mace,spear) yes 2,3,4,5}
+#endif
     [event]
         name=start
         {VARIABLE enemy_sides 2,3,4,5}
@@ -1272,8 +1373,8 @@ Spells remaining: " + ${VARIABLE_NAME}
         {VARIABLE enemy_weakened 0}
         [if]
             [variable]
-                name=sc09
-                numerical_equals=1
+                name=ch5_quests.sc09.done
+                equals=yes
             [/variable]
             [then]
                 {VARIABLE_OP enemy_weakened add 1}
@@ -1281,8 +1382,8 @@ Spells remaining: " + ${VARIABLE_NAME}
         [/if]
         [if]
             [variable]
-                name=sc10
-                numerical_equals=1
+                name=ch5_quests.sc10.done
+                equals=yes
             [/variable]
             [then]
                 {VARIABLE_OP enemy_weakened add 1}
@@ -1290,8 +1391,8 @@ Spells remaining: " + ${VARIABLE_NAME}
         [/if]
         [if]
             [variable]
-                name=sc13
-                numerical_equals=1
+                name=ch5_quests.sc13.done
+                equals=yes
             [/variable]
             [then]
                 {VARIABLE_OP enemy_weakened add 1}
@@ -1299,8 +1400,8 @@ Spells remaining: " + ${VARIABLE_NAME}
         [/if]
         [if]
             [variable]
-                name=sc14
-                numerical_equals=1
+                name=ch5_quests.sc14.done
+                equals=yes
             [/variable]
             [then]
                 {VARIABLE_OP enemy_weakened add 1}
@@ -1308,8 +1409,8 @@ Spells remaining: " + ${VARIABLE_NAME}
         [/if]
         [if]
             [variable]
-                name=sc16
-                numerical_equals=1
+                name=ch5_quests.sc16.done
+                equals=yes
             [/variable]
             [then]
                 {VARIABLE_OP enemy_weakened add 1}
@@ -1317,8 +1418,8 @@ Spells remaining: " + ${VARIABLE_NAME}
         [/if]
         [if]
             [variable]
-                name=sc19
-                numerical_equals=1
+                name=ch5_quests.sc19.done
+                equals=yes
             [/variable]
             [then]
                 {VARIABLE_OP enemy_weakened add 1}
@@ -1326,8 +1427,8 @@ Spells remaining: " + ${VARIABLE_NAME}
         [/if]
         [if]
             [variable]
-                name=sc21
-                numerical_equals=1
+                name=ch5_quests.sc21.done
+                equals=yes
             [/variable]
             [then]
                 {VARIABLE_OP enemy_weakened add 1}
@@ -1335,18 +1436,47 @@ Spells remaining: " + ${VARIABLE_NAME}
         [/if]
         [if]
             [variable]
-                name=sc27
-                numerical_equals=1
+                name=ch5_quests.sc27.done
+                equals=yes
             [/variable]
             [then]
                 {VARIABLE_OP enemy_weakened add 2}
             [/then]
         [/if]
     [/event]
+    [event]
+        name=die
+        id=amplificator
+        [filter]
+            id=amplificator
+        [/filter]
+        [filter_second]
+            side=1
+        [/filter_second]
+        [message]
+            speaker=second_unit
+            message=_"Whatever that thing was, it won't be bothering anyone anymore."
+        [/message]
+        [fire_event]
+            name=amplificator_destroyed
+        [/fire_event]
+    [/event]
 #enddef
 
 #define RECALL_ALL
     [event]
+#ifdef HARD
+        [foreach]  # should this be in RECALL_ALL, or it's own event that always happens?
+            array=recall_no_heal
+            [do]
+                [unstore_unit]
+                    variable=this_item
+                    x,y=recall,recall
+                [/unstore_unit]
+            [/do]
+        [/foreach]
+        {CLEAR_VARIABLE recall_no_heal}
+#endif
         name=prestart
         [recall]
             id=Lethalia
@@ -1360,6 +1490,23 @@ Spells remaining: " + ${VARIABLE_NAME}
             id=Efraim
             show=no
         [/recall]
+#ifdef HARD
+        [modify_unit] # Stats will have been reset at end of scenario.  Put them back.
+            [filter]
+                id=Efraim
+            [/filter]
+            hitpoints=$Efrstore.hitpoints
+            status=$Efrstore.status
+        [/modify_unit]
+        [modify_unit]
+            [filter]
+                id=Lethalia
+            [/filter]
+            hitpoints=$Lethstore.hitpoints
+            status=$Lethstore.status
+        [/modify_unit]
+        {CLEAR_VARIABLE Efrstore,Lethstore}
+#endif
         [if]
             [variable]
                 name=max_autorecall


### PR DESCRIPTION
I'm sure some little stuff slipped in here, but two main changes (on hard):
1. Your units don't heal when you leave the room.  
2.  When you enter a room, the objectives must be completed before you can go back the way you came in.  In the case of storerooms, you must complete the objectives before you leave at all.  No more stepping out and stepping back in with your army brand new any time you run into a little trouble.  You can still escape if you can make it to a different exit (for now, long term on hard you should probably not have a way out).  Also, every room now has objectives.

I changed the vars, like sc08=1 and sc09=1 to ch5_quests.sc08.done=yes and ch5_quests.sc09.done=yes.  I find this to help a lot when troubleshooting as if they are all under one variable the inspect gui show you them all at once instead of making you click all over, and you can copy to clipboard.  Also, putting putting .done and .undead under ch5_quests.sc22 groups them nicely.  Haven't done items yet.  There's a converter added to prestart which I tested on an old save as best I could.