### PR TITLE
correct corruption4 regeneration text

### DIFF
--- a/units/Vritra.cfg
+++ b/units/Vritra.cfg
@@ -710,7 +710,7 @@ A unit afflicted by this ability may lose up to 16 HP per turn, except for poiso
                 id=regenerates
                 name= _ "regenerates"
                 female_name= _ "female^regenerates"
-                description= _ "The unit will heal itself 8 HP per turn. If it is poisoned, it will remove the poison instead of healing. This happens only at night, though, during the day, the unit will take 8 damage instead."
+                description= _ "The unit will heal itself 8 HP per turn. If it is poisoned, it will remove the poison instead of healing. This happens only at night, though, during the day, the unit will take 16 damage instead."
                 affect_self=yes
                 poison=cured
                 [filter_self]


### PR DESCRIPTION
Also, note that in the main GUI if you mouse over her level you see "Oops..." where advancements are supposed to be.