### PR TITLE
add active_on=offense

### DIFF
--- a/utils/abilities.cfg
+++ b/utils/abilities.cfg
@@ -743,7 +743,6 @@ Enemy units cannot see this unit during dawn or dusk, except if they have units 
     [/leadership]
 #enddef
 
-
 #define ABILITY_ALL_DAMAGE_AURA INTENSITY
     [leadership]
         id=all damage aura {INTENSITY}
@@ -927,8 +926,8 @@ Enemy units cannot see this unit during dawn or dusk, except if they have units 
         damage={INTENSITY}
         damage_type=arcane
         id=deathaura
-        name= _ "Deathaura"
-        female_name= _ "female^Deathaura"
+        name= _ "Deathaura ({INTENSITY})"
+        female_name= _ "female^Deathaura ({INTENSITY})"
         description= _ "This ability causes its bearer unit to poison and injure adjacent enemy units at the beginning of your turn ("+{INTENSITY}+_" damage). It cannot kill."
         halo_image_self="halo/fire-aura.png~SCALE(170, 170)~O(75%)~CS(-150,-200,-75)"
         poison=yes
@@ -965,6 +964,33 @@ Enemy units cannot see this unit during dawn or dusk, except if they have units 
         [/filter_self]
     [/regenerate]
 #enddef
+#define ABILITY_DEVOURING_EMBERS
+    [regenerate]
+        value=16
+        id=devouring embers
+        name=_ "devouring embers"
+        description=_ "This unit heals 16 HP per turn when above lava. If poisoned, the poison will be cured instead."
+        name_inactive=_ "devouring embers"
+        special_note = _" This unit regenerates, which allows it to heal as though always stationed in a village, if it is above lava."
+        affect_self=yes
+        [filter_self]
+            [filter_location]
+                terrain=Ql*,Mv*
+            [/filter_location]
+        [/filter_self]
+        poison=cured
+    [/regenerate]
+#enddef
+#define WEAPON_SPECIAL_EXPLOSIVE_DETONATION
+    [damage]
+        id=explosive detonation
+        name=_"explosive detonation"
+        description=_"When used on offense, this attack causes the attacker to explode, killing it instantly.  All adjacent units will take damage of the weapon's type equal to the attacker's hitpoints."
+        active_on=offense
+        multiply=0
+    [/damage]
+#enddef
+
 #define WEAPON_SPECIAL_SPIRITUAL_ATTACK
     [damage]
         id=spiritual attack
@@ -1299,6 +1325,7 @@ Enemy units cannot see this unit during dawn or dusk, except if they have units 
         id=storm
         name= _ "storm"
         description= _ "The damage of this attack will affect also a lot of other enemy units around the caster, and will also deal some impact damage. It is so tiring that the unit's damage decreases by 12 after the attack, the damage penalty will half each turn."
+        active_on=offense
     [/dummy]
 #enddef
 #define WEAPON_SPECIAL_INFECT
@@ -1320,6 +1347,7 @@ Enemy units cannot see this unit during dawn or dusk, except if they have units 
         id=knockback
         name= _ "knockback"
         description= _ "When this attack is used offensively, at the end of the fight the enemy will be knocked back."
+        active_on=offense
     [/damage]
 #enddef
 #define ABILITY_NECROMANCY
@@ -1891,7 +1919,7 @@ Enemy units cannot see this unit during dawn or dusk, except if they have units 
         name= _ "electrical discharge"
         female_name= _ "female^electrical discharge"
         description= _ "When this unit is hit with a melee attack, the resulting discharge of electricity causes an equal amount of lightning damage to be taken by the attacker. It can kill."
-#        halo_image_self="halo/reflect.png"  # need something that looks like it's throwing off sparks
+        #        halo_image_self="halo/reflect.png"  # need something that looks like it's throwing off sparks
     [/dummy]
 #enddef
 #define ABILITY_SOUL_EATER
@@ -1962,81 +1990,81 @@ Enemy units cannot see this unit during dawn or dusk, except if they have units 
     [/resistance]
 #enddef
 #define ABILITY_RECALL
-[teleport]
-    id=recall
-    name= _ "recall"
-    female_name= _ "female^recall"
-    description= _ "This unit may teleport to an leader of its side."
-    [tunnel]
-        bidirectional=false
-        [source]
-            x=$teleport_unit.x,y=$teleport_unit.y
-        [/source]
-        [target]
+    [teleport]
+        id=recall
+        name= _ "recall"
+        female_name= _ "female^recall"
+        description= _ "This unit may teleport to an leader of its side."
+        [tunnel]
+            bidirectional=false
+            [source]
+                x=$teleport_unit.x,y=$teleport_unit.y
+            [/source]
+            [target]
+                [filter]
+                    side=$teleport_unit.side
+                    canrecruit=yes
+                [/filter]
+            [/target]
             [filter]
-                side=$teleport_unit.side
-                canrecruit=yes
             [/filter]
-        [/target]
-        [filter]
-        [/filter]
-    [/tunnel]
-[/teleport]
+        [/tunnel]
+    [/teleport]
 #enddef
 
 #define ABILITY_COMBAT_RECALL
-[teleport]
-    id=combat recall
-    name= _ "combat recall"
-    female_name= _ "female^combat recall"
-    description= _ "This unit may teleport to any hex up to 3 hexes from a leader of its side."
-    [tunnel]
-        bidirectional=false
-        [source]
-            x=$teleport_unit.x,y=$teleport_unit.y
-        [/source]
-        [target]
+    [teleport]
+        id=combat recall
+        name= _ "combat recall"
+        female_name= _ "female^combat recall"
+        description= _ "This unit may teleport to any hex up to 3 hexes from a leader of its side."
+        [tunnel]
+            bidirectional=false
+            [source]
+                x=$teleport_unit.x,y=$teleport_unit.y
+            [/source]
+            [target]
+                [filter]
+                    side=$teleport_unit.side
+                    canrecruit=yes
+                [/filter]
+                radius=3
+            [/target]
             [filter]
-                side=$teleport_unit.side
-                canrecruit=yes
             [/filter]
-            radius=3
-        [/target]
-        [filter]
-        [/filter]
-    [/tunnel]
-[/teleport]
+        [/tunnel]
+    [/teleport]
 #enddef
 
 #define ABILITY_HOMECOMING
-[teleport]
-    id=homecoming
-    name= _ "homecoming"
-    female_name= _ "female^homecoming"
-    description= _ "This unit may teleport to an Ancient Lich, Arch Necromancer or Demilich."
-    [tunnel]
-        bidirectional=false
-        [source]
-            x=$teleport_unit.x,y=$teleport_unit.y
-        [/source]
-        [target]
+    [teleport]
+        id=homecoming
+        name= _ "homecoming"
+        female_name= _ "female^homecoming"
+        description= _ "This unit may teleport to an Ancient Lich, Arch Necromancer or Demilich."
+        [tunnel]
+            bidirectional=false
+            [source]
+                x=$teleport_unit.x,y=$teleport_unit.y
+            [/source]
+            [target]
+                [filter]
+                    side=$teleport_unit.side
+                    [and]
+                        type=09 Ancient Lich
+                        [or]
+                            type=Arch Necromancer
+                        [/or]
+                        [or]
+                            type=Demilich
+                        [/or]
+                    [/and]
+                [/filter]
+            [/target]
             [filter]
-                side=$teleport_unit.side
-                [and]
-                    type=09 Ancient Lich
-                    [or]
-                        type=Arch Necromancer
-                    [/or]
-                    [or]
-                        type=Demilich
-                    [/or]
-                [/and]
             [/filter]
-        [/target]
-        [filter]
-        [/filter]
-    [/tunnel]
-[/teleport]
+        [/tunnel]
+    [/teleport]
 #enddef
 
 # These abilities replace the dummy abilities used before wesnoth 1.16 version

--- a/utils/abilities.cfg
+++ b/utils/abilities.cfg
@@ -1919,7 +1919,7 @@ Enemy units cannot see this unit during dawn or dusk, except if they have units 
         name= _ "electrical discharge"
         female_name= _ "female^electrical discharge"
         description= _ "When this unit is hit with a melee attack, the resulting discharge of electricity causes an equal amount of lightning damage to be taken by the attacker. It can kill."
-        #        halo_image_self="halo/reflect.png"  # need something that looks like it's throwing off sparks
+#        halo_image_self="halo/reflect.png"  # need something that looks like it's throwing off sparks
     [/dummy]
 #enddef
 #define ABILITY_SOUL_EATER


### PR DESCRIPTION
Hmm, was only trying to add a couple active_on=offsense entries, but it looks like other stuff got in there as well.  No harm, except an extra tab I'll remove in a moment.

At some point, all weapon specials should probably be reviewed for active_on.  And maybe fix the descriptions that say something like, "when this weapon is used" but mean ""when this weapon is used on offense".  It's not important, but it looks nicer and it's helpful if you're moving a unit into danger to know what it can/can't use on defense.