### PR TITLE
fix faster wail

### DIFF
--- a/units/Monstrosity.cfg
+++ b/units/Monstrosity.cfg
@@ -236,7 +236,7 @@
             require_amla="wail,wail-damage"
             [effect]
                 apply_to=attack
-                range=wail
+                name=wail
                 increase_attacks=1
             [/effect]
             {AMLA_DEFAULT_BONUSES}


### PR DESCRIPTION
I'm not sure this attack is working correctly.  From what I gather from the GUI, it should only be active if the unit ate a WC this turn, but it seems to always be active.