### PR TITLE
fix wrath for enemies, move to abilities

### DIFF
--- a/lua/main.lua
+++ b/lua/main.lua
@@ -1060,3 +1060,21 @@ function loti.util.list_attacks(unit)
 
 	return has_attack
 end
+
+function wesnoth.wml_actions.set_wrath_intensity(cfg)
+	local unit_id = cfg.id or wml.error("[set_wrath_intensity]: missing required id=")
+	local unit = wesnoth.units.get(unit_id).__cfg
+	local vars = wml.get_child(unit, "variables")
+	local abilities = wml.get_child(unit, "abilities")
+	local wrath_intensity = 0
+	if vars.wrath == true then wrath_intensity = vars.wrath_intensity end
+	local latent_wrath_special = wml.get_child(abilities, "damage", "latent_wrath")
+	if latent_wrath_special == nil then
+		--wesnoth.interface.add_chat_message("Didn't find latent_wrath_special, creating")
+		table.insert(abilities, { "damage", { id = "latent_wrath", apply_to = "self", add = wrath_intensity }})
+	else
+		--wesnoth.interface.add_chat_message(string.format("Found latent_wrath_special, adding latent_wrath_special.add = %d",wrath_intensity))
+		latent_wrath_special.add = wrath_intensity
+	end
+	wesnoth.units.to_map(unit)
+end

--- a/lua/main.lua
+++ b/lua/main.lua
@@ -1097,10 +1097,10 @@ function wesnoth.wml_actions.set_wrath_intensity(cfg)
 
 	local latent_wrath_special = wml.get_child(abilities, "damage", "latent_wrath")
 	if latent_wrath_special == nil then
-		--wesnoth.interface.add_chat_message(string.format("Didn't find latent_wrath_special, creating with add = %d",wrath_intensity))
+		if debug then wesnoth.interface.add_chat_message(string.format("Didn't find latent_wrath_special, creating with add = %d",wrath_intensity)) end
 		table.insert(abilities, { "damage", { id = "latent_wrath", apply_to = "self", add = wrath_intensity }})
 	else
-		--wesnoth.interface.add_chat_message(string.format("Found latent_wrath_special, setting latent_wrath_special.add = %d",wrath_intensity))
+		if debug then wesnoth.interface.add_chat_message(string.format("Found latent_wrath_special, setting latent_wrath_special.add = %d",wrath_intensity)) end
 		latent_wrath_special.add = wrath_intensity
 	end
 	wesnoth.units.to_map(unit)

--- a/lua/stats.lua
+++ b/lua/stats.lua
@@ -607,13 +607,9 @@ function wesnoth.update_stats(original)
 	end
 
 	-- PART VIII: Abilities
-	local abilities = wml.get_child(remade, "abilities")
-	-- add latent_wrath to apply wrath/lethargy to all attacks
-	local latent_wrath_special = wml.get_child(abilities, "damage", "latent_wrath")
-	if latent_wrath_special == nil then
-		local wrath_intensity = 0
-		if vars.wrath == true then wrath_intensity = vars.wrath_intensity end
-		table.insert(abilities, { "damage", { id = "latent_wrath", apply_to = "self", add = wrath_intensity }})
+	local latent_wrath_special = wml.get_child(wml.get_child(original, "abilities"), "damage", "latent_wrath")
+	if latent_wrath_special ~= nil then
+		table.insert(wml.get_child(remade, "abilities"), { "damage", latent_wrath_special })
 	end
 
 	-- PART IX: Apply visual effects

--- a/lua/stats.lua
+++ b/lua/stats.lua
@@ -615,7 +615,7 @@ function wesnoth.update_stats(original)
 		if vars.wrath == true then wrath_intensity = vars.wrath_intensity end
 		table.insert(abilities, { "damage", { id = "latent_wrath", apply_to = "self", add = wrath_intensity }})
 	end
-	
+
 	-- PART IX: Apply visual effects
 	if #visual_effects > 0 then
 		local visual_obj = { visual_provider = true }

--- a/lua/stats.lua
+++ b/lua/stats.lua
@@ -604,14 +604,19 @@ function wesnoth.update_stats(original)
 		if best_backstab then
 			table.insert(specials, best_backstab)
 		end
-		local wrath_intensity = 0
-		if vars.wrath == true then
-			wrath_intensity = vars.wrath_intensity
-		end
-		table.insert(specials, { "damage", { id = "latent_wrath", apply_to = "self", add = wrath_intensity }})
 	end
 
-	-- PART VIII: Apply visual effects
+	-- PART VIII: Abilities
+	local abilities = wml.get_child(remade, "abilities")
+	-- add latent_wrath to apply wrath/lethargy to all attacks
+	local latent_wrath_special = wml.get_child(abilities, "damage", "latent_wrath")
+	if latent_wrath_special == nil then
+		local wrath_intensity = 0
+		if vars.wrath == true then wrath_intensity = vars.wrath_intensity end
+		table.insert(abilities, { "damage", { id = "latent_wrath", apply_to = "self", add = wrath_intensity }})
+	end
+	
+	-- PART IX: Apply visual effects
 	if #visual_effects > 0 then
 		local visual_obj = { visual_provider = true }
 		for i = 1,#visual_effects do
@@ -649,7 +654,7 @@ function wesnoth.update_stats(original)
 	table.insert(visible_modifications, overlays_object)
 
 
-	-- PART IX: Some final changes
+	-- PART X: Some final changes
 	for i = #vars,1,-1 do
 		if vars[i][1] == "disabled_defences" then
 			local found = false
@@ -682,7 +687,7 @@ function wesnoth.update_stats(original)
 	end
 	remade.advances_to = table.concat(new_advances_to, ",")
 
-	-- PART X: Call WML hooks
+	-- PART XI: Call WML hooks
 	for i = 1,#events_to_fire do
 		remade = call_event_on_unit(remade, events_to_fire[i])
 	end

--- a/utils/abilities_events.cfg
+++ b/utils/abilities_events.cfg
@@ -828,25 +828,14 @@
                     animate=no
                     fire_attacker_hits=true
                 [/harm_unit_loti]
-                [if]
-                    [variable]
-                        name=unit.variables.wrath
-                        equals=yes
-                    [/variable]
-                    [then]
-                        {VARIABLE_OP unit.variables.wrath_intensity add $second_unit.level}
-                    [/then]
-                    [else]
-                        {VARIABLE unit.variables.wrath yes}
-                        {VARIABLE unit.variables.wrath_intensity $second_unit.level}
-                    [/else]
-                [/if]
+                {VARIABLE unit.variables.wrath yes}
                 [unstore_unit]
                     variable=unit
                     find_vacant=no
                 [/unstore_unit]
                 [set_wrath_intensity]
                     id=$unit.id
+                    add=$second_unit.level
                 [/set_wrath_intensity]
 
                 [fire_event]
@@ -5383,25 +5372,14 @@
                 [/filter_adjacent]
             [/or]
         [/filter]
-        [if]
-            [variable]
-                name=unit.variables.wrath
-                equals=yes
-            [/variable]
-            [then]
-                {VARIABLE_OP unit.variables.wrath_intensity add 1}
-            [/then]
-            [else]
-                {VARIABLE unit.variables.wrath yes}
-                {VARIABLE unit.variables.wrath_intensity 1}
-            [/else]
-        [/if]
+        {VARIABLE unit.variables.wrath yes}
         [unstore_unit]
             variable=unit
             find_vacant=no
         [/unstore_unit]
         [set_wrath_intensity]
             id=$unit.id
+            add=1
         [/set_wrath_intensity]
     [/event]
 
@@ -5438,25 +5416,14 @@
         [filter_second]
             ability=triggerable
         [/filter_second]
-        [if]
-            [variable]
-                name=second_unit.variables.wrath
-                equals=yes
-            [/variable]
-            [then]
-                {VARIABLE_OP second_unit.variables.wrath_intensity add 1}
-            [/then]
-            [else]
-                {VARIABLE second_unit.variables.wrath yes}
-                {VARIABLE second_unit.variables.wrath_intensity 1}
-            [/else]
-        [/if]
+        {VARIABLE second_unit.variables.wrath yes}
         [unstore_unit]
             variable=second_unit
             find_vacant=no
         [/unstore_unit]
         [set_wrath_intensity]
             id=$second_unit.id
+            add=1
         [/set_wrath_intensity]
     [/event]
 
@@ -5480,25 +5447,14 @@
         [for]
             array=vindictors
             [do]
-                [if]
-                    [variable]
-                        name=vindictors[$i].variables.wrath
-                        equals=yes
-                    [/variable]
-                    [then]
-                        {VARIABLE_OP vindictors[$i].variables.wrath_intensity add 1}
-                    [/then]
-                    [else]
-                        {VARIABLE vindictors[$i].variables.wrath yes}
-                        {VARIABLE vindictors[$i].variables.wrath_intensity 1}
-                    [/else]
-                [/if]
+                {VARIABLE vindictors[$i].variables.wrath yes}
                 [unstore_unit]
                     variable=vindictors[$i]
                     find_vacant=no
                 [/unstore_unit]
                 [set_wrath_intensity]
                     id=$vindictors[$i].id
+                    add=1
                 [/set_wrath_intensity]
             [/do]
         [/for]
@@ -5653,19 +5609,7 @@
     [event]
         name=lethargy x
         first_time_only=no
-        [if]
-            [variable]
-                name=unit.variables.wrath
-                equals=yes
-            [/variable]
-            [then]
-                {VARIABLE_OP unit.variables.wrath_intensity sub $lethargy_amount}
-            [/then]
-            [else]
-                {VARIABLE unit.variables.wrath yes}
-                {VARIABLE unit.variables.wrath_intensity "$(-1*$lethargy_amount)"}
-            [/else]
-        [/if]
+        {VARIABLE unit.variables.wrath yes}
         [unstore_unit]
             variable=unit
             find_vacant=no
@@ -5673,6 +5617,7 @@
         [/unstore_unit]
         [set_wrath_intensity]
             id=$unit.id
+            sub=$lethargy_amount
         [/set_wrath_intensity]
     [/event]
 
@@ -5718,25 +5663,14 @@
             array=infuriated
             variable=infuriated_unit
             [do]
-                [if]
-                    [variable]
-                        name=infuriated_unit.variables.wrath_intensity
-                        greater_than_equal_to=1
-                    [/variable]
-                    [then]
-                        {VARIABLE_OP infuriated_unit.variables.wrath_intensity add 1}
-                    [/then]
-                    [else]
-                        {VARIABLE infuriated_unit.variables.wrath yes}
-                        {VARIABLE infuriated_unit.variables.wrath_intensity 1}
-                    [/else]
-                [/if]
+                {VARIABLE infuriated_unit.variables.wrath yes}
                 [unstore_unit]
                     variable=infuriated_unit
                     find_vacant=no
                 [/unstore_unit]
                 [set_wrath_intensity]
                     id=$infuriated_unit.id
+                    add=1
                 [/set_wrath_intensity]
             [/do]
         [/foreach]
@@ -5756,55 +5690,13 @@
             [/filter]
             variable=wrathful
         [/store_unit]
-        [for]
+        [for]  # Change [set_wrath_intensity] to accept find_in=wrathful and skip this loop?
             array=wrathful
             variable=h
             [do]
-                [if]
-                    [variable]
-                        name=wrathful[$h].variables.wrath_intensity
-                        greater_than=1
-                    [/variable]
-                    [or]
-                        [variable]
-                            name=wrathful[$h].variables.wrath_intensity
-                            less_than=-1
-                        [/variable]
-                    [/or]
-                    [then]
-                        [if]
-                            [variable]
-                                name=wrathful[$h].variables.wrath_intensity
-                                greater_than=0
-                            [/variable]
-                            [then]
-                                [set_variable]
-                                    name=wrathful[$h].variables.wrath_intensity
-                                    divide=2
-                                    round=floor
-                                [/set_variable]
-                            [/then]
-                            [else]
-                                [set_variable]
-                                    name=wrathful[$h].variables.wrath_intensity
-                                    divide=2
-                                    round=ceil
-                                [/set_variable]
-                            [/else]
-                        [/if]
-                    [/then]
-                    [else]
-                        {CLEAR_VARIABLE wrathful[$h].variables.wrath,wrathful[$h].variables.wrath_intensity}
-                    [/else]
-                [/if]
-                [unstore_unit]
-                    variable=wrathful[$h]
-                    find_vacant=no
-                    advance=no
-                [/unstore_unit]
-
                 [set_wrath_intensity]
                     id=$wrathful[$h].id
+                    div=2
                 [/set_wrath_intensity]
             [/do]
         [/for]
@@ -5866,20 +5758,7 @@
                 [/for]
                 {CLEAR_VARIABLE drained}
                 {VARIABLE_OP amount div 2}
-                # move to [s_w_i]?
-                [if]
-                    [variable]
-                        name=fueled[$i].variables.wrath_intensity
-                        greater_than_equal_to=1
-                    [/variable]
-                    [then]
-                        {VARIABLE_OP fueled[$i].variables.wrath_intensity add $amount}
-                    [/then]
-                    [else]
-                        {VARIABLE fueled[$i].variables.wrath yes}
-                        {VARIABLE fueled[$i].variables.wrath_intensity $amount}
-                    [/else]
-                [/if]
+                {VARIABLE fueled[$i].variables.wrath yes}
                 [unstore_unit]
                     variable=fueled[$i]
                     find_vacant=no
@@ -5887,6 +5766,7 @@
                 [/unstore_unit]
                 [set_wrath_intensity]
                     id=$fueled[$i].id
+                    add=$amount
                 [/set_wrath_intensity]
                 {CLEAR_VARIABLE amount}
             [/do]

--- a/utils/abilities_events.cfg
+++ b/utils/abilities_events.cfg
@@ -41,63 +41,63 @@
     {CLEAR_VARIABLE resistance}
 #enddef
 #define EXPLOSIVE_UNIT_DIES BOMBER WEAPON_TYPE
-# A unit hits with weapon special 'explosive detonation', or with trait 'unstable' and hit by impact weapon, explodes, killing self and damaging adjacent
+    # A unit hits with weapon special 'explosive detonation', or with trait 'unstable' and hit by impact weapon, explodes, killing self and damaging adjacent
     # add 1/4 damage at radius 1?
     # affected adjacent units with explosive detonation or unstable should probably light off as well- k>1 baby, chain reaction!
-        # Get units to harm after explosion (which kills the cause of all the trouble)
-        [store_unit]
-            [filter]
-                [filter_adjacent]
-                    x,y=${BOMBER}.x,${BOMBER}.y
-                [/filter_adjacent]
-            [/filter]
-            variable=dont_stand_so_close_to_me
-        [/store_unit]
-        # Add animation to bomber and blow him up (assumes no death animation exists)
-        [object]
-            silent=yes
-            [filter]
-                id=${BOMBER}.id
-            [/filter]
-            [effect]
-                apply_to=new_animation
-                [death]
-                    missile_start_time=0
-                    [missile_frame]
-                        halo="projectiles/fireball-impact-[1~16].png:100"
-                        sound=explosion.ogg
-                        auto_vflip=no
-                    [/missile_frame]
-                [/death]
-            [/effect]
-        [/object]
-        [harm_unit]
-            [filter]
-                id=${BOMBER}.id
-            [/filter]
-            amount=$(${BOMBER}.hitpoints * 1000)  # sometimes you just have to be sure
-            damage_type=${WEAPON_TYPE}
-            fire_event=yes
-            animate=yes
-            kill=yes
-        [/harm_unit]
-        # Harm bomber's victims
-        [foreach]
-            array=dont_stand_so_close_to_me
-            [do]
-                [harm_unit]
-                    [filter]
-                        id=$this_item.id
-                    [/filter]
-                    amount=${BOMBER}.hitpoints
-                    damage_type=${WEAPON_TYPE}
-                    fire_event=yes
-                    animate=yes
-                    kill=yes
-                [/harm_unit]
-            [/do]
-        [/foreach]
-        {CLEAR_VARIABLE dont_stand_so_close_to_me}
+    # Get units to harm after explosion (which kills the cause of all the trouble)
+    [store_unit]
+        [filter]
+            [filter_adjacent]
+                x,y=${BOMBER}.x,${BOMBER}.y
+            [/filter_adjacent]
+        [/filter]
+        variable=dont_stand_so_close_to_me
+    [/store_unit]
+    # Add animation to bomber and blow him up (assumes no death animation exists)
+    [object]
+        silent=yes
+        [filter]
+            id=${BOMBER}.id
+        [/filter]
+        [effect]
+            apply_to=new_animation
+            [death]
+                missile_start_time=0
+                [missile_frame]
+                    halo="projectiles/fireball-impact-[1~16].png:100"
+                    sound=explosion.ogg
+                    auto_vflip=no
+                [/missile_frame]
+            [/death]
+        [/effect]
+    [/object]
+    [harm_unit]
+        [filter]
+            id=${BOMBER}.id
+        [/filter]
+        amount=$(${BOMBER}.hitpoints * 1000)  # sometimes you just have to be sure
+        damage_type=${WEAPON_TYPE}
+        fire_event=yes
+        animate=yes
+        kill=yes
+    [/harm_unit]
+    # Harm bomber's victims
+    [foreach]
+        array=dont_stand_so_close_to_me
+        [do]
+            [harm_unit]
+                [filter]
+                    id=$this_item.id
+                [/filter]
+                amount=${BOMBER}.hitpoints
+                damage_type=${WEAPON_TYPE}
+                fire_event=yes
+                animate=yes
+                kill=yes
+            [/harm_unit]
+        [/do]
+    [/foreach]
+    {CLEAR_VARIABLE dont_stand_so_close_to_me}
 #enddef
 
 #define ABILITIES_EVENTS
@@ -841,31 +841,14 @@
                         {VARIABLE unit.variables.wrath_intensity $second_unit.level}
                     [/else]
                 [/if]
-                [for]
-                    array=unit.attack
-                    variable=i
-                    [do]
-                        [for]
-                            array=unit.attack[$i].specials.damage
-                            variable=j
-                            [do]
-                                [if]
-                                    [variable]
-                                        name=unit.attack[$i].specials.damage[$j].id
-                                        equals=latent_wrath
-                                    [/variable]
-                                    [then]
-                                        {VARIABLE unit.attack[$i].specials.damage[$j].add $unit.variables.wrath_intensity}
-                                    [/then]
-                                [/if]
-                            [/do]
-                        [/for]
-                    [/do]
-                [/for]
                 [unstore_unit]
                     variable=unit
                     find_vacant=no
                 [/unstore_unit]
+                [set_wrath_intensity]
+                    id=$unit.id
+                [/set_wrath_intensity]
+
                 [fire_event]
                     name=force respec
                     [primary_unit]
@@ -5417,12 +5400,9 @@
             variable=unit
             find_vacant=no
         [/unstore_unit]
-        [fire_event]
-            name=set wrath intensity
-            [primary_unit]
-                find_in=unit
-            [/primary_unit]
-        [/fire_event]
+        [set_wrath_intensity]
+            id=$unit.id
+        [/set_wrath_intensity]
     [/event]
 
     [event]
@@ -5475,12 +5455,9 @@
             variable=second_unit
             find_vacant=no
         [/unstore_unit]
-        [fire_event]
-            name=set wrath intensity
-            [primary_unit]
-                find_in=second_unit
-            [/primary_unit]
-        [/fire_event]
+        [set_wrath_intensity]
+            id=$second_unit.id
+        [/set_wrath_intensity]
     [/event]
 
     [event]
@@ -5520,12 +5497,9 @@
                     variable=vindictors[$i]
                     find_vacant=no
                 [/unstore_unit]
-                [fire_event]
-                    name=set wrath intensity
-                    [primary_unit]
-                        find_in=vindictors[$i]
-                    [/primary_unit]
-                [/fire_event]
+                [set_wrath_intensity]
+                    id=$vindictors[$i].id
+                [/set_wrath_intensity]
             [/do]
         [/for]
         {CLEAR_VARIABLE vindictors}
@@ -5697,12 +5671,9 @@
             find_vacant=no
             advance=no
         [/unstore_unit]
-        [fire_event]
-            name=set wrath intensity
-            [primary_unit]
-                find_in=unit
-            [/primary_unit]
-        [/fire_event]
+        [set_wrath_intensity]
+            id=$unit.id
+        [/set_wrath_intensity]
     [/event]
 
     [event]
@@ -5764,49 +5735,13 @@
                     variable=infuriated_unit
                     find_vacant=no
                 [/unstore_unit]
-                [fire_event]
-                    name=set wrath intensity
-                    [primary_unit]
-                        find_in=infuriated_unit
-                    [/primary_unit]
-                [/fire_event]
+                [set_wrath_intensity]
+                    id=$infuriated_unit.id
+                [/set_wrath_intensity]
             [/do]
         [/foreach]
         {CLEAR_VARIABLE infuriated}
     [/event]
-
-    [event]
-        name=set wrath intensity
-        first_time_only=no
-
-        [for]
-            array=unit.attack
-            variable=swi
-            [do]
-                [for]
-                    array=unit.attack[$swi].specials.damage
-                    variable=swj
-                    [do]
-                        [if]
-                            [variable]
-                                name=unit.attack[$swi].specials.damage[$swj].id
-                                equals=latent_wrath
-                            [/variable]
-                            [then]
-                                {VARIABLE unit.attack[$swi].specials.damage[$swj].add $unit.variables.wrath_intensity}
-                            [/then]
-                        [/if]
-                    [/do]
-                [/for]
-            [/do]
-        [/for]
-        [unstore_unit]
-            variable=unit
-            find_vacant=no
-            advance=no
-        [/unstore_unit]
-    [/event]
-
     [event]
         name=turn refresh
         first_time_only=no
@@ -5857,51 +5792,9 @@
                                 [/set_variable]
                             [/else]
                         [/if]
-                        [for]
-                            array=wrathful[$h].attack
-                            variable=i
-                            [do]
-                                [for]
-                                    array=wrathful[$h].attack[$i].specials.damage
-                                    variable=j
-                                    [do]
-                                        [if]
-                                            [variable]
-                                                name=wrathful[$h].attack[$i].specials.damage[$j].id
-                                                equals=latent_wrath
-                                            [/variable]
-                                            [then]
-                                                {VARIABLE wrathful[$h].attack[$i].specials.damage[$j].add $wrathful[$h].variables.wrath_intensity}
-                                            [/then]
-                                        [/if]
-                                    [/do]
-                                [/for]
-                            [/do]
-                        [/for]
                     [/then]
                     [else]
                         {CLEAR_VARIABLE wrathful[$h].variables.wrath,wrathful[$h].variables.wrath_intensity}
-                        [for]
-                            array=wrathful[$h].attack
-                            variable=i
-                            [do]
-                                [for]
-                                    array=wrathful[$h].attack[$i].specials.damage
-                                    variable=j
-                                    [do]
-                                        [if]
-                                            [variable]
-                                                name=wrathful[$h].attack[$i].specials.damage[$j].id
-                                                equals=latent_wrath
-                                            [/variable]
-                                            [then]
-                                                {VARIABLE wrathful[$h].attack[$i].specials.damage[$j].add 0}
-                                            [/then]
-                                        [/if]
-                                    [/do]
-                                [/for]
-                            [/do]
-                        [/for]
                     [/else]
                 [/if]
                 [unstore_unit]
@@ -5909,6 +5802,10 @@
                     find_vacant=no
                     advance=no
                 [/unstore_unit]
+
+                [set_wrath_intensity]
+                    id=$wrathful[$h].id
+                [/set_wrath_intensity]
             [/do]
         [/for]
         {CLEAR_VARIABLE wrathful}
@@ -5969,6 +5866,7 @@
                 [/for]
                 {CLEAR_VARIABLE drained}
                 {VARIABLE_OP amount div 2}
+                # move to [s_w_i]?
                 [if]
                     [variable]
                         name=fueled[$i].variables.wrath_intensity
@@ -5985,13 +5883,11 @@
                 [unstore_unit]
                     variable=fueled[$i]
                     find_vacant=no
+                    advance=no
                 [/unstore_unit]
-                [fire_event]
-                    name=set wrath intensity
-                    [primary_unit]
-                        find_in=fueled[$i]
-                    [/primary_unit]
-                [/fire_event]
+                [set_wrath_intensity]
+                    id=$fueled[$i].id
+                [/set_wrath_intensity]
                 {CLEAR_VARIABLE amount}
             [/do]
         [/for]
@@ -6017,32 +5913,14 @@
             array=wrathful
             [do]
                 {CLEAR_VARIABLE wrathful[$h].variables.wrath,wrathful[$h].variables.wrath_intensity}
-                [for]
-                    variable=i
-                    array=wrathful[$h].attack
-                    [do]
-                        [for]
-                            variable=j
-                            array=wrathful[$h].attack[$i].specials.damage
-                            [do]
-                                [if]
-                                    [variable]
-                                        name=wrathful[$h].attack[$i].specials.damage[$j].id
-                                        equals=latent_wrath
-                                    [/variable]
-                                    [then]
-                                        {VARIABLE wrathful[$h].attack[$i].specials.damage[$j].add 0}
-                                    [/then]
-                                [/if]
-                            [/do]
-                        [/for]
-                    [/do]
-                [/for]
                 [unstore_unit]
                     variable=wrathful[$h]
                     find_vacant=no
                     advance=no
                 [/unstore_unit]
+                [set_wrath_intensity]
+                    id=$wrathful[$h].id
+                [/set_wrath_intensity]
             [/do]
         [/for]
         {CLEAR_VARIABLE wrathful}

--- a/utils/abilities_events.cfg
+++ b/utils/abilities_events.cfg
@@ -828,11 +828,6 @@
                     animate=no
                     fire_attacker_hits=true
                 [/harm_unit_loti]
-                {VARIABLE unit.variables.wrath yes}
-                [unstore_unit]
-                    variable=unit
-                    find_vacant=no
-                [/unstore_unit]
                 [set_wrath_intensity]
                     id=$unit.id
                     add=$second_unit.level
@@ -5372,11 +5367,6 @@
                 [/filter_adjacent]
             [/or]
         [/filter]
-        {VARIABLE unit.variables.wrath yes}
-        [unstore_unit]
-            variable=unit
-            find_vacant=no
-        [/unstore_unit]
         [set_wrath_intensity]
             id=$unit.id
             add=1
@@ -5416,11 +5406,6 @@
         [filter_second]
             ability=triggerable
         [/filter_second]
-        {VARIABLE second_unit.variables.wrath yes}
-        [unstore_unit]
-            variable=second_unit
-            find_vacant=no
-        [/unstore_unit]
         [set_wrath_intensity]
             id=$second_unit.id
             add=1
@@ -5447,11 +5432,6 @@
         [for]
             array=vindictors
             [do]
-                {VARIABLE vindictors[$i].variables.wrath yes}
-                [unstore_unit]
-                    variable=vindictors[$i]
-                    find_vacant=no
-                [/unstore_unit]
                 [set_wrath_intensity]
                     id=$vindictors[$i].id
                     add=1
@@ -5609,12 +5589,6 @@
     [event]
         name=lethargy x
         first_time_only=no
-        {VARIABLE unit.variables.wrath yes}
-        [unstore_unit]
-            variable=unit
-            find_vacant=no
-            advance=no
-        [/unstore_unit]
         [set_wrath_intensity]
             id=$unit.id
             sub=$lethargy_amount
@@ -5663,11 +5637,6 @@
             array=infuriated
             variable=infuriated_unit
             [do]
-                {VARIABLE infuriated_unit.variables.wrath yes}
-                [unstore_unit]
-                    variable=infuriated_unit
-                    find_vacant=no
-                [/unstore_unit]
                 [set_wrath_intensity]
                     id=$infuriated_unit.id
                     add=1
@@ -5682,15 +5651,11 @@
         [store_unit]
             [filter]
                 side=$side_number
-                [filter_wml]
-                    [variables]
-                        wrath=yes
-                    [/variables]
-                [/filter_wml]
+                ability=latent_wrath
             [/filter]
             variable=wrathful
         [/store_unit]
-        [for]  # Change [set_wrath_intensity] to accept find_in=wrathful and skip this loop?
+        [for]
             array=wrathful
             variable=h
             [do]
@@ -5758,12 +5723,6 @@
                 [/for]
                 {CLEAR_VARIABLE drained}
                 {VARIABLE_OP amount div 2}
-                {VARIABLE fueled[$i].variables.wrath yes}
-                [unstore_unit]
-                    variable=fueled[$i]
-                    find_vacant=no
-                    advance=no
-                [/unstore_unit]
                 [set_wrath_intensity]
                     id=$fueled[$i].id
                     add=$amount
@@ -5780,11 +5739,7 @@
 
         [store_unit]
             [filter]
-                [filter_wml]
-                    [variables]
-                        wrath=yes
-                    [/variables]
-                [/filter_wml]
+                ability=latent_wrath
             [/filter]
             variable=wrathful
         [/store_unit]
@@ -5792,14 +5747,9 @@
             variable=h
             array=wrathful
             [do]
-                {CLEAR_VARIABLE wrathful[$h].variables.wrath,wrathful[$h].variables.wrath_intensity}
-                [unstore_unit]
-                    variable=wrathful[$h]
-                    find_vacant=no
-                    advance=no
-                [/unstore_unit]
                 [set_wrath_intensity]
                     id=$wrathful[$h].id
+                    set=0
                 [/set_wrath_intensity]
             [/do]
         [/for]


### PR DESCRIPTION
I'm not convinced the changes to update_stats are even needed anymore, since the ability special is created if it doesn't exist when it is needed.

Creating the ability on demand also fixed the issue with enemies not being effected by wrath, at least when attacked with lesser lethargy.

I don't see any reason all of the wml setting unit.variables.wrath* can't be moved to [set_wrath_intensity], assuming we can't just get rid of the variables stuff outright.  If not, I should look at how the unit is passed so that we don't need to "unstore" twice.

Fueled by death appears to still only look at positive wrath.

Tested with whirlwind and greater underdraw (lesser lethargy).

See #751 