### PR TITLE
fix abilitie active only is exact count of adjacent unit match

### DIFF
--- a/utils/abilities.cfg
+++ b/utils/abilities.cfg
@@ -228,7 +228,7 @@ All adjacent lower-level units from the same side deal 25% more damage for each 
             [filter_adjacent]
                 status=undrainable
                 is_enemy=no
-                count=2
+                count=2-6
             [/filter_adjacent]
         [/filter_self]
         halo_image=halo/elven/elven-shield-halo-80pct.png~CS(-100,-200,-50)
@@ -251,7 +251,7 @@ All adjacent lower-level units from the same side deal 25% more damage for each 
                     status=undrainable
                 [/not]
                 is_enemy=no
-                count=2
+                count=2-6
             [/filter_adjacent]
         [/filter_self]
         halo_image=halo/elven/elven-shield-halo-40pct.png~CS(-50,50,-50)


### PR DESCRIPTION
these abilities should active if at leat 2 adjacnet allied unit matche, but work only if 2 units excatly match.

Fix https://github.com/Dugy/Legend_of_the_Invincibles/issues/866 issue