### PR TITLE
Status effects now cleared when advancing on the enemy's turn.

### DIFF
--- a/utils/global_events.cfg
+++ b/utils/global_events.cfg
@@ -279,6 +279,13 @@
             [/filter]
             moves="$pre_advance_store.moves"
             attacks_left="$pre_advance_store.attacks_left"
+            [status]
+                dazzled=no
+                incinerated=no
+                infected=no
+                poisoned=no
+                slowed=no
+            [/status]
         [/modify_unit]
         {UPDATE_STATS}
         {CLEAR_VARIABLE pre_advance_store}


### PR DESCRIPTION
Should I add petrified to the list? Units could still advance via incineration or damage aura.