### PR TITLE
Ch3 Bitter Swamp: buying the Tome of Necromancy now gives you the right item.

### DIFF
--- a/scenarios3/12_Bitter_Swamp.cfg
+++ b/scenarios3/12_Bitter_Swamp.cfg
@@ -262,7 +262,7 @@
                     message= _ "Hello, I am a trader. I sell items. Look at my stock and tell me what would you like to look at more closely."
                     {SELL_GEMS}
                     {SHOP_ITEM _"Sword of Barys" 150 55 items/sword.png i1}
-                    {SHOP_ITEM _"Tome of Liches" 100 13 items/book5.png i2}
+                    {SHOP_ITEM _"Tome of Liches" 100 807 items/book5.png i2}
                     {SHOP_ITEM _"Poisonous Bow" 80 31 items/bow.png i3}
                     {SHOP_ITEM _"Staff of Crelanu" 200 30 items/staff.png i4}
                     [option]


### PR DESCRIPTION
I was quite surprised to get Warheart when I bought the tome. After a brief look at git blame, I have no idea how this came about.