### PR TITLE
EXPLOSIVE_SLOW description

### DIFF
--- a/utils/abilities.cfg
+++ b/utils/abilities.cfg
@@ -1785,7 +1785,8 @@ Enemy units cannot see this unit during dawn or dusk, except if they have units 
     [damage]
         id=explosive slow
         name= _ "explosive slow"
-        description= _ "When this attack is used, all enemies adjacent to a target are slowed."
+        description= _ "When this attack is used offensively, all enemies adjacent to a target are slowed."
+        active_on=offense
     [/damage]
 #enddef
 #define WEAPON_SPECIAL_EXPLOSIVE


### PR DESCRIPTION
Only works on offense.  Update description, and active_on so the gui will show it inactive on defense.