### PR TITLE
Fix the bug where advancing during enemy turn prevent from altering AMLA

### DIFF
--- a/utils/global_events.cfg
+++ b/utils/global_events.cfg
@@ -1694,6 +1694,7 @@ $soul_eating"
                         {VARIABLE_OP times_advanced sub 1}
                     [/do]
                 [/while]
+                {VARIABLE advanced2.variables.achieved_amla true}
                 [unstore_unit]
                     variable=advanced2
                     find_vacant=no


### PR DESCRIPTION
As the title states, this quick one-line fix is to allow players to alter advancements chosen for units that leveled-up during enemy turn.
AFAIK there is no other consequences