### PR TITLE
replace depr not_living

### DIFF
--- a/scenarios8/04_Kidnapped.cfg
+++ b/scenarios8/04_Kidnapped.cfg
@@ -670,7 +670,7 @@
                     description= _ "Immune to drain, poison, and plague"
                     [effect]
                         apply_to=status
-                        add=not_living
+                        add=unpoisonable,undrainable,unplagueable
                     [/effect]
                 [/trait]
                 [trait]

--- a/units/demons_race.cfg
+++ b/units/demons_race.cfg
@@ -285,7 +285,7 @@
         description= _ "Immune to drain, poison, and plague, extra cold, blade and pierce resistances"
         [effect]
             apply_to=status
-            add=not_living
+            add=unpoisonable,undrainable,unplagueable
         [/effect]
         [effect]
             apply_to=resistance
@@ -940,7 +940,7 @@ shrine=Shrine|Temple|Cathedral|Dome|Cradle
         description= _ "Immune to drain, poison, and plague"
         [effect]
             apply_to=status
-            add=not_living
+            add=unpoisonable,undrainable,unplagueable
         [/effect]
     [/trait]
     [trait]

--- a/utils/abilities_events.cfg
+++ b/utils/abilities_events.cfg
@@ -2749,7 +2749,7 @@
         [/filter_attack]
         [filter_second]
             [not]
-                status=not_living
+                status=unplagueable
             [/not]
             [not]
                 [filter_location]
@@ -2779,7 +2779,7 @@
         [/filter_second_attack]
         [filter]
             [not]
-                status=not_living
+                status=unplagueable
             [/not]
             [not]
                 [filter_location]
@@ -2809,7 +2809,7 @@
         [/filter_attack]
         [filter_second]
             [not]
-                status=not_living
+                status=unplagueable
             [/not]
         [/filter_second]
         [modify_unit]
@@ -2834,7 +2834,7 @@
         [/filter_second_attack]
         [filter]
             [not]
-                status=not_living
+                status=unplagueable
             [/not]
         [/filter]
         [modify_unit]
@@ -3608,7 +3608,7 @@
                         # Drain
                         [if]
                             [variable]
-                                name=this_item.status.not_living
+                                name=this_item.status.undrainable
                                 not_equals=yes
                             [/variable]
                             [and]
@@ -3832,7 +3832,7 @@
                         # Drain
                         [if]
                             [variable]
-                                name=this_item.status.not_living
+                                name=this_item.status.undrainable
                                 not_equals=yes
                             [/variable]
                             [and]

--- a/utils/amla.cfg
+++ b/utils/amla.cfg
@@ -2903,7 +2903,7 @@
         require_amla="undead_legacy, UL3"
         [effect]
             apply_to=status
-            add=not_living
+            add=unpoisonable,undrainable,unplagueable
         [/effect]
         {AMLA_DEFAULT_BONUSES}
     [/advancement]

--- a/utils/chapter9_utils.cfg
+++ b/utils/chapter9_utils.cfg
@@ -8165,7 +8165,7 @@ The map can be viewed through the right-click menu."}
                 [/effect]
                 [effect]
                     apply_to=status
-                    add=not_living
+                    add=unpoisonable,undrainable,unplagueable
                 [/effect]
             [/object]
         [/modifications]

--- a/utils/item_list.cfg
+++ b/utils/item_list.cfg
@@ -9261,7 +9261,7 @@ Showshaunshog proved him wrong by collecting condensed water from smoke."
         {QUANTITY damage_plus 4 1 -4}
         [effect]
             apply_to=status
-            add=not_living
+            add=unpoisonable,undrainable,unplagueable
         [/effect]
         blade_resist=5
         pierce_resist=5

--- a/utils/item_list.cfg
+++ b/utils/item_list.cfg
@@ -799,7 +799,7 @@ Stand up and see the sky turn bright"
     [object]
         name= _ "Foul Potion"
         image=items/potion-green.png
-        description_override= _ "<span color='orange'>New ability: Unholy hunger (the unit loses increasing amounts of maximum HP per turn (unless cared by a healer), but when it kills an enemy, the count restarts and it gains 3 to maximum HP and is healed slightly).</span>"
+        description_override= _ "<span color='orange'>New ability: Unholy hunger (the unit loses increasing amounts of maximum HP per turn (unless cared by a healer), but when it kills an enemy, the count restarts and it gains 3 to maximum HP and is healed slightly).  Has no effect if the victim cannot be drained, like the undead.</span>"
         number=16
         sort=potion
         drop=1

--- a/utils/utils.cfg
+++ b/utils/utils.cfg
@@ -1516,7 +1516,7 @@ $item_info.description"
                             [/effect]
                             [effect]
                                 apply_to=status
-                                add=not_living
+                                add=unpoisonable
                             [/effect]
                         [/object]
                         {CLEAR_VARIABLE beel_store,beel_store_level_add}


### PR DESCRIPTION
Replaced instances of not_living that will break when it is removed.

Soul Eclipse will need to have effects broken into multiple instances (one per status) unless items.lua is updated.

Ref #663 