### PR TITLE
exterminator steals, not shadowwalker

### DIFF
--- a/utils/abilities_events.cfg
+++ b/utils/abilities_events.cfg
@@ -1446,7 +1446,7 @@
                 type=Assassin
             [/or]
             [or]
-                type=Shadowalker
+                type=Exterminator
             [/or]
             [or]
                 ability=steals


### PR DESCRIPTION
I didn't know the thief line also had steals by default.  Be nice if they had the ability so we could see it.

Anyway, attacker hits had exterminator, but defender hits had shadowwalker.