### PR TITLE
remove a lot from items stored on unit

### DIFF
--- a/lua/items.lua
+++ b/lua/items.lua
@@ -926,16 +926,13 @@ loti.item.describe_item = function(number, sort, set_items)
 				elseif effect.set == "lawful" then line = "<span color='yellow'>" .. _"Sets alignment to lawful" .. "</span>"
 				elseif effect.set == "neutral" then line = "<span color='yellow'>" .. _"Sets alignment to neutral" .. "</span>" end
 			elseif effect.apply_to == "status" then
-				for part in string.gmatch(effect.add, '([^,]+)') do
-					if line then table.insert(desc, line) end
-					if part == "unpoisonable" then line = "<span color='yellow'>" .. _"Immune to Poison" .. "</span>"
-					elseif part == "unslowable" then line = "<span color='yellow'>" .. _"Immune to Slow" .. "</span>"
-					elseif part == "undrainable" then line = "<span color='yellow'>" .. _"Immune to Drain" .. "</span>"
-					elseif part == "unplaguable" then line = "<span color='yellow'>" .. _"Immune to Plague" .. "</span>"
-					elseif part == "unpretrifiable" then line = "<span color='yellow'>" .. _"Immune to Petrify" .. "</span>"
-					elseif part == "unhealable" then line = "<span color='yellow'>" .. _"Unhealable" .. "</span>"
-					elseif part == "invulnerable" then line = "<span color='yellow'>" .. _"Invulnerable" .. "</span>" end
-				end
+				if effect.add == "unpoisonable" then line = "<span color='yellow'>" .. _"Immune to Poison" .. "</span>"
+				elseif effect.add == "unslowable" then line = "<span color='yellow'>" .. _"Immune to Slow" .. "</span>"
+				elseif effect.add == "undrainable" then line = "<span color='yellow'>" .. _"Immune to Drain" .. "</span>"
+				elseif effect.add == "unplaguable" then line = "<span color='yellow'>" .. _"Immune to Plague" .. "</span>"
+				elseif effect.add == "unpretrifiable" then line = "<span color='yellow'>" .. _"Immune to Petrify" .. "</span>"
+				elseif effect.add == "unhealable" then line = "<span color='yellow'>" .. _"Unhealable" .. "</span>"
+				elseif effect.add == "invulnerable" then line = "<span color='yellow'>" .. _"Invulnerable" .. "</span>" end
 			elseif effect.apply_to == "bonus_attack" then
 				line = "<span color='green'>" .. _"Bonus attack: " .. effect.description .. "</span>"
 			elseif effect.apply_to == "status" and effect.add == "not_living" then

--- a/lua/items.lua
+++ b/lua/items.lua
@@ -926,13 +926,16 @@ loti.item.describe_item = function(number, sort, set_items)
 				elseif effect.set == "lawful" then line = "<span color='yellow'>" .. _"Sets alignment to lawful" .. "</span>"
 				elseif effect.set == "neutral" then line = "<span color='yellow'>" .. _"Sets alignment to neutral" .. "</span>" end
 			elseif effect.apply_to == "status" then
-				if effect.add == "unpoisonable" then line = "<span color='yellow'>" .. _"Immune to Poison" .. "</span>"
-				elseif effect.add == "unslowable" then line = "<span color='yellow'>" .. _"Immune to Slow" .. "</span>"
-				elseif effect.add == "undrainable" then line = "<span color='yellow'>" .. _"Immune to Drain" .. "</span>"
-				elseif effect.add == "unplaguable" then line = "<span color='yellow'>" .. _"Immune to Plague" .. "</span>"
-				elseif effect.add == "unpretrifiable" then line = "<span color='yellow'>" .. _"Immune to Petrify" .. "</span>"
-				elseif effect.add == "unhealable" then line = "<span color='yellow'>" .. _"Unhealable" .. "</span>"
-				elseif effect.add == "invulnerable" then line = "<span color='yellow'>" .. _"Invulnerable" .. "</span>" end
+				for part in string.gmatch(effect.add, '([^,]+)') do
+					if line then table.insert(desc, line) end
+					if part == "unpoisonable" then line = "<span color='yellow'>" .. _"Immune to Poison" .. "</span>"
+					elseif part == "unslowable" then line = "<span color='yellow'>" .. _"Immune to Slow" .. "</span>"
+					elseif part == "undrainable" then line = "<span color='yellow'>" .. _"Immune to Drain" .. "</span>"
+					elseif part == "unplaguable" then line = "<span color='yellow'>" .. _"Immune to Plague" .. "</span>"
+					elseif part == "unpretrifiable" then line = "<span color='yellow'>" .. _"Immune to Petrify" .. "</span>"
+					elseif part == "unhealable" then line = "<span color='yellow'>" .. _"Unhealable" .. "</span>"
+					elseif part == "invulnerable" then line = "<span color='yellow'>" .. _"Invulnerable" .. "</span>" end
+				end
 			elseif effect.apply_to == "bonus_attack" then
 				line = "<span color='green'>" .. _"Bonus attack: " .. effect.description .. "</span>"
 			elseif effect.apply_to == "status" and effect.add == "not_living" then

--- a/lua/stats.lua
+++ b/lua/stats.lua
@@ -687,7 +687,6 @@ function wesnoth.update_stats(original)
 
 	-- PART XI: Call WML hooks
 	for i = 1,#events_to_fire do
-		--wesnoth.interface.add_chat_message(string.format("%d) %s",i,events_to_fire[i]))
 		remade = call_event_on_unit(remade, events_to_fire[i])
 	end
 	-- Restore unit from variable after the WML hooks.

--- a/lua/stats.lua
+++ b/lua/stats.lua
@@ -93,9 +93,12 @@ function wesnoth.update_stats(original)
 	for i, item in ipairs(visible_modifications) do -- Update objects to reflect set effects and update items
 		if item[1] == "object" and item[2].number and item[2].sort then
 			visible_modifications[i][2] = loti.unit.item_with_set_effects(item[2].number, set_items, item[2].sort)
-
-			-- Legacy field: used by WML menu "Items" to show "Remove item" options
-			visible_modifications[i][2].description = loti.item.describe_item(item[2].number, item[2].sort, set_items)
+			-- extract anything we won't NEED to save in the unit
+			for k,v in pairs(visible_modifications[i][2]) do
+				if type(v) ~= "table" and k ~= "name" and k ~= "number" and k ~= "sort" then
+					visible_modifications[i][2][k] = nil
+				end
+			end
 		end
 	end
 
@@ -105,7 +108,6 @@ function wesnoth.update_stats(original)
 	visible_modifications = wml.get_child(remade, "modifications")
 	vars.updated = true
 	vars.geared = geared
-
 	-- Remove temporary dummy attacks
 	for i = #remade,1,-1 do
 		if remade[i][1] == "attack" and remade[i][2].temporary == true then
@@ -685,6 +687,7 @@ function wesnoth.update_stats(original)
 
 	-- PART XI: Call WML hooks
 	for i = 1,#events_to_fire do
+		--wesnoth.interface.add_chat_message(string.format("%d) %s",i,events_to_fire[i]))
 		remade = call_event_on_unit(remade, events_to_fire[i])
 	end
 	-- Restore unit from variable after the WML hooks.

--- a/lua/unitdata.lua
+++ b/lua/unitdata.lua
@@ -312,7 +312,9 @@ local wml_based_implementation = {
 	add_item = function(unit, item_number, item_sort)
 		unit = normalize_unit_param(unit)
 
-		local item = wesnoth.deepcopy(loti.item.type[item_number])
+		local item = {}
+		item.number = item_number
+		item.name = loti.item.type[item_number].name
 		if item_sort then
 			item.sort = item_sort
 		end


### PR DESCRIPTION
I'm surprised by this.  I expected to have to replace things like foo.description with loti.item.type[foo.number].description all over the place, but it seemed to pretty much just work.

I probably left some stuff in that doesn't need to be.  Anything that was a table inside the item stayed.  If you look at the helm on the Duke in the attached you'll see what I mean (is number_required a clue that this table is not needed? or may not be needed if some code changes elsewhere?).

[LotI2-Tunnels of Cruelty Turn 1.gz](https://github.com/Dugy/Legend_of_the_Invincibles/files/15444847/LotI2-Tunnels.of.Cruelty.Turn.1.gz)

ref #787