### PR TITLE
Teleporting to Lethalia in Across the Barren Land

### DIFF
--- a/scenarios6/09_Across_the_Barren_Land.cfg
+++ b/scenarios6/09_Across_the_Barren_Land.cfg
@@ -582,7 +582,18 @@ You can teleport all units to your leader once per ten turns (see option in the 
     [/event]
     [event]
         name=start
-        {TELEPORT_TO_LEADER_MENU Efraim 10 10 10}
+        [if]
+            [variable]
+                name=leader_chosen
+                equals=Efraim
+            [/variable]
+            [then]
+                {TELEPORT_TO_LEADER_MENU Efraim 10 10 10}
+            [/then]
+            [else]
+                {TELEPORT_TO_LEADER_MENU Lethalia 10 10 10}
+            [/else]
+        [/if]
         [message]
             speaker=$leader_chosen
             message= _ "Behind this desert, there should be a mountain range. Behind the mountain range, there should be another desert, or a steppe. Behind that desert or steppe, there should be another mountain range. The Heart Mountains. Behind them, there should be the end of these barren lands."


### PR DESCRIPTION
In Across the Barren Land, there is a message and a note in objectives that you can teleport your units to your leader via a right click menu item. But it  is always added to Efraim even if you have chosen to play Lethalia so in that case you do not have that option. Here is a fix.