### PR TITLE
improve bzb momument sighted conversation

### DIFF
--- a/utils/utils.cfg
+++ b/utils/utils.cfg
@@ -1295,18 +1295,21 @@ $item_info.description"
                                 local have_vritra = #wesnoth.units.find_on_map{ id = "Vritra" } == 1
                                 local have_efraim = #wesnoth.units.find_on_map{ id = "Efraim" } == 1
                                 if finder.id ~= "Lethalia" and have_lethalia then
-                                    wml.variables["msg_speaker"]="Lethalia"
+                                    wml.variables["msg_speaker"] = "Lethalia"
                                     return
                                 end
                                 if finder.id == "Lethalia" and have_vritra then
-                                    wml.variables["msg_speaker"]="Vritra"
+                                    wml.variables["msg_speaker"] = "Vritra"
                                     return
                                 end
                                 if finder.id == "Lethalia" and not have_vritra and have_efraim then
-                                    wml.variables["msg_speaker"]="Efraim"
+                                    wml.variables["msg_speaker"] = "Efraim"
                                     return
                                 end
-                                wml.variables["msg_speaker"]="Krux"
+                                if finder.id == "Krux" and have_vritra then
+                                    wml.variables["msg_speaker"] = "Vritra"
+                                    return
+                                wml.variables["msg_speaker"] = "Krux"
                                 >>
             [/lua]
 

--- a/utils/utils.cfg
+++ b/utils/utils.cfg
@@ -62,6 +62,7 @@
     [/event]
     [event]
         name=victory
+        id=clear_no_fast_ai
         {CLEAR_VARIABLE no_fast_ai}
     [/event]
 #enddef
@@ -337,145 +338,145 @@ $item_info.description"
 #enddef
 
 #define TRAIT_PERFECTIONIST
-[trait]
-    id=perfectionist
-    male_name= _"perfectionist"
-    female_name= _"female^perfectionist"
-    generate_description=false
-    description= _"An obsessive attention to detail allows this unit to inflict 50% more damage, while requiring much more XP to advance"
-    [effect]
-        apply_to=max_experience
+    [trait]
+        id=perfectionist
+        male_name= _"perfectionist"
+        female_name= _"female^perfectionist"
+        generate_description=false
+        description= _"An obsessive attention to detail allows this unit to inflict 50% more damage, while requiring much more XP to advance"
+        [effect]
+            apply_to=max_experience
 #ifdef EASY
-        increase=100%
+            increase=100%
 #endif
 #ifdef NORMAL
-        increase=200%
+            increase=200%
 #endif
 #ifdef HARD
-        increase=300%
+            increase=300%
 #endif
-    [/effect]
-    [effect]
-        apply_to=attack
-        increase_damage=50%
-    [/effect]
-[/trait]
+        [/effect]
+        [effect]
+            apply_to=attack
+            increase_damage=50%
+        [/effect]
+    [/trait]
 #enddef
 
 #define TRAIT_UNSTOPPABLE
-[trait]
-    id=unstoppable
-    male_name= _"unstoppable"
-    female_name= _"female^unstoppable"
-    generate_description=false
-    description= _"This unit is very unwilling to die when trying to help their friends"
-    [effect]
-        apply_to=hitpoints
-        increase_total=15
-    [/effect]
-    [effect]
-        apply_to=hitpoints
-        times=per level
-        increase_total=10
-    [/effect]
-[/trait]
+    [trait]
+        id=unstoppable
+        male_name= _"unstoppable"
+        female_name= _"female^unstoppable"
+        generate_description=false
+        description= _"This unit is very unwilling to die when trying to help their friends"
+        [effect]
+            apply_to=hitpoints
+            increase_total=15
+        [/effect]
+        [effect]
+            apply_to=hitpoints
+            times=per level
+            increase_total=10
+        [/effect]
+    [/trait]
 #enddef
 
 #define TRAIT_THANATOLOGIST
-[trait]
-    id=thanatologist
-    male_name= _"thanatologist"
-    female_name= _"female^thanatologist"
-    generate_description=false
-    description= _"This unit has good understanding of death, and has made experiments that improved own resistances of pierce, blade and cold"
-    [resistance]
-        pierce=-20
-        blade=-10
-        cold=-20
-    [/resistance]
-[/trait]
+    [trait]
+        id=thanatologist
+        male_name= _"thanatologist"
+        female_name= _"female^thanatologist"
+        generate_description=false
+        description= _"This unit has good understanding of death, and has made experiments that improved own resistances of pierce, blade and cold"
+        [resistance]
+            pierce=-20
+            blade=-10
+            cold=-20
+        [/resistance]
+    [/trait]
 #enddef
 
 #define TRAIT_IMPULSIVE
-[trait]
-    id=impulsive
-    male_name= _"impulsive"
-    female_name= _"female^impulsive"
-    generate_description=false
-    description= _"This unit does not think before acting, and can attack first even when defending"
-    [effect]
-        apply_to=attack
-        [set_specials]
-            mode=append
-            {WEAPON_SPECIAL_FIRSTSTRIKE}
-        [/set_specials]
-    [/effect]
-[/trait]
+    [trait]
+        id=impulsive
+        male_name= _"impulsive"
+        female_name= _"female^impulsive"
+        generate_description=false
+        description= _"This unit does not think before acting, and can attack first even when defending"
+        [effect]
+            apply_to=attack
+            [set_specials]
+                mode=append
+                {WEAPON_SPECIAL_FIRSTSTRIKE}
+            [/set_specials]
+        [/effect]
+    [/trait]
 #enddef
 
 #define TRAIT_THERMOPHILE
-[trait]
-    id=thermophile
-    male_name= _"thermophile"
-    female_name= _"female^thermophile"
-    generate_description=false
-    description= _"This unit liked sitting around lava pools to have developed a liking for hot temperatures"
-    [resistance]
-        fire=-60
-        cold=10
-    [/resistance]
-[/trait]
+    [trait]
+        id=thermophile
+        male_name= _"thermophile"
+        female_name= _"female^thermophile"
+        generate_description=false
+        description= _"This unit liked sitting around lava pools to have developed a liking for hot temperatures"
+        [resistance]
+            fire=-60
+            cold=10
+        [/resistance]
+    [/trait]
 #enddef
 
 #define TRAIT_BROKEN
-[trait]
-    id=broken
-    male_name= _"broken"
-    female_name= _"female^broken"
-    generate_description=false
-    description= _"This unit has fought too many battles and has seen too many friends die, lacks the vigour of life but knows many tricks to avoid getting hit"
-    [effect]
-        apply_to=defense
-        replace=false
-        [defense]
-            frozen=-10
-            shallow_water=-10
-            deep_water=-10
-            reef=-10
-            flat=-10
-            castle=-10
-            village=-10
-            forest=-10
-            cave=-10
-            hills=-10
-            mountains=-10
-            fungus=-10
-            swamp_water=-10
-            sand=-10
-        [/defense]
-    [/effect]
-    [effect]
-        apply_to=attack
-        increase_attacks=-1
-    [/effect]
-    [effect]
-        apply_to=movement
-        increase=-1
-    [/effect]
-[/trait]
+    [trait]
+        id=broken
+        male_name= _"broken"
+        female_name= _"female^broken"
+        generate_description=false
+        description= _"This unit has fought too many battles and has seen too many friends die, lacks the vigour of life but knows many tricks to avoid getting hit"
+        [effect]
+            apply_to=defense
+            replace=false
+            [defense]
+                frozen=-10
+                shallow_water=-10
+                deep_water=-10
+                reef=-10
+                flat=-10
+                castle=-10
+                village=-10
+                forest=-10
+                cave=-10
+                hills=-10
+                mountains=-10
+                fungus=-10
+                swamp_water=-10
+                sand=-10
+            [/defense]
+        [/effect]
+        [effect]
+            apply_to=attack
+            increase_attacks=-1
+        [/effect]
+        [effect]
+            apply_to=movement
+            increase=-1
+        [/effect]
+    [/trait]
 #enddef
 
 #define TRAIT_CYNIC
-[trait]
-    id=cynic
-    male_name= _"cynic"
-    female_name= _"female^cynic"
-    generate_description=false
-    description= _"This unit has fought monsters to subconsciously defy magic, becoming more resistant to arcane damage"
-    [resistance]
-        arcane=-50
-    [/resistance]
-[/trait]
+    [trait]
+        id=cynic
+        male_name= _"cynic"
+        female_name= _"female^cynic"
+        generate_description=false
+        description= _"This unit has fought monsters to subconsciously defy magic, becoming more resistant to arcane damage"
+        [resistance]
+            arcane=-50
+        [/resistance]
+    [/trait]
 #enddef
 
 #define CAMPAIGN3_DEATH_MESSAGES
@@ -875,6 +876,7 @@ $item_info.description"
 #define DISABLE_UPKEEP SIDE
     [event]
         name=unit placed
+        id=original_upkeep
         first_time_only=no
         [filter]
             side={SIDE}
@@ -897,8 +899,10 @@ $item_info.description"
         [deny_undo]
         [/deny_undo]
     [/event]
+
     [event]
         name=victory
+        id=original_upkeep
         [modify_unit]
             [filter]
                 side={SIDE}
@@ -1284,6 +1288,28 @@ $item_info.description"
                 side=1
                 x,y={XY_RANGE}
             [/filter]
+            [lua]
+                code = <<
+                                local finder = wml.variables["unit"]
+                                local have_lethalia = #wesnoth.units.find_on_map{ id = "Lethalia" } == 1
+                                local have_vritra = #wesnoth.units.find_on_map{ id = "Vritra" } == 1
+                                local have_efraim = #wesnoth.units.find_on_map{ id = "Efraim" } == 1
+                                if finder.id ~= "Lethalia" and have_lethalia then
+                                    wml.variables["msg_speaker"]="Lethalia"
+                                    return
+                                end
+                                if finder.id == "Lethalia" and have_vritra then
+                                    wml.variables["msg_speaker"]="Vritra"
+                                    return
+                                end
+                                if finder.id == "Lethalia" and not have_vritra and have_efraim then
+                                    wml.variables["msg_speaker"]="Efraim"
+                                    return
+                                end
+                                wml.variables["msg_speaker"]="Krux"
+                                >>
+            [/lua]
+
             [if]
                 [variable]
                     name=seen_beelzebub_monument
@@ -1301,19 +1327,13 @@ $item_info.description"
                         [/variable]
                         [then]
                             [message]
-                                id=Lethalia
-                                [or]
-                                    id=Vritra
-                                [/or]
+                                speaker=$msg_speaker
                                 message= _ "Oh damn. Beelzebub is here again."
                             [/message]
                         [/then]
                         [else]
                             [message]
-                                id=Lethalia
-                                [or]
-                                    id=Vritra
-                                [/or]
+                                speaker=$msg_speaker
                                 message= _ "There's that weird looking stone thing again."
                             [/message]
                         [/else]
@@ -1325,15 +1345,13 @@ $item_info.description"
                         message= _ "Look! That stone looks quite weird."
                     [/message]
                     [message]
-                        id=Lethalia
-                        [or]
-                            id=Vritra
-                        [/or]
+                        speaker=$msg_speaker
                         message= _ "Maybe we should investigate."
                     [/message]
                     {VARIABLE seen_beelzebub_monument true}
                 [/else]
             [/if]
+            {CLEAR_VARIABLE msg_speaker}
         [/event]
         [event]
             name=moveto

--- a/utils/utils.cfg
+++ b/utils/utils.cfg
@@ -1309,6 +1309,7 @@ $item_info.description"
                                 if finder.id == "Krux" and have_vritra then
                                     wml.variables["msg_speaker"] = "Vritra"
                                     return
+                                end
                                 wml.variables["msg_speaker"] = "Krux"
                                 >>
             [/lua]


### PR DESCRIPTION
It bugs me when Lethalia sees the BZB monument and says "Look!" and then replies to herself.  I don't mind when she speaks both parts when touching the monument, but the former case just comes off as odd.  So this addresses that.  Tested as best I can (I'm in ch5 at the moment, can't test with the kids).

I've never cared for the way the monument message triggers work either.  Sometimes, you trigger one and can't even see it.  Other times you can just about walk up to it and not get a message (fixed this in Pits the other day).  Have you ever considered making the moment a unit and using a sighted event?

Looks like wmlindent did some whitespace changes.  And I added a couple ids to events (that helps a LOT when using :inspect).

Set as draft while I think about the kids.